### PR TITLE
[TM-2029] Get > 1k queries for site polygons down to 11

### DIFF
--- a/apps/research-service/src/site-polygons/dto/site-polygon.dto.ts
+++ b/apps/research-service/src/site-polygons/dto/site-polygon.dto.ts
@@ -107,9 +107,9 @@ export class SitePolygonLightDto extends HybridSupportDto {
 export class SitePolygonFullDto extends SitePolygonLightDto {
   constructor(
     sitePolygon: SitePolygon,
-    indicators: IndicatorDto[],
-    establishmentTreeSpecies: TreeSpeciesDto[],
-    reportingPeriods: ReportingPeriodDto[]
+    indicators?: IndicatorDto[],
+    establishmentTreeSpecies?: TreeSpeciesDto[],
+    reportingPeriods?: ReportingPeriodDto[]
   ) {
     super();
 
@@ -117,11 +117,11 @@ export class SitePolygonFullDto extends SitePolygonLightDto {
       name: sitePolygon.polyName,
       siteId: sitePolygon.siteUuid,
       projectId: sitePolygon.site?.project?.uuid,
-      indicators: indicators,
+      indicators: indicators ?? [],
       siteName: sitePolygon.site?.name,
       geometry: sitePolygon.polygon?.polygon,
-      establishmentTreeSpecies,
-      reportingPeriods,
+      establishmentTreeSpecies: establishmentTreeSpecies ?? [],
+      reportingPeriods: reportingPeriods ?? [],
       lightResource: false
     });
   }

--- a/apps/research-service/src/site-polygons/site-polygon-query.builder.ts
+++ b/apps/research-service/src/site-polygons/site-polygon-query.builder.ts
@@ -59,9 +59,9 @@ export class SitePolygonQueryBuilder extends PaginatedQueryBuilder<SitePolygon> 
   }
 
   async excludeTestProjects() {
-    // avoid joining against the entire project table by doing a quick query first. The number of test projects is small
-    const testProjects = await Project.findAll({ where: { isTest: true }, attributes: ["id"] });
-    return this.where({ projectId: { [Op.notIn]: testProjects.map(({ id }) => id) } }, this.siteJoin);
+    // Avoid joining against the entire project table by doing a quick query first. The number of test projects is small
+    const testProjects = Subquery.select(Project, "id").eq("isTest", true).literal;
+    return this.where({ projectId: { [Op.notIn]: testProjects } }, this.siteJoin);
   }
 
   async filterSiteUuids(siteUuids: string[]) {

--- a/apps/research-service/src/site-polygons/site-polygons.controller.ts
+++ b/apps/research-service/src/site-polygons/site-polygons.controller.ts
@@ -133,12 +133,20 @@ export class SitePolygonsController {
 
     const indexIds: string[] = [];
     const document = buildJsonApi(dtoType, { pagination: isNumberPage(query.page) ? "number" : "cursor" });
-    for (const sitePolygon of await queryBuilder.execute()) {
+    const sitePolygons = await queryBuilder.execute();
+    const associations = await this.sitePolygonService.loadAssociationDtos(sitePolygons, lightResource ?? false);
+    for (const sitePolygon of sitePolygons) {
       indexIds.push(sitePolygon.uuid);
       if (lightResource) {
-        document.addData(sitePolygon.uuid, await this.sitePolygonService.buildLightDto(sitePolygon));
+        document.addData(
+          sitePolygon.uuid,
+          await this.sitePolygonService.buildLightDto(sitePolygon, associations[sitePolygon.id] ?? {})
+        );
       } else {
-        document.addData(sitePolygon.uuid, await this.sitePolygonService.buildFullDto(sitePolygon));
+        document.addData(
+          sitePolygon.uuid,
+          await this.sitePolygonService.buildFullDto(sitePolygon, associations[sitePolygon.id] ?? {})
+        );
       }
     }
 

--- a/libs/database/src/lib/entities/site.entity.ts
+++ b/libs/database/src/lib/entities/site.entity.ts
@@ -70,10 +70,6 @@ export class Site extends Model<Site> {
     return Subquery.select(Site, "uuid").eq("projectId", projectId).in("status", Site.APPROVED_STATUSES).literal;
   }
 
-  static idsForUuidsSubquery(uuids: string[]) {
-    return Subquery.select(Site, "id").in("uuid", uuids).literal;
-  }
-
   @PrimaryKey
   @AutoIncrement
   @Column(BIGINT.UNSIGNED)

--- a/libs/database/src/lib/entities/site.entity.ts
+++ b/libs/database/src/lib/entities/site.entity.ts
@@ -70,6 +70,10 @@ export class Site extends Model<Site> {
     return Subquery.select(Site, "uuid").eq("projectId", projectId).in("status", Site.APPROVED_STATUSES).literal;
   }
 
+  static idsForUuidsSubquery(uuids: string[]) {
+    return Subquery.select(Site, "id").in("uuid", uuids).literal;
+  }
+
   @PrimaryKey
   @AutoIncrement
   @Column(BIGINT.UNSIGNED)


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-2029

When loading a full page of 100 site polygons with the full DTO, the service was issuing > 1k queries (the total depended on how many site reports there were for the sites related to the polygons in the query result). That still turned out to be much better than the massive joins I had in here before that were returning > 300k rows from the DB and blowing up the process memory. 

With this, it's down to 11 queries, regardless of the number of polygons, sites or reports in the resulting data set. It also cut the processing time down from ~8 seconds in staging to 1.5-3s to return a payload of ~1MB for 100 polygons.