### PR TITLE
[TM-1807] Fix flaky tests

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -36,7 +36,7 @@ jobs:
 
       - run: npm ci --legacy-peer-deps
 
-      #      - run: npx nx run-many -t lint build --no-cloud
+      - run: npx nx run-many -t lint build --no-cloud
 
       - name: Bring up DB Docker Container
         run: |
@@ -44,22 +44,11 @@ jobs:
           ./docker/test-connection.sh
 
       # First run just the small database test to get the test database synced to the current schema
-      # in a clean way. For some reason, the `run-many` is necessary here. If this line simply uses
-      # nx test database, the connection to the DB gets cut off before the sync is complete.
+      # in a clean way.
       - name: Sync DB Schema
         run: npx nx test database --no-cloud --skip-nx-cache
 
-      # Run the UDB service tests in isolation because they require clearing out DB tables and ensuring
-      # they know exactly what's in them, which is not conducive to parallel runs with other test
-      # suites.
-      #      - name: Unified DB Test
-      #        run: npx nx test unified-database-service --no-cloud --coverage
-
-      # Run the entity service tests in isolation because they require clearing out DB tables and ensuring
-      # they know exactly what's in them, which is not conducive to parallel runs with other test
-      # suites.
-      #      - name: Entity Service Test
-      #        run: npx nx test entity-service --no-cloud --coverage --runInBand
-
+      # All tests are run in band so that wipes of database tables from one test doesn't interfere
+      # with other tests.
       - name: Test all
-        run: npx nx run-many -t test --parallel=1 --no-cloud --coverage --runInBand --passWithNoTests --exclude database #unified-database-service database entity-service
+        run: npx nx run-many -t test --parallel=1 --no-cloud --coverage --runInBand --passWithNoTests --exclude database

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -36,7 +36,7 @@ jobs:
 
       - run: npm ci --legacy-peer-deps
 
-      - run: npx nx run-many -t lint build --no-cloud
+      #      - run: npx nx run-many -t lint build --no-cloud
 
       - name: Bring up DB Docker Container
         run: |
@@ -52,14 +52,14 @@ jobs:
       # Run the UDB service tests in isolation because they require clearing out DB tables and ensuring
       # they know exactly what's in them, which is not conducive to parallel runs with other test
       # suites.
-      - name: Unified DB Test
-        run: npx nx test unified-database-service --no-cloud --coverage
+      #      - name: Unified DB Test
+      #        run: npx nx test unified-database-service --no-cloud --coverage
 
-      # Run the UDB service tests in isolation because they require clearing out DB tables and ensuring
+      # Run the entity service tests in isolation because they require clearing out DB tables and ensuring
       # they know exactly what's in them, which is not conducive to parallel runs with other test
       # suites.
-      - name: Entity Service Test
-        run: npx nx test entity-service --no-cloud --coverage --runInBand
+      #      - name: Entity Service Test
+      #        run: npx nx test entity-service --no-cloud --coverage --runInBand
 
       - name: Test all
-        run: npx nx run-many -t test --no-cloud --coverage --passWithNoTests --exclude unified-database-service database entity-service
+        run: npx nx run-many -t test --parallel=1 --no-cloud --coverage --runInBand --passWithNoTests --exclude database #unified-database-service database entity-service

--- a/README.md
+++ b/README.md
@@ -89,10 +89,12 @@ To set up the local testing database, run the `./bin/setup-test-database.sh` scr
 `wri-terramatch-api` project is checked out in the same parent directory as this one. The script may be run
 again at any time to clear out the test database records and schema.
 
-`setup-jest.ts` is responsible for creating the Sequelize connection for all tests. Via the `sync` command, it also
-creates database tables according to the schema declared in the `entity.ts` files in this codebase. Care should be
+`setup-jest.ts` is responsible for creating the Sequelize connection for all tests.
+
+`sync-sequelize.ts` creates database tables according to the schema declared in the `entity.ts` files in this codebase. Care should be
 taken to make sure that the schema is set up in this codebase such that the database tables are created with the same
-types and indices as in the primary database controlled by the Laravel backend.
+types and indices as in the primary database controlled by the Laravel backend. This hook is only run for the database
+test.
 
 Factories may be used to create entries in the database for testing. See `user.factory.ts`, and uses of `UserFactory` for
 an example.

--- a/bin/setup-test-database.sh
+++ b/bin/setup-test-database.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
-cd ../wri-terramatch-api
+pushd ../wri-terramatch-api
 cat <<- SQL | docker-compose exec -T mariadb mysql -h localhost -u root -proot
 drop database if exists terramatch_microservices_test;
 create database terramatch_microservices_test;
 grant all on terramatch_microservices_test.* to 'wri'@'%';
 SQL
+
+popd
+# Sync the DB schema
+nx test database --no-cloud --skip-nx-cache
 

--- a/jest/setup-jest.ts
+++ b/jest/setup-jest.ts
@@ -18,7 +18,6 @@ beforeAll(async () => {
     logging: false
   });
 
-  await sequelize.sync();
   FactoryGirl.setAdapter(new SequelizeAdapter());
 });
 

--- a/jest/sync-sequelize.ts
+++ b/jest/sync-sequelize.ts
@@ -1,0 +1,5 @@
+import { User } from "../libs/database/src/lib/entities";
+
+beforeAll(async () => {
+  await User.sequelize!.sync();
+});

--- a/libs/common/src/lib/localization/localization.service.spec.ts
+++ b/libs/common/src/lib/localization/localization.service.spec.ts
@@ -3,6 +3,7 @@ import { LocalizationService } from "./localization.service";
 import { i18nItem, i18nTranslation, LocalizationKey } from "@terramatch-microservices/database/entities";
 import { ConfigService } from "@nestjs/config";
 import { tx } from "@transifex/native";
+import { createMock } from "@golevelup/ts-jest";
 
 jest.mock("@transifex/native", () => ({
   tx: {
@@ -18,15 +19,7 @@ describe("LocalizationService", () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        LocalizationService,
-        {
-          provide: ConfigService,
-          useValue: {
-            get: jest.fn().mockReturnValue("mocked value")
-          }
-        }
-      ]
+      providers: [LocalizationService, { provide: ConfigService, useValue: createMock<ConfigService>() }]
     }).compile();
 
     service = module.get<LocalizationService>(LocalizationService);

--- a/libs/database/jest.config.ts
+++ b/libs/database/jest.config.ts
@@ -15,5 +15,6 @@ export default {
       lines: 0,
       statements: 0
     }
-  }
+  },
+  setupFilesAfterEnv: ["./jest/setup-jest.ts", "./jest/sync-sequelize.ts"]
 };


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-1807

It turns out this had nothing to do with any particular test, it was related to the DB connection for tests. To mitigate I've done a few things:
* Run the suites serially instead of in parallel
* Run all test in band. This combined with the step above makes it so that only the first test in each suite sets up the database connection.
* Only run sequelize sync in the database test suite, which is forced to run first, by itself. 

I don't understand why it's still taking ~13-15s for each suite to get started. It seems like the DB connection should not be nearly so slow, but at least they all run successfully now, and the overall PR action completes in a reasonable amount of time.