### PR TITLE
[TM-1850] Get sensitive ENV variables from github secrets

### DIFF
--- a/.github/workflows/deploy-service.yml
+++ b/.github/workflows/deploy-service.yml
@@ -74,13 +74,17 @@ jobs:
           echo "${{ vars.ENV }}" > .env
           echo "DB_PASSWORD=\"${{ secrets.DB_PASSWORD }}\"" >> .env
           echo "MAIL_PASSWORD=\"${{ secrets.MAIL_PASSWORD }}\"" >> .env
+          echo "JWT_SECRET=\"${{ secrets.JWT_SECRET }}\"" >> .env
+          echo "AIRTABLE_API_KEY=\"${{ secrets.AIRTABLE_API_KEY }}\"" >> .env
+          echo "SENTRY_DSN=\"${{ secrets.SENTRY_DSN }}\"" >> .env
+          echo "SLACK_API_KEY=\"${{ secrets.SLACK_API_KEY }}\"" >> .env
           : # Don't build the base image with NODE_ENV because it'll limit the packages that are installed
           docker build -t terramatch-microservices-base:nx-base .
           SERVICE_IMAGE=$ECR_REGISTRY/$ECR_REPOSITORY:${{ env.IMAGE_TAG }}
           docker build \
             --build-arg NODE_ENV=production \
             --build-arg DEPLOY_ENV=${{ inputs.env }} \
-            --build-arg SENTRY_DSN="${{ vars.SENTRY_DSN }}" \
+            --build-arg SENTRY_DSN="${{ secrets.SENTRY_DSN }}" \
             --build-arg BUILD_FLAG='--prod --verbose --no-cloud' \
             -f apps/${{ inputs.service }}/Dockerfile \
             -t $SERVICE_IMAGE .


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-1850

I discovered yesterday that when we echo the ENV from github environments to the build environment, you can expand that little arrow and see all the values. Any user logged into Github, whether their part of our project or not can see them. So, we need to keep all secrets in their own secret definitions, and pull them out separately. 

Next steps:
* I'm going to delete all old completed actions for deployments, so that those secrets are no longer visible.
* In a future ticket, we're going to need to rotate all of these values aside from `DB_PASSWORD`, which has always been a secret. That's going to be a big pain though, requiring a big synchronous update to the ENV of all 4 ENVs with updates to both PHP and v3. For now, simply removing the security problem is good enough. 