### PR TITLE
[TM-1825] Support both styles of pagination in the site polygons controller

### DIFF
--- a/apps/research-service/src/site-polygons/dto/site-polygon-query.dto.ts
+++ b/apps/research-service/src/site-polygons/dto/site-polygon-query.dto.ts
@@ -6,9 +6,10 @@ import {
   POLYGON_STATUSES,
   PolygonStatus
 } from "@terramatch-microservices/database/constants";
-import { CursorPage } from "@terramatch-microservices/common/dto/page.dto";
+import { CursorPage, NumberPage, Page } from "@terramatch-microservices/common/dto/page.dto";
+import { Type } from "class-transformer";
 
-export class SitePolygonQueryDto extends IntersectionType(CursorPage) {
+export class SitePolygonQueryDto extends IntersectionType(CursorPage, NumberPage) {
   @ApiProperty({
     enum: POLYGON_STATUSES,
     name: "polygonStatus[]",
@@ -77,6 +78,13 @@ export class SitePolygonQueryDto extends IntersectionType(CursorPage) {
   includeTestProjects?: boolean;
 
   @ValidateNested()
+  @Type(({ object }) => {
+    // Surprisingly, the object here is the whole query DTO.
+    const keys = Object.keys(object.page ?? {});
+    if (keys.includes("after")) return CursorPage;
+    if (keys.includes("number")) return NumberPage;
+    return Page;
+  })
   @IsOptional()
-  page?: CursorPage;
+  page?: CursorPage | NumberPage;
 }

--- a/apps/research-service/src/site-polygons/site-polygons.controller.ts
+++ b/apps/research-service/src/site-polygons/site-polygons.controller.ts
@@ -8,7 +8,7 @@ import {
   Query,
   UnauthorizedException
 } from "@nestjs/common";
-import { buildJsonApi, JsonApiDocument } from "@terramatch-microservices/common/util";
+import { buildJsonApi, JsonApiDocument, SerializeOptions } from "@terramatch-microservices/common/util";
 import { ApiExtraModels, ApiOkResponse, ApiOperation } from "@nestjs/swagger";
 import { ExceptionResponse, JsonApiResponse } from "@terramatch-microservices/common/decorators";
 import { SitePolygonDto } from "./dto/site-polygon.dto";
@@ -25,6 +25,7 @@ import { SitePolygonBulkUpdateBodyDto } from "./dto/site-polygon-update.dto";
 import { SitePolygonsService } from "./site-polygons.service";
 import { PolicyService } from "@terramatch-microservices/common";
 import { SitePolygon } from "@terramatch-microservices/database/entities";
+import { isNumberPage } from "@terramatch-microservices/common/dto/page.dto";
 
 const MAX_PAGE_SIZE = 100 as const;
 
@@ -60,12 +61,17 @@ export class SitePolygonsController {
       );
     }
 
-    const { size: pageSize = MAX_PAGE_SIZE, after: pageAfter } = query.page ?? {};
-    if (pageSize > MAX_PAGE_SIZE || pageSize < 1) {
+    const page = query.page ?? {};
+    page.size ??= MAX_PAGE_SIZE;
+    if (page.size > MAX_PAGE_SIZE || page.size < 1) {
       throw new BadRequestException("Page size is invalid");
     }
 
-    const queryBuilder = (await this.sitePolygonService.buildQuery(pageSize, pageAfter))
+    if (isNumberPage(page) && page.number < 1) {
+      throw new BadRequestException("Page number is invalid");
+    }
+
+    const queryBuilder = (await this.sitePolygonService.buildQuery(page))
       .hasStatuses(query.polygonStatus)
       .modifiedSince(query.lastModifiedDate)
       .isMissingIndicators(query.missingIndicator);
@@ -84,7 +90,7 @@ export class SitePolygonsController {
     if (!query.includeTestProjects && query.siteId == null && query.projectId == null) {
       await queryBuilder.excludeTestProjects();
     }
-    const document = buildJsonApi(SitePolygonDto, { pagination: "cursor" });
+    const document = buildJsonApi(SitePolygonDto, { pagination: isNumberPage(query.page) ? "number" : "cursor" });
     for (const sitePolygon of await queryBuilder.execute()) {
       const indicators = await this.sitePolygonService.getIndicators(sitePolygon);
       const establishmentTreeSpecies = await this.sitePolygonService.getEstablishmentTreeSpecies(sitePolygon);
@@ -102,7 +108,9 @@ export class SitePolygonsController {
       );
     }
 
-    return document.serialize({ paginationTotal: await queryBuilder.paginationTotal() });
+    const serializeOptions: SerializeOptions = { paginationTotal: await queryBuilder.paginationTotal() };
+    if (isNumberPage(query.page)) serializeOptions.pageNumber = query.page.number;
+    return document.serialize(serializeOptions);
   }
 
   @Patch()

--- a/libs/common/src/lib/dto/page.dto.ts
+++ b/libs/common/src/lib/dto/page.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsInt, IsOptional } from "class-validator";
+import { IsInt, IsOptional, IsUUID } from "class-validator";
 
-class Page {
+export class Page {
   @ApiProperty({
     name: "page[size]",
     description: "The size of page being requested",
@@ -21,9 +21,10 @@ export class CursorPage extends Page {
     required: false,
     description:
       "The last record before the page being requested. The value is a UUID. " +
-      "If neither page[after] nor page[number] is provided, the first page is returned."
+      "If page[after] is not provided, the first page is returned."
   })
   @IsOptional()
+  @IsUUID()
   after?: string;
 }
 
@@ -31,10 +32,14 @@ export class NumberPage extends Page {
   @ApiProperty({
     name: "page[number]",
     required: false,
-    description:
-      "The page number to return. If neither page[after] nor page[number] is provided, the first " +
-      "page is returned. If page[number] is provided, page[size] is required."
+    description: "The page number to return. If page[number] is not provided, the first page is returned."
   })
   @IsOptional()
+  @IsInt()
   number?: number;
 }
+
+export const isCursorPage = (page?: CursorPage | NumberPage): page is CursorPage =>
+  page != null && (page as CursorPage).after != null;
+export const isNumberPage = (page?: CursorPage | NumberPage): page is NumberPage =>
+  page != null && (page as NumberPage).number != null;

--- a/libs/common/src/lib/util/json-api-builder.ts
+++ b/libs/common/src/lib/util/json-api-builder.ts
@@ -116,7 +116,7 @@ type DocumentBuilderOptions = {
   forceDataArray?: boolean;
 };
 
-type SerializeOptions = {
+export type SerializeOptions = {
   paginationTotal?: number;
   pageNumber?: number;
 };


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-1825

@egrojMonroy note: In order for the meta properties of the controller DTO result to match what the FE expects for page number pagination, the `page[number]` *must* be provided in the query. If it is left off, the controller defaults to cursor pagination shape, which is a little different and will cause problems in the FE. So make sure that the FE code that interacts with this always provides a page number, even on the first page.