### PR TITLE
[TM-1864] Sideloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ We have a CLI app in this repo. Currently it's responsible for building and laun
 To build the CLI and make it executable:
 
 - `nx executable tm-v3-cli`
-- `cd dist/tm-v3-cli; npm link`
+- `(cd dist/tm-v3-cli; npm link)`
 
 The CLI may then be invoked as a direct shell command:
 
@@ -71,7 +71,7 @@ As you will note on the NestJS documentation above, the REPL gives you access to
 In addition, the `boostrap-repl.ts` utility that is used by all services exposes a couple of things to make life a bit
 easier in the REPL env:
 
-- All of lodash accessible through `lodash` (e.g. `lodash.joins([1, 2])`)
+- All of lodash accessible through `lodash` (e.g. `lodash.join([1, 2])`)
 - All database models are made accessible in the global context (e.g. `await User.findOne({ emailAddress: "foo@bar.org" })`)
 
 # Deployment

--- a/apps/entity-service/src/entities/dto/entity-query.dto.ts
+++ b/apps/entity-service/src/entities/dto/entity-query.dto.ts
@@ -62,6 +62,7 @@ export class EntityQueryDto extends IntersectionType(QuerySort, NumberPage) {
     type: [EntitySideload]
   })
   @IsArray()
+  @IsOptional()
   @Type(() => EntitySideload)
   @ValidateNested({ each: true })
   sideloads?: EntitySideload[];

