### PR TITLE
[TM-2028] Removing the bulk of the joins is making this endpoint much faster

### DIFF
--- a/apps/research-service/src/site-polygons/site-polygon-query.builder.ts
+++ b/apps/research-service/src/site-polygons/site-polygon-query.builder.ts
@@ -10,8 +10,7 @@ import {
   PolygonGeometry,
   Project,
   Site,
-  SitePolygon,
-  SiteReport
+  SitePolygon
 } from "@terramatch-microservices/database/entities";
 import { IndicatorSlug, PolygonStatus } from "@terramatch-microservices/database/constants";
 import { uniq } from "lodash";
@@ -43,37 +42,18 @@ export const INDICATOR_MODEL_CLASSES: { [Slug in IndicatorSlug]: IndicatorClass<
   msuCarbon: IndicatorOutputMsuCarbon
 };
 
-const INDICATOR_EXCLUDE_COLUMNS = ["id", "sitePolygonId", "createdAt", "updatedAt", "deletedAt"];
-
 export class SitePolygonQueryBuilder extends PaginatedQueryBuilder<SitePolygon> {
   private siteJoin: IncludeOptions = {
     model: Site,
-    include: [
-      { association: "treesPlanted", attributes: ["name", "amount"] },
-      {
-        model: SiteReport,
-        include: [{ association: "treesPlanted", attributes: ["name", "amount"] }],
-        attributes: ["dueAt", "submittedAt"]
-      },
-      { association: "project", attributes: ["uuid"] }
-    ],
-    attributes: ["projectId", "name"],
+    include: [{ association: "project", attributes: ["uuid"] }],
+    attributes: ["id", "projectId", "name"],
     required: true
   };
 
   constructor(pageSize: number) {
     super(SitePolygon, pageSize);
 
-    this.findOptions.include = [
-      { model: IndicatorOutputFieldMonitoring, attributes: { exclude: INDICATOR_EXCLUDE_COLUMNS } },
-      { model: IndicatorOutputHectares, attributes: { exclude: INDICATOR_EXCLUDE_COLUMNS } },
-      { model: IndicatorOutputMsuCarbon, attributes: { exclude: INDICATOR_EXCLUDE_COLUMNS } },
-      { model: IndicatorOutputTreeCount, attributes: { exclude: INDICATOR_EXCLUDE_COLUMNS } },
-      { model: IndicatorOutputTreeCover, attributes: { exclude: INDICATOR_EXCLUDE_COLUMNS } },
-      { model: IndicatorOutputTreeCoverLoss, attributes: { exclude: INDICATOR_EXCLUDE_COLUMNS } },
-      { model: PolygonGeometry, attributes: ["polygon"], required: true },
-      this.siteJoin
-    ];
+    this.findOptions.include = [{ model: PolygonGeometry, attributes: ["polygon"], required: true }, this.siteJoin];
 
     this.where({ isActive: true });
   }

--- a/libs/database/src/lib/entities/site-polygon.entity.ts
+++ b/libs/database/src/lib/entities/site-polygon.entity.ts
@@ -170,25 +170,25 @@ export class SitePolygon extends Model<SitePolygon> {
   indicatorsTreeCoverLoss: IndicatorOutputTreeCoverLoss[] | null;
 
   private _indicators: Indicator[] | null;
-  async getIndicators(refresh = false) {
-    if (!refresh && this._indicators != null) return this._indicators;
+  async getIndicators() {
+    if (this._indicators != null) return this._indicators;
 
-    if (refresh || this.indicatorsFieldMonitoring == null) {
+    if (this.indicatorsFieldMonitoring == null) {
       this.indicatorsFieldMonitoring = await this.$get("indicatorsFieldMonitoring");
     }
-    if (refresh || this.indicatorsHectares == null) {
+    if (this.indicatorsHectares == null) {
       this.indicatorsHectares = await this.$get("indicatorsHectares");
     }
-    if (refresh || this.indicatorsMsuCarbon == null) {
+    if (this.indicatorsMsuCarbon == null) {
       this.indicatorsMsuCarbon = await this.$get("indicatorsMsuCarbon");
     }
-    if (refresh || this.indicatorsTreeCount == null) {
+    if (this.indicatorsTreeCount == null) {
       this.indicatorsTreeCount = await this.$get("indicatorsTreeCount");
     }
-    if (refresh || this.indicatorsTreeCover == null) {
+    if (this.indicatorsTreeCover == null) {
       this.indicatorsTreeCover = await this.$get("indicatorsTreeCover");
     }
-    if (refresh || this.indicatorsTreeCoverLoss == null) {
+    if (this.indicatorsTreeCoverLoss == null) {
       this.indicatorsTreeCoverLoss = await this.$get("indicatorsTreeCoverLoss");
     }
 


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-2028

This is addressing some memory / cpu issues in the research service that are currently blocking the research team. This is an intermediate fix - it trades out a bunch of joins for a bajillion N+1 queries. I'm going to create a follow up ticket to optimize that down to fewer queries, but in the mean time this is getting the service to respond correctly, and _much_ faster. With a page size of 30 and a sample query from the research team, a request that was taking ~20 seconds in AWS is down to 5 seconds, and the default page size of 100 finishes successfully instead of running out of memory. The number of joins in these queries was causing a response of ~50 site polygons to return > 350k rows from the DB.