### PR TITLE
[TM-2040 fix id country landscapes

### DIFF
--- a/apps/entity-service/src/bounding-boxes/bounding-box.controller.spec.ts
+++ b/apps/entity-service/src/bounding-boxes/bounding-box.controller.spec.ts
@@ -21,7 +21,16 @@ jest.mock("@terramatch-microservices/database/util/subquery.builder", () => ({
 }));
 
 jest.mock("@terramatch-microservices/database/entities", () => ({
+  LandscapeGeometry: {
+    findAll: jest.fn(),
+    LANDSCAPE_SLUGS: [
+      "gcb", // Greater Cape Basin
+      "grv", // Greater Rift Valley of Kenya
+      "ikr" // Lake Kivu & Rusizi River Basin
+    ]
+  },
   PolygonGeometry: {
+    findAll: jest.fn(),
     findOne: jest.fn()
   },
   Site: {
@@ -190,15 +199,15 @@ describe("BoundingBoxController", () => {
     });
 
     it("should call getCountryLandscapeBoundingBox when country is provided without authorization", async () => {
-      await testQueryParameters({ country: "US" }, "getCountryLandscapeBoundingBox", ["US", []], "US-", false);
+      await testQueryParameters({ country: "US" }, "getCountryLandscapeBoundingBox", ["US", []], "US", false);
     });
 
     it("should call getCountryLandscapeBoundingBox when landscapes are provided without authorization", async () => {
       await testQueryParameters(
-        { landscapes: ["ikr", "amazon"] },
+        { landscapes: ["ikr", "gcb"] },
         "getCountryLandscapeBoundingBox",
-        ["global", ["ikr", "amazon"]],
-        "global-ikr-amazon",
+        ["", ["ikr", "gcb"]],
+        "ikr,gcb",
         false
       );
     });

--- a/apps/entity-service/src/bounding-boxes/bounding-box.controller.ts
+++ b/apps/entity-service/src/bounding-boxes/bounding-box.controller.ts
@@ -126,11 +126,21 @@ export class BoundingBoxController {
       }
 
       case "country/landscapes": {
-        const country = query.country ?? "global";
+        const country = query.country;
         const landscapes: string[] = query.landscapes ?? [];
 
-        const result = await this.boundingBoxService.getCountryLandscapeBoundingBox(country, landscapes);
-        const id = `${country}-${landscapes.join("-")}`;
+        const result = await this.boundingBoxService.getCountryLandscapeBoundingBox(country ?? "", landscapes);
+
+        let id: string;
+        if (!isEmpty(country) && landscapes.length > 0) {
+          id = `${country},${landscapes.join(",")}`;
+        } else if (!isEmpty(country)) {
+          id = country as string;
+        } else if (landscapes.length > 0) {
+          id = landscapes.join(",");
+        } else {
+          id = "global";
+        }
         return buildJsonApi(BoundingBoxDto).addData(id, result).document.serialize();
       }
     }

--- a/apps/entity-service/src/bounding-boxes/bounding-box.controller.ts
+++ b/apps/entity-service/src/bounding-boxes/bounding-box.controller.ts
@@ -7,7 +7,7 @@ import { ExceptionResponse, JsonApiResponse } from "@terramatch-microservices/co
 import { buildJsonApi, JsonApiDocument } from "@terramatch-microservices/common/util";
 import { isEmpty } from "lodash";
 import { PolicyService } from "@terramatch-microservices/common";
-import { Project, Site, SitePolygon } from "@terramatch-microservices/database/entities";
+import { Project, Site, SitePolygon, LandscapeGeometry } from "@terramatch-microservices/database/entities";
 import { Op } from "sequelize";
 import { Subquery } from "@terramatch-microservices/database/util/subquery.builder";
 
@@ -128,6 +128,20 @@ export class BoundingBoxController {
       case "country/landscapes": {
         const country = query.country;
         const landscapes: string[] = query.landscapes ?? [];
+
+        if (landscapes.length > 0) {
+          const validLandscapes = LandscapeGeometry.LANDSCAPE_SLUGS;
+          const invalidLandscapes = landscapes.filter(
+            landscape => !validLandscapes.some(validSlug => validSlug === landscape)
+          );
+          if (invalidLandscapes.length > 0) {
+            throw new BadRequestException(
+              `Invalid landscape slugs provided: ${invalidLandscapes.join(
+                ", "
+              )}. Valid landscape slugs are: ${validLandscapes.join(", ")}`
+            );
+          }
+        }
 
         const result = await this.boundingBoxService.getCountryLandscapeBoundingBox(country ?? "", landscapes);
 


### PR DESCRIPTION
returns a standar id for country landscape so it can be used consistently for cache frontend 