--- a/apps/entity-service/src/entities/dto/entity-query.dto.ts
+++ b/apps/entity-service/src/entities/dto/entity-query.dto.ts
@@ -58,9 +58,8 @@ export class EntityQueryDto extends IntersectionType(QuerySort, NumberPage) {
 
   @ApiProperty({
     required: false,
-    isArray: true,
     description: "If the base entity supports it, this will load the first page of associated entities",
-    type: () => EntitySideload
+    type: [EntitySideload]
   })
   @IsArray()
   @Type(() => EntitySideload)

--- a/apps/entity-service/src/entities/entities.controller.ts
+++ b/apps/entity-service/src/entities/entities.controller.ts
@@ -17,7 +17,7 @@ import { PolicyService } from "@terramatch-microservices/common";
 import { buildDeletedResponse, buildJsonApi, getDtoType } from "@terramatch-microservices/common/util";
 import { SiteFullDto, SiteLightDto } from "./dto/site.dto";
 import { EntityIndexParamsDto } from "./dto/entity-index-params.dto";
-import { EntityQueryDto } from "./dto/entity-query.dto";
+import { EntityQueryDto, EntitySideload } from "./dto/entity-query.dto";
 import { MediaDto } from "./dto/media.dto";
 import { ProjectReportFullDto, ProjectReportLightDto } from "./dto/project-report.dto";
 import { NurseryFullDto, NurseryLightDto } from "./dto/nursery.dto";
@@ -25,7 +25,7 @@ import { EntityModel } from "@terramatch-microservices/database/constants/entiti
 import { JsonApiDeletedResponse } from "@terramatch-microservices/common/decorators/json-api-response.decorator";
 
 @Controller("entities/v3")
-@ApiExtraModels(ANRDto, ProjectApplicationDto, MediaDto)
+@ApiExtraModels(ANRDto, ProjectApplicationDto, MediaDto, EntitySideload)
 export class EntitiesController {
   constructor(private readonly policyService: PolicyService, private readonly entitiesService: EntitiesService) {}
 

--- a/apps/entity-service/src/entities/entities.service.spec.ts
+++ b/apps/entity-service/src/entities/entities.service.spec.ts
@@ -9,6 +9,7 @@ import { pickApiProperties } from "@terramatch-microservices/common/dto/json-api
 import { MediaDto } from "./dto/media.dto";
 import { EntityQueryDto } from "./dto/entity-query.dto";
 import { EntityType } from "@terramatch-microservices/database/constants/entities";
+import { PolicyService } from "@terramatch-microservices/common";
 
 describe("EntitiesService", () => {
   let mediaService: DeepMocked<MediaService>;
@@ -25,7 +26,11 @@ describe("EntitiesService", () => {
 
   beforeEach(async () => {
     const module = await Test.createTestingModule({
-      providers: [{ provide: MediaService, useValue: (mediaService = createMock<MediaService>()) }, EntitiesService]
+      providers: [
+        { provide: MediaService, useValue: (mediaService = createMock<MediaService>()) },
+        { provide: PolicyService, useValue: createMock<PolicyService>() },
+        EntitiesService
+      ]
     }).compile();
 
     service = module.get(EntitiesService);

--- a/apps/entity-service/src/entities/entities.service.ts
+++ b/apps/entity-service/src/entities/entities.service.ts
@@ -57,7 +57,7 @@ const ASSOCIATION_PROCESSORS = {
 export type ProcessableAssociation = keyof typeof ASSOCIATION_PROCESSORS;
 export const PROCESSABLE_ASSOCIATIONS = Object.keys(ASSOCIATION_PROCESSORS) as ProcessableAssociation[];
 
-const MAX_PAGE_SIZE = 100 as const;
+export const MAX_PAGE_SIZE = 100 as const;
 
 @Injectable()
 export class EntitiesService {

--- a/apps/entity-service/src/entities/entity-associations.controller.ts
+++ b/apps/entity-service/src/entities/entity-associations.controller.ts
@@ -19,7 +19,11 @@ export class EntityAssociationsController {
     operationId: "entityAssociationIndex",
     summary: "Get all of a single type of association that are related to a given entity."
   })
-  @JsonApiResponse([DemographicDto, SeedingDto, TreeSpeciesDto])
+  @JsonApiResponse([
+    { data: DemographicDto, hasMany: true },
+    { data: SeedingDto, hasMany: true },
+    { data: TreeSpeciesDto, hasMany: true }
+  ])
   @ExceptionResponse(BadRequestException, { description: "Param types invalid" })
   @ExceptionResponse(NotFoundException, { description: "Base entity not found" })
   async associationIndex(@Param() { entity, uuid, association }: EntityAssociationIndexParamsDto) {

--- a/apps/entity-service/src/entities/processors/association-processor.spec.ts
+++ b/apps/entity-service/src/entities/processors/association-processor.spec.ts
@@ -15,13 +15,19 @@ import { DemographicDto, DemographicEntryDto } from "../dto/demographic.dto";
 import { pickApiProperties } from "@terramatch-microservices/common/dto/json-api-attributes";
 import { TreeSpeciesDto } from "../dto/tree-species.dto";
 import { SeedingDto } from "../dto/seeding.dto";
+import { PolicyService } from "@terramatch-microservices/common";
+import { SiteReport } from "@terramatch-microservices/database/entities";
 
 describe("AssociationProcessor", () => {
   let service: EntitiesService;
 
   beforeEach(async () => {
     const module = await Test.createTestingModule({
-      providers: [{ provide: MediaService, useValue: createMock<MediaService>() }, EntitiesService]
+      providers: [
+        { provide: MediaService, useValue: createMock<MediaService>() },
+        { provide: PolicyService, useValue: createMock<PolicyService>() },
+        EntitiesService
+      ]
     }).compile();
 
     service = module.get(EntitiesService);
@@ -101,6 +107,16 @@ describe("AssociationProcessor", () => {
         if (data.taxonId === undefined) data.taxonId = null;
         expect(seedingData).toMatchObject(data);
       }
+    });
+
+    it("should memoize the base entity", async () => {
+      const { uuid } = await SiteReportFactory.create();
+      const spy = jest.spyOn(SiteReport, "findOne");
+      const processor = service.createAssociationProcessor("siteReports", uuid, "seedings");
+      const first = await processor.getBaseEntity();
+      const second = await processor.getBaseEntity();
+      expect(first).toBe(second);
+      expect(spy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/entity-service/src/entities/processors/association-processor.ts
+++ b/apps/entity-service/src/entities/processors/association-processor.ts
@@ -1,6 +1,6 @@
 import { NotFoundException, Type } from "@nestjs/common";
 import { AssociationDto } from "../dto/association.dto";
-import { DocumentBuilder } from "@terramatch-microservices/common/util";
+import { DocumentBuilder, getDtoType } from "@terramatch-microservices/common/util";
 import { EntityClass, EntityModel, EntityType } from "@terramatch-microservices/database/constants/entities";
 import { intersection } from "lodash";
 import { UuidModel } from "@terramatch-microservices/database/types/util";
@@ -57,8 +57,16 @@ export abstract class AssociationProcessor<M extends UuidModel<M>, D extends Ass
     const associations = await this.getAssociations(await this.getBaseEntity());
 
     const additionalProps = { entityType: this.entityType, entityUuid: this.entityUuid };
+    const indexIds: string[] = [];
     for (const association of associations) {
       document.addData(association.uuid, new this.DTO(association, additionalProps));
     }
+
+    const resource = getDtoType(this.DTO);
+    document.addIndexData({
+      resource,
+      requestPath: `/entities/v3/${this.entityType}/${this.entityUuid}/${resource}`,
+      ids: indexIds
+    });
   }
 }

--- a/apps/entity-service/src/entities/processors/entity-processor.ts
+++ b/apps/entity-service/src/entities/processors/entity-processor.ts
@@ -1,9 +1,9 @@
 import { Model, ModelCtor } from "sequelize-typescript";
 import { Attributes, col, fn, WhereOptions } from "sequelize";
-import { DocumentBuilder } from "@terramatch-microservices/common/util";
-import { EntitiesService } from "../entities.service";
+import { DocumentBuilder, getStableRequestQuery, IndexData } from "@terramatch-microservices/common/util";
+import { EntitiesService, ProcessableEntity } from "../entities.service";
 import { EntityQueryDto } from "../dto/entity-query.dto";
-import { Type } from "@nestjs/common";
+import { BadRequestException, Type } from "@nestjs/common";
 import { EntityDto } from "../dto/entity.dto";
 import { EntityClass, EntityModel } from "@terramatch-microservices/database/constants/entities";
 import { Action } from "@terramatch-microservices/database/entities/action.entity";
@@ -32,6 +32,21 @@ export type PaginatedResult<ModelType extends EntityModel> = {
   paginationTotal: number;
 };
 
+export type DtoResult<DtoType extends EntityDto> = {
+  id: string;
+  dto: DtoType;
+};
+
+const getIndexData = (
+  resource: ProcessableEntity,
+  query: EntityQueryDto,
+  total: number,
+  pageNumber: number
+): Omit<IndexData, "ids"> => {
+  const requestPath = `/entities/v3/${resource}${getStableRequestQuery(query)}`;
+  return { resource, requestPath, total, pageNumber };
+};
+
 export abstract class EntityProcessor<
   ModelType extends EntityModel,
   LightDto extends EntityDto,
@@ -40,13 +55,51 @@ export abstract class EntityProcessor<
   abstract readonly LIGHT_DTO: Type<LightDto>;
   abstract readonly FULL_DTO: Type<FullDto>;
 
-  constructor(protected readonly entitiesService: EntitiesService) {}
+  constructor(protected readonly entitiesService: EntitiesService, protected readonly resource: ProcessableEntity) {}
 
   abstract findOne(uuid: string): Promise<ModelType | null>;
-  abstract findMany(query: EntityQueryDto, userId: number, permissions: string[]): Promise<PaginatedResult<ModelType>>;
+  abstract findMany(query: EntityQueryDto): Promise<PaginatedResult<ModelType>>;
 
-  abstract addFullDto(document: DocumentBuilder, model: ModelType): Promise<void>;
-  abstract addLightDto(document: DocumentBuilder, model: ModelType): Promise<void>;
+  abstract getFullDto(model: ModelType): Promise<DtoResult<FullDto>>;
+  abstract getLightDto(model: ModelType): Promise<DtoResult<LightDto>>;
+
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  async processSideload(
+    document: DocumentBuilder,
+    model: ModelType,
+    entity: ProcessableEntity,
+    pageSize: number
+  ): Promise<void> {
+    throw new BadRequestException("This resource does not support sideloading");
+  }
+  /* eslint-enable @typescript-eslint/no-unused-vars */
+
+  async addIndex(document: DocumentBuilder, query: EntityQueryDto, sideloaded = false) {
+    const { models, paginationTotal } = await this.findMany(query);
+    const indexData = getIndexData(this.resource, query, paginationTotal, query.page?.number ?? 1);
+
+    const indexIds: string[] = [];
+    if (models.length !== 0) {
+      await this.entitiesService.authorize("read", models);
+
+      for (const model of models) {
+        const { id, dto } = await this.getLightDto(model);
+        indexIds.push(id);
+        if (sideloaded) document.addIncluded(id, dto);
+        else document.addData(id, dto);
+      }
+    }
+
+    document.addIndexData({ ...indexData, ids: indexIds });
+
+    if (models.length > 0 && !sideloaded && query.sideloads != null && query.sideloads.length > 0) {
+      for (const model of models) {
+        for (const { entity, pageSize } of query.sideloads) {
+          await this.processSideload(document, model, entity, pageSize);
+        }
+      }
+    }
+  }
 
   async delete(model: ModelType) {
     await Action.targetable((model.constructor as EntityClass<ModelType>).LARAVEL_TYPE, model.id).destroy();

--- a/apps/entity-service/src/entities/processors/entity-processor.ts
+++ b/apps/entity-service/src/entities/processors/entity-processor.ts
@@ -70,7 +70,7 @@ export abstract class EntityProcessor<
     entity: ProcessableEntity,
     pageSize: number
   ): Promise<void> {
-    throw new BadRequestException("This resource does not support sideloading");
+    throw new BadRequestException("This entity does not support sideloading");
   }
   /* eslint-enable @typescript-eslint/no-unused-vars */
 

--- a/apps/entity-service/src/entities/processors/entity.processor.spec.ts
+++ b/apps/entity-service/src/entities/processors/entity.processor.spec.ts
@@ -5,13 +5,18 @@ import { createMock } from "@golevelup/ts-jest";
 import { EntitiesService } from "../entities.service";
 import { ProjectFactory } from "@terramatch-microservices/database/factories";
 import { ActionFactory } from "@terramatch-microservices/database/factories/action.factory";
+import { PolicyService } from "@terramatch-microservices/common";
 
-describe("ProjectProcessor", () => {
+describe("EntityProcessor", () => {
   let processor: ProjectProcessor;
 
   beforeEach(async () => {
     const module = await Test.createTestingModule({
-      providers: [{ provide: MediaService, useValue: createMock<MediaService>() }, EntitiesService]
+      providers: [
+        { provide: MediaService, useValue: createMock<MediaService>() },
+        { provide: PolicyService, useValue: createMock<PolicyService>() },
+        EntitiesService
+      ]
     }).compile();
 
     processor = module.get(EntitiesService).createEntityProcessor("projects") as ProjectProcessor;

--- a/apps/entity-service/src/entities/processors/nursery-report.processor.ts
+++ b/apps/entity-service/src/entities/processors/nursery-report.processor.ts
@@ -1,12 +1,15 @@
 import { Media, Nursery, NurseryReport, ProjectReport, ProjectUser } from "@terramatch-microservices/database/entities";
 import { EntityProcessor } from "./entity-processor";
 import { EntityQueryDto } from "../dto/entity-query.dto";
-import { DocumentBuilder } from "@terramatch-microservices/common/util";
 import { Includeable, Op } from "sequelize";
 import { BadRequestException } from "@nestjs/common";
 import { FrameworkKey } from "@terramatch-microservices/database/constants/framework";
-import { AdditionalNurseryReportFullProps, NurseryReportFullDto, NurseryReportMedia } from "../dto/nursery-report.dto";
-import { NurseryReportLightDto } from "../dto/nursery-report.dto";
+import {
+  AdditionalNurseryReportFullProps,
+  NurseryReportFullDto,
+  NurseryReportLightDto,
+  NurseryReportMedia
+} from "../dto/nursery-report.dto";
 
 export class NurseryReportProcessor extends EntityProcessor<
   NurseryReport,
@@ -16,7 +19,7 @@ export class NurseryReportProcessor extends EntityProcessor<
   readonly LIGHT_DTO = NurseryReportLightDto;
   readonly FULL_DTO = NurseryReportFullDto;
 
-  async findOne(uuid: string): Promise<NurseryReport> {
+  async findOne(uuid: string) {
     return await NurseryReport.findOne({
       where: { uuid },
       include: [
@@ -128,7 +131,7 @@ export class NurseryReportProcessor extends EntityProcessor<
     return { models: await builder.execute(), paginationTotal: await builder.paginationTotal() };
   }
 
-  async addFullDto(document: DocumentBuilder, nurseryReport: NurseryReport): Promise<void> {
+  async getFullDto(nurseryReport: NurseryReport) {
     const nurseryReportId = nurseryReport.id;
     const mediaCollection = await Media.nurseryReport(nurseryReportId).findAll();
     const reportTitle = await this.getReportTitle(nurseryReport);
@@ -141,12 +144,12 @@ export class NurseryReportProcessor extends EntityProcessor<
       ...(this.entitiesService.mapMediaCollection(mediaCollection, NurseryReport.MEDIA) as NurseryReportMedia)
     };
 
-    document.addData(nurseryReport.uuid, new NurseryReportFullDto(nurseryReport, props));
+    return { id: nurseryReport.uuid, dto: new NurseryReportFullDto(nurseryReport, props) };
   }
 
-  async addLightDto(document: DocumentBuilder, nurseryReport: NurseryReport): Promise<void> {
+  async getLightDto(nurseryReport: NurseryReport) {
     const reportTitle = await this.getReportTitle(nurseryReport);
-    document.addData(nurseryReport.uuid, new NurseryReportLightDto(nurseryReport, { reportTitle }));
+    return { id: nurseryReport.uuid, dto: new NurseryReportLightDto(nurseryReport, { reportTitle }) };
   }
 
   protected async getReportTitleBase(dueAt: Date | null, title: string | null, locale: string | null) {

--- a/apps/entity-service/src/entities/processors/nursery.processor.ts
+++ b/apps/entity-service/src/entities/processors/nursery.processor.ts
@@ -1,8 +1,7 @@
 import { Media, Nursery, NurseryReport, Project, ProjectUser } from "@terramatch-microservices/database/entities";
-import { NurseryLightDto, NurseryFullDto, AdditionalNurseryFullProps, NurseryMedia } from "../dto/nursery.dto";
-import { EntityProcessor, PaginatedResult } from "./entity-processor";
+import { AdditionalNurseryFullProps, NurseryFullDto, NurseryLightDto, NurseryMedia } from "../dto/nursery.dto";
+import { EntityProcessor } from "./entity-processor";
 import { EntityQueryDto } from "../dto/entity-query.dto";
-import { DocumentBuilder } from "@terramatch-microservices/common/util";
 import { col, fn, Includeable, Op } from "sequelize";
 import { BadRequestException } from "@nestjs/common";
 import { FrameworkKey } from "@terramatch-microservices/database/constants/framework";
@@ -11,7 +10,7 @@ export class NurseryProcessor extends EntityProcessor<Nursery, NurseryLightDto, 
   readonly LIGHT_DTO = NurseryLightDto;
   readonly FULL_DTO = NurseryFullDto;
 
-  async findOne(uuid: string): Promise<Nursery> {
+  async findOne(uuid: string) {
     return await Nursery.findOne({
       where: { uuid },
       include: [
@@ -24,7 +23,7 @@ export class NurseryProcessor extends EntityProcessor<Nursery, NurseryLightDto, 
     });
   }
 
-  async findMany(query: EntityQueryDto, userId?: number, permissions?: string[]): Promise<PaginatedResult<Nursery>> {
+  async findMany(query: EntityQueryDto) {
     const projectAssociation: Includeable = {
       association: "project",
       attributes: ["uuid", "name"],
@@ -44,15 +43,16 @@ export class NurseryProcessor extends EntityProcessor<Nursery, NurseryLightDto, 
       }
     }
 
+    const permissions = await this.entitiesService.getPermissions();
     const frameworkPermissions = permissions
       ?.filter(name => name.startsWith("framework-"))
       .map(name => name.substring("framework-".length) as FrameworkKey);
     if (frameworkPermissions?.length > 0) {
       builder.where({ frameworkKey: { [Op.in]: frameworkPermissions } });
     } else if (permissions?.includes("manage-own")) {
-      builder.where({ projectId: { [Op.in]: ProjectUser.userProjectsSubquery(userId) } });
+      builder.where({ projectId: { [Op.in]: ProjectUser.userProjectsSubquery(this.entitiesService.userId) } });
     } else if (permissions?.includes("projects-manage")) {
-      builder.where({ projectId: { [Op.in]: ProjectUser.projectsManageSubquery(userId) } });
+      builder.where({ projectId: { [Op.in]: ProjectUser.projectsManageSubquery(this.entitiesService.userId) } });
     }
 
     const associationFieldMap = {
@@ -96,7 +96,7 @@ export class NurseryProcessor extends EntityProcessor<Nursery, NurseryLightDto, 
     return { models: await builder.execute(), paginationTotal: await builder.paginationTotal() };
   }
 
-  async addFullDto(document: DocumentBuilder, nursery: Nursery): Promise<void> {
+  async getFullDto(nursery: Nursery) {
     const nurseryId = nursery.id;
 
     const nurseryReportsTotal = await NurseryReport.nurseries([nurseryId]).count();
@@ -113,14 +113,14 @@ export class NurseryProcessor extends EntityProcessor<Nursery, NurseryLightDto, 
       ) as NurseryMedia)
     };
 
-    document.addData(nursery.uuid, new NurseryFullDto(nursery, props));
+    return { id: nursery.uuid, dto: new NurseryFullDto(nursery, props) };
   }
 
-  async addLightDto(document: DocumentBuilder, nursery: Nursery): Promise<void> {
+  async getLightDto(nursery: Nursery) {
     const nurseryId = nursery.id;
 
     const seedlingsGrownCount = await this.getSeedlingsGrownCount(nurseryId);
-    document.addData(nursery.uuid, new NurseryLightDto(nursery, { seedlingsGrownCount }));
+    return { id: nursery.uuid, dto: new NurseryLightDto(nursery, { seedlingsGrownCount }) };
   }
 
   protected async getTotalOverdueReports(nurseryId: number) {

--- a/apps/entity-service/src/entities/processors/project-report.processor.ts
+++ b/apps/entity-service/src/entities/processors/project-report.processor.ts
@@ -188,11 +188,13 @@ export class ProjectReportProcessor extends EntityProcessor<
 
   protected async getSeedlingsGrown(projectReport: ProjectReport) {
     if (projectReport.frameworkKey == "ppc") {
-      return TreeSpecies.visible().collection("tree-planted").projectReports([projectReport.id]).sum("amount");
+      return (
+        (await TreeSpecies.visible().collection("tree-planted").projectReports([projectReport.id]).sum("amount")) ?? 0
+      );
     }
 
     if (projectReport.frameworkKey == "terrafund") {
-      return NurseryReport.task(projectReport.taskId).sum("seedlingsYoungTrees");
+      return (await NurseryReport.task(projectReport.taskId).sum("seedlingsYoungTrees")) ?? 0;
     }
 
     return 0;

--- a/apps/entity-service/src/entities/processors/project-report.processor.ts
+++ b/apps/entity-service/src/entities/processors/project-report.processor.ts
@@ -1,9 +1,12 @@
 import { ProjectReport } from "@terramatch-microservices/database/entities/project-report.entity";
 import { EntityProcessor } from "./entity-processor";
-import { AdditionalProjectReportFullProps, ProjectReportFullDto, ProjectReportMedia } from "../dto/project-report.dto";
-import { ProjectReportLightDto } from "../dto/project-report.dto";
+import {
+  AdditionalProjectReportFullProps,
+  ProjectReportFullDto,
+  ProjectReportLightDto,
+  ProjectReportMedia
+} from "../dto/project-report.dto";
 import { EntityQueryDto } from "../dto/entity-query.dto";
-import { DocumentBuilder } from "@terramatch-microservices/common/util/json-api-builder";
 import { Includeable, Op } from "sequelize";
 import { BadRequestException } from "@nestjs/common";
 import { FrameworkKey } from "@terramatch-microservices/database/constants/framework";
@@ -47,7 +50,7 @@ export class ProjectReportProcessor extends EntityProcessor<
     });
   }
 
-  async findMany(query: EntityQueryDto, userId?: number, permissions?: string[]) {
+  async findMany(query: EntityQueryDto) {
     const projectAssociation: Includeable = {
       association: "project",
       attributes: ["uuid", "name"],
@@ -71,15 +74,16 @@ export class ProjectReportProcessor extends EntityProcessor<
       }
     }
 
+    const permissions = await this.entitiesService.getPermissions();
     const frameworkPermissions = permissions
       ?.filter(name => name.startsWith("framework-"))
       .map(name => name.substring("framework-".length) as FrameworkKey);
     if (frameworkPermissions?.length > 0) {
       builder.where({ frameworkKey: { [Op.in]: frameworkPermissions } });
     } else if (permissions?.includes("manage-own")) {
-      builder.where({ projectId: { [Op.in]: ProjectUser.userProjectsSubquery(userId) } });
+      builder.where({ projectId: { [Op.in]: ProjectUser.userProjectsSubquery(this.entitiesService.userId) } });
     } else if (permissions?.includes("projects-manage")) {
-      builder.where({ projectId: { [Op.in]: ProjectUser.projectsManageSubquery(userId) } });
+      builder.where({ projectId: { [Op.in]: ProjectUser.projectsManageSubquery(this.entitiesService.userId) } });
     }
 
     const associationFieldMap = {
@@ -122,7 +126,7 @@ export class ProjectReportProcessor extends EntityProcessor<
     return { models: await builder.execute(), paginationTotal: await builder.paginationTotal() };
   }
 
-  async addFullDto(document: DocumentBuilder, projectReport: ProjectReport) {
+  async getFullDto(projectReport: ProjectReport) {
     const projectReportId = projectReport.id;
     const taskId = projectReport.taskId;
     const reportTitle = await this.getReportTitle(projectReport);
@@ -159,11 +163,12 @@ export class ProjectReportProcessor extends EntityProcessor<
         ProjectReport.MEDIA
       ) as ProjectReportMedia)
     };
-    document.addData(projectReport.uuid, new ProjectReportFullDto(projectReport, props));
+
+    return { id: projectReport.uuid, dto: new ProjectReportFullDto(projectReport, props) };
   }
 
-  async addLightDto(document: DocumentBuilder, projectReport: ProjectReport) {
-    document.addData(projectReport.uuid, new ProjectReportLightDto(projectReport));
+  async getLightDto(projectReport: ProjectReport) {
+    return { id: projectReport.uuid, dto: new ProjectReportLightDto(projectReport) };
   }
 
   protected async getReportTitle(projectReport: ProjectReport) {

--- a/apps/entity-service/src/entities/processors/project.processor.ts
+++ b/apps/entity-service/src/entities/processors/project.processor.ts
@@ -106,6 +106,9 @@ export class ProjectProcessor extends EntityProcessor<Project, ProjectLightDto, 
     entity: ProcessableEntity,
     pageSize: number
   ): Promise<void> {
+    if (!["sites", "nurseries"].includes(entity)) {
+      throw new BadRequestException("Projects only support sideloading associated sites and nurseries");
+    }
     const processor = this.entitiesService.createEntityProcessor(entity);
     await processor.addIndex(document, { page: { size: pageSize }, projectUuid: model.uuid }, true);
   }

--- a/apps/entity-service/src/entities/processors/project.processor.ts
+++ b/apps/entity-service/src/entities/processors/project.processor.ts
@@ -1,4 +1,3 @@
-import { DocumentBuilder } from "@terramatch-microservices/common/util";
 import { Aggregate, aggregateColumns, EntityProcessor } from "./entity-processor";
 import {
   Demographic,
@@ -28,6 +27,8 @@ import {
 import { EntityQueryDto } from "../dto/entity-query.dto";
 import { FrameworkKey } from "@terramatch-microservices/database/constants/framework";
 import { BadRequestException } from "@nestjs/common";
+import { ProcessableEntity } from "../entities.service";
+import { DocumentBuilder } from "@terramatch-microservices/common/util";
 
 export class ProjectProcessor extends EntityProcessor<Project, ProjectLightDto, ProjectFullDto> {
   readonly LIGHT_DTO = ProjectLightDto;
@@ -47,7 +48,7 @@ export class ProjectProcessor extends EntityProcessor<Project, ProjectLightDto, 
     });
   }
 
-  async findMany(query: EntityQueryDto, userId: number, permissions: string[]) {
+  async findMany(query: EntityQueryDto) {
     const builder = await this.entitiesService.buildQuery(Project, query, [
       { association: "organisation", attributes: ["name"] },
       { association: "framework" }
@@ -63,15 +64,16 @@ export class ProjectProcessor extends EntityProcessor<Project, ProjectLightDto, 
       }
     }
 
+    const permissions = await this.entitiesService.getPermissions();
     const frameworkPermissions = permissions
       .filter(name => name.startsWith("framework-"))
       .map(name => name.substring("framework-".length) as FrameworkKey);
     if (frameworkPermissions.length > 0) {
       builder.where({ frameworkKey: { [Op.in]: frameworkPermissions } });
     } else if (permissions.includes("manage-own")) {
-      builder.where({ id: { [Op.in]: ProjectUser.userProjectsSubquery(userId) } });
+      builder.where({ id: { [Op.in]: ProjectUser.userProjectsSubquery(this.entitiesService.userId) } });
     } else if (permissions.includes("projects-manage")) {
-      builder.where({ id: { [Op.in]: ProjectUser.projectsManageSubquery(userId) } });
+      builder.where({ id: { [Op.in]: ProjectUser.projectsManageSubquery(this.entitiesService.userId) } });
     }
 
     for (const term of ["country", "status", "updateRequestStatus", "frameworkKey"]) {
@@ -84,14 +86,24 @@ export class ProjectProcessor extends EntityProcessor<Project, ProjectLightDto, 
     return { models: await builder.execute(), paginationTotal: await builder.paginationTotal() };
   }
 
-  async addLightDto(document: DocumentBuilder, project: Project) {
+  async processSideload(
+    document: DocumentBuilder,
+    model: Project,
+    entity: ProcessableEntity,
+    pageSize: number
+  ): Promise<void> {
+    const processor = this.entitiesService.createEntityProcessor(entity);
+    await processor.addIndex(document, { page: { size: pageSize }, projectUuid: model.uuid }, true);
+  }
+
+  async getLightDto(project: Project) {
     const projectId = project.id;
     const totalHectaresRestoredSum =
       (await SitePolygon.active().approved().sites(Site.approvedUuidsSubquery(projectId)).sum("calcArea")) ?? 0;
-    document.addData(project.uuid, new ProjectLightDto(project, { totalHectaresRestoredSum }));
+    return { id: project.uuid, dto: new ProjectLightDto(project, { totalHectaresRestoredSum }) };
   }
 
-  async addFullDto(document: DocumentBuilder, project: Project) {
+  async getFullDto(project: Project) {
     const projectId = project.id;
     const approvedSitesQuery = Site.approvedIdsSubquery(projectId);
     const approvedSiteReportsQuery = SiteReport.approvedIdsSubquery(approvedSitesQuery);
@@ -151,7 +163,7 @@ export class ProjectProcessor extends EntityProcessor<Project, ProjectLightDto, 
       ) as ProjectMedia)
     };
 
-    document.addData(project.uuid, new ProjectFullDto(project, props));
+    return { id: project.uuid, dto: new ProjectFullDto(project, props) };
   }
 
   protected async getWorkdayCount(projectId: number, useDemographicsCutoff = false) {

--- a/apps/entity-service/src/entities/processors/site-report.processor.ts
+++ b/apps/entity-service/src/entities/processors/site-report.processor.ts
@@ -9,7 +9,6 @@ import {
 } from "@terramatch-microservices/database/entities";
 import { EntityProcessor } from "./entity-processor";
 import { EntityQueryDto } from "../dto/entity-query.dto";
-import { DocumentBuilder } from "@terramatch-microservices/common/util";
 import { Includeable, Op } from "sequelize";
 import { BadRequestException } from "@nestjs/common";
 import { FrameworkKey } from "@terramatch-microservices/database/constants/framework";
@@ -24,7 +23,7 @@ export class SiteReportProcessor extends EntityProcessor<SiteReport, SiteReportL
   readonly LIGHT_DTO = SiteReportLightDto;
   readonly FULL_DTO = SiteReportFullDto;
 
-  async findOne(uuid: string): Promise<SiteReport> {
+  async findOne(uuid: string) {
     return await SiteReport.findOne({
       where: { uuid },
       include: [
@@ -135,7 +134,7 @@ export class SiteReportProcessor extends EntityProcessor<SiteReport, SiteReportL
     return { models: await builder.execute(), paginationTotal: await builder.paginationTotal() };
   }
 
-  async addFullDto(document: DocumentBuilder, siteReport: SiteReport): Promise<void> {
+  async getFullDto(siteReport: SiteReport) {
     const siteReportId = siteReport.id;
     const reportTitle = await this.getReportTitle(siteReport);
     const projectReportTitle = await this.getProjectReportTitle(siteReport);
@@ -160,12 +159,12 @@ export class SiteReportProcessor extends EntityProcessor<SiteReport, SiteReportL
       ...(this.entitiesService.mapMediaCollection(mediaCollection, SiteReport.MEDIA) as SiteReportMedia)
     };
 
-    document.addData(siteReport.uuid, new SiteReportFullDto(siteReport, props));
+    return { id: siteReport.uuid, dto: new SiteReportFullDto(siteReport, props) };
   }
 
-  async addLightDto(document: DocumentBuilder, siteReport: SiteReport): Promise<void> {
+  async getLightDto(siteReport: SiteReport) {
     const reportTitle = await this.getReportTitle(siteReport);
-    document.addData(siteReport.uuid, new SiteReportLightDto(siteReport, { reportTitle }));
+    return { id: siteReport.uuid, dto: new SiteReportLightDto(siteReport, { reportTitle }) };
   }
 
   protected async getReportTitleBase(dueAt: Date | null, title: string | null, locale: string | null) {

--- a/apps/entity-service/src/entities/processors/site.processor.spec.ts
+++ b/apps/entity-service/src/entities/processors/site.processor.spec.ts
@@ -1,7 +1,7 @@
 import { Site } from "@terramatch-microservices/database/entities";
 import { Test } from "@nestjs/testing";
 import { MediaService } from "@terramatch-microservices/common/media/media.service";
-import { createMock } from "@golevelup/ts-jest";
+import { createMock, DeepMocked } from "@golevelup/ts-jest";
 import { EntitiesService } from "../entities.service";
 import { SiteProcessor } from "./site.processor";
 import { reverse, sortBy } from "lodash";
@@ -12,12 +12,14 @@ import {
   SiteFactory,
   UserFactory
 } from "@terramatch-microservices/database/factories";
-import { buildJsonApi } from "@terramatch-microservices/common/util";
-import { SiteFullDto, SiteLightDto } from "../dto/site.dto";
 import { BadRequestException } from "@nestjs/common/exceptions/bad-request.exception";
+import { PolicyService } from "@terramatch-microservices/common";
+import { SiteLightDto } from "../dto/site.dto";
+import { buildJsonApi } from "@terramatch-microservices/common/util";
 
 describe("SiteProcessor", () => {
   let processor: SiteProcessor;
+  let policyService: DeepMocked<PolicyService>;
   let userId: number;
 
   beforeAll(async () => {
@@ -28,10 +30,18 @@ describe("SiteProcessor", () => {
     await Site.truncate();
 
     const module = await Test.createTestingModule({
-      providers: [{ provide: MediaService, useValue: createMock<MediaService>() }, EntitiesService]
+      providers: [
+        { provide: MediaService, useValue: createMock<MediaService>() },
+        { provide: PolicyService, useValue: (policyService = createMock<PolicyService>({ userId })) },
+        EntitiesService
+      ]
     }).compile();
 
     processor = module.get(EntitiesService).createEntityProcessor("sites") as SiteProcessor;
+  });
+
+  afterEach(async () => {
+    jest.resetAllMocks();
   });
 
   describe("findMany", () => {
@@ -45,7 +55,8 @@ describe("SiteProcessor", () => {
         total = expected.length
       }: { permissions?: string[]; sortField?: string; sortUp?: boolean; total?: number } = {}
     ) {
-      const { models, paginationTotal } = await processor.findMany(query as EntityQueryDto, userId, permissions);
+      policyService.getPermissions.mockResolvedValue(permissions);
+      const { models, paginationTotal } = await processor.findMany(query as EntityQueryDto);
       expect(models.length).toBe(expected.length);
       expect(paginationTotal).toBe(total);
 
@@ -150,7 +161,28 @@ describe("SiteProcessor", () => {
     });
 
     it("should throw an error if the sort field is not recognized", async () => {
-      await expect(processor.findMany({ sort: { field: "foo" } }, userId, [])).rejects.toThrow(BadRequestException);
+      policyService.getPermissions.mockResolvedValue([]);
+      await expect(processor.findMany({ sort: { field: "foo" } })).rejects.toThrow(BadRequestException);
+    });
+
+    it("should support search", async () => {
+      const project = await ProjectFactory.create({ name: "Fancy Project" });
+      const site = await SiteFactory.create({ name: "Boring Site", projectId: project.id });
+
+      await expectSites([site], { search: "Fancy" });
+      await expectSites([], { searchFilter: "Fancy" });
+      await expectSites([site], { search: "Boring" });
+      await expectSites([site], { searchFilter: "Boring" });
+    });
+
+    describe("processSideloads", () => {
+      it("should throw", async () => {
+        policyService.getPermissions.mockResolvedValue(["framework-terrafund"]);
+        await SiteFactory.create({ frameworkKey: "terrafund" });
+        await expect(
+          processor.addIndex(buildJsonApi(SiteLightDto), { sideloads: [{ entity: "siteReports", pageSize: 1 }] })
+        ).rejects.toThrow(BadRequestException);
+      });
     });
   });
 
@@ -166,10 +198,9 @@ describe("SiteProcessor", () => {
     it("should serialize a Site as a light resource (SiteLightDto)", async () => {
       const { uuid } = await SiteFactory.create();
       const site = await processor.findOne(uuid);
-      const document = buildJsonApi(SiteLightDto, { forceDataArray: true });
-      await processor.addLightDto(document, site);
-      const attributes = document.serialize().data[0].attributes as SiteLightDto;
-      expect(attributes).toMatchObject({
+      const { id, dto } = await processor.getLightDto(site);
+      expect(id).toEqual(uuid);
+      expect(dto).toMatchObject({
         uuid,
         lightResource: true
       });
@@ -182,10 +213,9 @@ describe("SiteProcessor", () => {
       });
 
       const site = await processor.findOne(uuid);
-      const document = buildJsonApi(SiteFullDto, { forceDataArray: true });
-      await processor.addFullDto(document, site);
-      const attributes = document.serialize().data[0].attributes as SiteFullDto;
-      expect(attributes).toMatchObject({
+      const { id, dto } = await processor.getFullDto(site);
+      expect(id).toEqual(uuid);
+      expect(dto).toMatchObject({
         uuid,
         lightResource: false,
         projectUuid: project.uuid

--- a/apps/entity-service/src/entities/processors/site.processor.ts
+++ b/apps/entity-service/src/entities/processors/site.processor.ts
@@ -1,5 +1,4 @@
-import { DocumentBuilder } from "@terramatch-microservices/common/util";
-import { Aggregate, aggregateColumns, EntityProcessor, PaginatedResult } from "./entity-processor";
+import { Aggregate, aggregateColumns, EntityProcessor } from "./entity-processor";
 import {
   Demographic,
   DemographicEntry,
@@ -37,7 +36,7 @@ export class SiteProcessor extends EntityProcessor<Site, SiteLightDto, SiteFullD
     });
   }
 
-  async findMany(query: EntityQueryDto, userId?: number, permissions?: string[]): Promise<PaginatedResult<Site>> {
+  async findMany(query: EntityQueryDto) {
     const projectAssociation: Includeable = {
       association: "project",
       attributes: ["uuid", "name"]
@@ -66,6 +65,7 @@ export class SiteProcessor extends EntityProcessor<Site, SiteLightDto, SiteFullD
       }
     }
 
+    const permissions = await this.entitiesService.getPermissions();
     const frameworkPermissions = permissions
       ?.filter(name => name.startsWith("framework-"))
       .map(name => name.substring("framework-".length) as FrameworkKey);
@@ -73,11 +73,11 @@ export class SiteProcessor extends EntityProcessor<Site, SiteLightDto, SiteFullD
       builder.where({ frameworkKey: { [Op.in]: frameworkPermissions } });
     } else if (permissions?.includes("manage-own")) {
       builder.where({
-        projectId: { [Op.in]: ProjectUser.userProjectsSubquery(userId) }
+        projectId: { [Op.in]: ProjectUser.userProjectsSubquery(this.entitiesService.userId) }
       });
     } else if (permissions?.includes("projects-manage")) {
       builder.where({
-        projectId: { [Op.in]: ProjectUser.projectsManageSubquery(userId) }
+        projectId: { [Op.in]: ProjectUser.projectsManageSubquery(this.entitiesService.userId) }
       });
     }
 
@@ -102,7 +102,7 @@ export class SiteProcessor extends EntityProcessor<Site, SiteLightDto, SiteFullD
     return { models: await builder.execute(), paginationTotal: await builder.paginationTotal() };
   }
 
-  async addFullDto(document: DocumentBuilder, site: Site): Promise<void> {
+  async getFullDto(site: Site) {
     const siteId = site.id;
 
     const approvedSiteReportsQuery = SiteReport.approvedIdsSubquery([siteId]);
@@ -131,15 +131,16 @@ export class SiteProcessor extends EntityProcessor<Site, SiteLightDto, SiteFullD
       ...(this.entitiesService.mapMediaCollection(await Media.site(siteId).findAll(), Site.MEDIA) as SiteMedia)
     };
 
-    document.addData(site.uuid, new SiteFullDto(site, props));
+    return { id: site.uuid, dto: new SiteFullDto(site, props) };
   }
 
-  async addLightDto(document: DocumentBuilder, site: Site) {
+  async getLightDto(site: Site) {
     const siteId = site.id;
     const approvedSiteReportsQuery = SiteReport.approvedIdsSubquery([siteId]);
     const treesPlantedCount =
       (await TreeSpecies.visible().collection("tree-planted").siteReports(approvedSiteReportsQuery).sum("amount")) ?? 0;
-    document.addData(site.uuid, new SiteLightDto(site, { treesPlantedCount }));
+
+    return { id: site.uuid, dto: new SiteLightDto(site, { treesPlantedCount }) };
   }
 
   protected async getWorkdayCount(siteId: number, useDemographicsCutoff = false) {

--- a/apps/entity-service/src/repl.ts
+++ b/apps/entity-service/src/repl.ts
@@ -1,4 +1,7 @@
 import { AppModule } from "./app.module";
 import { bootstrapRepl } from "@terramatch-microservices/common/util/bootstrap-repl";
+import { EntityQueryDto } from "./entities/dto/entity-query.dto";
 
-bootstrapRepl("Entity Service", AppModule);
+bootstrapRepl("Entity Service", AppModule, {
+  EntityQueryDto
+});

--- a/apps/research-service/src/site-polygons/site-polygons.controller.spec.ts
+++ b/apps/research-service/src/site-polygons/site-polygons.controller.spec.ts
@@ -109,8 +109,8 @@ describe("SitePolygonsController", () => {
       mockQueryBuilder([sitePolygon], 1);
       const result = await controller.findMany({});
       expect(result.meta).not.toBe(null);
-      expect(result.meta.page.total).toBe(1);
-      expect(result.meta.page.cursor).toBe(sitePolygon.uuid);
+      expect(result.meta.indices[0].total).toBe(1);
+      expect(result.meta.indices[0].cursor).toBe(sitePolygon.uuid);
 
       const resources = result.data as Resource[];
       expect(resources.length).toBe(1);
@@ -123,8 +123,8 @@ describe("SitePolygonsController", () => {
       mockQueryBuilder([sitePolygon], 1);
       const result = await controller.findMany({ page: { size: 5, number: 1 } });
       expect(result.meta).not.toBe(null);
-      expect(result.meta.page.total).toBe(1);
-      expect(result.meta.page.number).toBe(1);
+      expect(result.meta.indices[0].total).toBe(1);
+      expect(result.meta.indices[0].pageNumber).toBe(1);
 
       const resources = result.data as Resource[];
       expect(resources.length).toBe(1);
@@ -135,7 +135,7 @@ describe("SitePolygonsController", () => {
       policyService.authorize.mockResolvedValue(undefined);
       const builder = mockQueryBuilder();
       const result = await controller.findMany({});
-      expect(result.meta.page.total).toBe(0);
+      expect(result.meta.indices[0].total).toBe(0);
 
       expect(builder.excludeTestProjects).toHaveBeenCalled();
     });

--- a/libs/common/src/lib/decorators/json-api-response.decorator.ts
+++ b/libs/common/src/lib/decorators/json-api-response.decorator.ts
@@ -3,7 +3,7 @@ import { ApiExtraModels, ApiResponse, ApiResponseOptions, getSchemaPath } from "
 import { applyDecorators, HttpStatus } from "@nestjs/common";
 import { DTO_ID_METADATA, DTO_TYPE_METADATA, IdType } from "./json-api-dto.decorator";
 import { JsonApiAttributes } from "../dto/json-api-attributes";
-import { isArray, uniq } from "lodash";
+import { Dictionary, isArray, uniq } from "lodash";
 
 type ExampleTypeProperty = {
   type: "string";
@@ -157,21 +157,32 @@ function buildSchema(options: JsonApiOptions) {
   }
 
   if (pagination != null) {
-    const properties = {
+    const properties: Dictionary<object> = {
+      resource: { type: "string", description: "The resource type for this included index" },
+      requestPath: {
+        type: "string",
+        description:
+          "The full stable (sorted query param) request path for this request, suitable for use as a store key in the FE React app"
+      },
       total: { type: "number", description: "The total number of records available.", example: 42 }
-    } as { total: object; cursor?: object; number?: object };
+    };
     if (pagination === "cursor") {
-      properties.cursor = {
+      properties["cursor"] = {
         type: "string",
         description: "The cursor for the first record on this page."
       };
     } else if (pagination === "number") {
-      properties.number = {
+      properties["pageNumber"] = {
         type: "number",
         description: "The current page number."
       };
     }
-    addMeta(document, "page", { type: "object", properties });
+    properties["ids"] = {
+      type: "array",
+      items: { type: "string" },
+      description: "The ordered set of resource IDs for this page of this index search."
+    };
+    addMeta(document, "indices", { type: "array", items: { type: "object", properties } });
   }
 
   return { document, extraModels };

--- a/libs/common/src/lib/util/json-api-builder.ts
+++ b/libs/common/src/lib/util/json-api-builder.ts
@@ -43,7 +43,7 @@ type ResourceMeta = {
 
 export type JsonApiDocument = {
   data?: Resource | Resource[];
-  included?: Resource | Resource[];
+  included?: Resource[];
   meta: DocumentMeta;
 };
 
@@ -189,9 +189,6 @@ export class DocumentBuilder {
       doc.included = this.included.map(resource => resource.serialize());
     }
 
-    if (!singular && this.indexData.length === 0) {
-      throw new ApiBuilderException("Index data is required on index endpoints");
-    }
     if (this.indexData.length > 0) {
       doc.meta.indices = this.indexData;
     }

--- a/nx.json
+++ b/nx.json
@@ -45,6 +45,11 @@
     }
   ],
   "targetDefaults": {
+    "serve": {
+      "options": {
+        "inspect": false
+      }
+    },
     "lint": {
       "options": {
         "max-warnings": 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "mysql2": "^3.13.0",
         "nestjs-request-context": "^4.0.0",
         "nodemailer": "^6.10.0",
+        "qs": "^6.14.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.2",
         "sequelize": "^6.37.6",
@@ -8310,20 +8311,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/body-parser/node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/bonjour-service": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.3.0.tgz",
@@ -10446,6 +10433,20 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/express/node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/factory-girl-ts": {
       "version": "2.3.1",
@@ -15497,11 +15498,11 @@
       ]
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"
@@ -18849,6 +18850,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "dev": true,
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/webpack-dev-server/node_modules/raw-body": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "mysql2": "^3.13.0",
     "nestjs-request-context": "^4.0.0",
     "nodemailer": "^6.10.0",
+    "qs": "^6.14.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
     "sequelize": "^6.37.6",


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-1864

Supports sideloading of associated resources by passing an array of `sideloads` in the query. Currently only sites and nurseries on project is supported. In the FE, this is currently only used to get the first page of sites and nurseries for projects on the my projects page in order to prevent N+1 API requests when that page loads.