### PR TITLE
[TM-1852] project organisation filter not working

### DIFF
--- a/libs/database/src/lib/util/paginated-query.builder.ts
+++ b/libs/database/src/lib/util/paginated-query.builder.ts
@@ -37,6 +37,7 @@ export class PaginatedQueryBuilder<T extends Model<T>> {
 
   constructor(private readonly MODEL: ModelCtor<T>, private readonly pageSize: number, include?: Includeable[]) {
     this.findOptions.limit = this.pageSize;
+    this.pageTotalFindOptions = {};
     if (include != null && include.length > 0) {
       this.findOptions.include = include;
     }


### PR DESCRIPTION
This initialization is being temporarily added to address the error 
"Property 'pageTotalFindOptions' does not exist on type 'PaginatedQueryBuilder<T>'."