### PR TITLE
[TM-1676] Don't hardcode the template path in the template service.

### DIFF
--- a/apps/user-service/src/users/user-creation.service.ts
+++ b/apps/user-service/src/users/user-creation.service.ts
@@ -124,7 +124,7 @@ export class UserCreationService {
       cta: await this.localizationService.translate(cta, locale),
       monitoring: "monitoring"
     };
-    return this.templateService.render(emailData);
+    return this.templateService.render("user-services/views/default-email.hbs", emailData);
   }
 
   private async sendEmailVerification(


### PR DESCRIPTION
The previous implementation was causing services other than `user-service` to fail deployment because the directory the template service was looking for doesn't exist anywhere but in the user service.