### PR TITLE
[TM-2083] tree restoration goals

### DIFF
--- a/apps/dashboard-service/src/app.module.ts
+++ b/apps/dashboard-service/src/app.module.ts
@@ -10,6 +10,8 @@ import { CacheService } from "./dashboard/dto/cache.service";
 import { RedisModule } from "@nestjs-modules/ioredis";
 import { ConfigModule, ConfigService } from "@nestjs/config";
 import { DashboardProcessor } from "./dashboard/worker/dashboard.processor";
+import { TreeRestorationGoalController } from "./dashboard/tree-restoration-goal.controller";
+import { TreeRestorationGoalService } from "./dashboard/dto/tree-restoration-goal.service";
 
 @Module({
   imports: [
@@ -30,7 +32,7 @@ import { DashboardProcessor } from "./dashboard/worker/dashboard.processor";
     }),
     BullModule.registerQueue({ name: "dashboard" })
   ],
-  controllers: [TotalSectionHeaderController],
+  controllers: [TotalSectionHeaderController, TreeRestorationGoalController],
   providers: [
     {
       provide: APP_FILTER,
@@ -38,7 +40,8 @@ import { DashboardProcessor } from "./dashboard/worker/dashboard.processor";
     },
     TotalSectionHeaderService,
     CacheService,
-    DashboardProcessor
+    DashboardProcessor,
+    TreeRestorationGoalService
   ]
 })
 export class AppModule {}

--- a/apps/dashboard-service/src/dashboard/dto/tree-restoration-goal.dto.ts
+++ b/apps/dashboard-service/src/dashboard/dto/tree-restoration-goal.dto.ts
@@ -1,0 +1,49 @@
+import { JsonApiDto } from "@terramatch-microservices/common/decorators";
+import { ApiProperty } from "@nestjs/swagger";
+import { populateDto } from "@terramatch-microservices/common/dto/json-api-attributes";
+
+@JsonApiDto({ type: "treeRestorationGoals" })
+export class TreeRestorationGoalDto {
+  constructor(data: TreeRestorationGoalDto) {
+    populateDto<TreeRestorationGoalDto>(this, data);
+  }
+
+  @ApiProperty({
+    description: "Total number of trees grown goal for for-profit organizations",
+    type: Number
+  })
+  forProfitTreeCount: number;
+
+  @ApiProperty({
+    description: "Total number of trees grown goal for non-profit organizations",
+    type: Number
+  })
+  nonProfitTreeCount: number;
+
+  @ApiProperty({
+    description: "Total trees grown goal across all organizations",
+    type: Number
+  })
+  totalTreesGrownGoal: number;
+
+  @ApiProperty({
+    description: "Total number of trees under restoration across all organizations",
+    type: Number
+  })
+  treesUnderRestorationActualTotal: number;
+
+  @ApiProperty({
+    description: "Total number of trees under restoration for for-profit organizations",
+    type: Number
+  })
+  treesUnderRestorationActualForProfit: number;
+
+  @ApiProperty({
+    description: "Total number of trees under restoration for non-profit organizations",
+    type: Number
+  })
+  treesUnderRestorationActualNonProfit: number;
+
+  @ApiProperty({ nullable: true, type: String })
+  lastUpdatedAt: string | null;
+}

--- a/apps/dashboard-service/src/dashboard/dto/tree-restoration-goal.service.spec.ts
+++ b/apps/dashboard-service/src/dashboard/dto/tree-restoration-goal.service.spec.ts
@@ -1,0 +1,497 @@
+import { TreeRestorationGoalService } from "./tree-restoration-goal.service";
+import { DashboardProjectsQueryBuilder } from "../dashboard-query.builder";
+import { Project, Site, SiteReport, TreeSpecies } from "@terramatch-microservices/database/entities";
+import { DashboardQueryDto } from "./dashboard-query.dto";
+import { literal, Op } from "sequelize";
+
+jest.mock("../dashboard-query.builder");
+jest.mock("@terramatch-microservices/database/entities");
+
+describe("TreeRestorationGoalService", () => {
+  let service: TreeRestorationGoalService;
+  let mockBuilder: jest.Mocked<DashboardProjectsQueryBuilder>;
+
+  const mockProjects = [
+    {
+      id: 1,
+      treesGrownGoal: 10000,
+      organisation: { type: "non-profit-organization" }
+    },
+    {
+      id: 2,
+      treesGrownGoal: 15000,
+      organisation: { type: "for-profit-organization" }
+    },
+    {
+      id: 3,
+      treesGrownGoal: null,
+      organisation: { type: "non-profit-organization" }
+    }
+  ] as unknown as Project[];
+
+  const mockSiteReports = [
+    {
+      id: 1,
+      dueAt: new Date("2023-01-15T00:00:00.000Z"),
+      treesPlanted: [{ amount: 1000 }, { amount: 2000 }]
+    },
+    {
+      id: 2,
+      dueAt: new Date("2023-07-20T00:00:00.000Z"),
+      treesPlanted: [{ amount: 1500 }]
+    },
+    {
+      id: 3,
+      dueAt: new Date("2024-01-10T00:00:00.000Z"),
+      treesPlanted: [{ amount: 2500 }]
+    }
+  ];
+
+  const mockDistinctDates = [
+    { year: 2023, month: 1 },
+    { year: 2023, month: 7 },
+    { year: 2024, month: 1 }
+  ];
+
+  beforeEach(() => {
+    service = new TreeRestorationGoalService();
+
+    mockBuilder = {
+      queryFilters: jest.fn().mockReturnThis(),
+      execute: jest.fn()
+    } as unknown as jest.Mocked<DashboardProjectsQueryBuilder>;
+
+    (DashboardProjectsQueryBuilder as jest.Mock).mockImplementation(() => mockBuilder);
+
+    // Mock Site methods
+    (Site.approvedIdsProjectsSubquery as jest.Mock).mockResolvedValue("approved-sites-subquery");
+
+    // Mock SiteReport methods
+    (SiteReport.approvedIdsSubquery as jest.Mock).mockResolvedValue("approved-site-reports-subquery");
+    (SiteReport.findAll as jest.Mock).mockResolvedValue(mockSiteReports);
+
+    // Mock TreeSpecies methods
+    (TreeSpecies.visible as jest.Mock).mockReturnValue({
+      collection: jest.fn().mockReturnThis(),
+      siteReports: jest.fn().mockReturnThis(),
+      sum: jest.fn().mockResolvedValue(5000)
+    });
+
+    jest.clearAllMocks();
+  });
+
+  describe("getTreeRestorationGoal", () => {
+    it("should return complete tree restoration goal data", async () => {
+      const query: DashboardQueryDto = {
+        country: "BEN",
+        programmes: ["terrafund"]
+      };
+
+      mockBuilder.execute.mockResolvedValue(mockProjects);
+
+      const result = await service.getTreeRestorationGoal(query);
+
+      expect(DashboardProjectsQueryBuilder).toHaveBeenCalledWith(Project, [
+        {
+          association: "organisation",
+          attributes: ["uuid", "name", "type"]
+        }
+      ]);
+      expect(mockBuilder.queryFilters).toHaveBeenCalledWith(query);
+      expect(mockBuilder.execute).toHaveBeenCalled();
+
+      expect(result).toHaveProperty("forProfitTreeCount");
+      expect(result).toHaveProperty("nonProfitTreeCount");
+      expect(result).toHaveProperty("totalTreesGrownGoal");
+      expect(result).toHaveProperty("treesUnderRestorationActualTotal");
+      expect(result).toHaveProperty("treesUnderRestorationActualForProfit");
+      expect(result).toHaveProperty("treesUnderRestorationActualNonProfit");
+
+      expect(result.totalTreesGrownGoal).toBe(25000); // 10000 + 15000 + 0
+    });
+
+    it("should handle empty projects list", async () => {
+      const query: DashboardQueryDto = {};
+
+      mockBuilder.execute.mockResolvedValue([]);
+      (Site.approvedIdsProjectsSubquery as jest.Mock).mockResolvedValue(literal("(0)"));
+
+      // Override TreeSpecies mock to return 0 for empty case
+      (TreeSpecies.visible as jest.Mock).mockReturnValue({
+        collection: jest.fn().mockReturnThis(),
+        siteReports: jest.fn().mockReturnThis(),
+        sum: jest.fn().mockResolvedValue(0)
+      });
+
+      // Override SiteReport.findAll to return empty array for empty projects case
+      (SiteReport.findAll as jest.Mock).mockResolvedValue([]);
+
+      const result = await service.getTreeRestorationGoal(query);
+
+      expect(result.totalTreesGrownGoal).toBe(0);
+      expect(result.forProfitTreeCount).toBe(0);
+      expect(result.nonProfitTreeCount).toBe(0);
+      expect(result.treesUnderRestorationActualTotal).toEqual([]);
+      expect(result.treesUnderRestorationActualForProfit).toEqual([]);
+      expect(result.treesUnderRestorationActualNonProfit).toEqual([]);
+    });
+
+    it("should filter projects by organisation type correctly", async () => {
+      const query: DashboardQueryDto = {
+        organisationType: ["non-profit-organization"]
+      };
+
+      mockBuilder.execute.mockResolvedValue(mockProjects);
+
+      await service.getTreeRestorationGoal(query);
+
+      // Check that Site.approvedIdsProjectsSubquery was called with correct project IDs
+      expect(Site.approvedIdsProjectsSubquery).toHaveBeenCalledWith([1, 2, 3]); // all projects
+      expect(Site.approvedIdsProjectsSubquery).toHaveBeenCalledWith([2]); // for-profit only (project 2)
+      expect(Site.approvedIdsProjectsSubquery).toHaveBeenCalledWith([1, 3]); // non-profit only (projects 1, 3)
+    });
+
+    it("should handle projects with null treesGrownGoal", async () => {
+      const query: DashboardQueryDto = {};
+      const projectsWithNulls = [
+        { id: 1, treesGrownGoal: null, organisation: { type: "non-profit-organization" } },
+        { id: 2, treesGrownGoal: undefined, organisation: { type: "for-profit-organization" } },
+        { id: 3, treesGrownGoal: 5000, organisation: { type: "non-profit-organization" } }
+      ] as unknown as Project[];
+
+      mockBuilder.execute.mockResolvedValue(projectsWithNulls);
+
+      const result = await service.getTreeRestorationGoal(query);
+
+      expect(result.totalTreesGrownGoal).toBe(5000); // Only the non-null value
+    });
+
+    it("should handle all filters combined", async () => {
+      const query: DashboardQueryDto = {
+        organisationType: ["for-profit-organization", "non-profit-organization"],
+        country: "CMR",
+        programmes: ["terrafund", "ppc"],
+        projectUuid: "uuid-123",
+        landscapes: ["landscape1"],
+        cohort: "cohort-2024"
+      };
+
+      mockBuilder.execute.mockResolvedValue(mockProjects);
+
+      await service.getTreeRestorationGoal(query);
+
+      expect(mockBuilder.queryFilters).toHaveBeenCalledWith(query);
+    });
+  });
+
+  describe("getTreeCount (private method)", () => {
+    it("should calculate tree count from approved site reports", async () => {
+      const mockApprovedSitesQuery = literal("approved-sites");
+
+      // Call the private method through the public interface
+      const result = await (service as unknown as { getTreeCount: (query: unknown) => Promise<number> }).getTreeCount(
+        mockApprovedSitesQuery
+      );
+
+      expect(SiteReport.approvedIdsSubquery).toHaveBeenCalledWith(mockApprovedSitesQuery);
+      expect(TreeSpecies.visible).toHaveBeenCalled();
+      expect(result).toBe(5000);
+    });
+
+    it("should return 0 when no tree species data", async () => {
+      const mockApprovedSitesQuery = literal("approved-sites");
+
+      (TreeSpecies.visible as jest.Mock).mockReturnValue({
+        collection: jest.fn().mockReturnThis(),
+        siteReports: jest.fn().mockReturnThis(),
+        sum: jest.fn().mockResolvedValue(null)
+      });
+
+      const result = await (service as unknown as { getTreeCount: (query: unknown) => Promise<number> }).getTreeCount(
+        mockApprovedSitesQuery
+      );
+
+      expect(result).toBe(0);
+    });
+  });
+
+  describe("getDistinctDates (private method)", () => {
+    it("should return distinct year/month combinations from site reports", async () => {
+      const mockApprovedSitesQuery = literal("approved-sites");
+
+      (SiteReport.findAll as jest.Mock).mockResolvedValue([
+        { year: 2023, month: 1 },
+        { year: 2023, month: 7 },
+        { year: 2024, month: 1 }
+      ]);
+
+      const result = await (
+        service as unknown as { getDistinctDates: (query: unknown) => Promise<unknown[]> }
+      ).getDistinctDates(mockApprovedSitesQuery);
+
+      expect(SiteReport.approvedIdsSubquery).toHaveBeenCalledWith(mockApprovedSitesQuery);
+      expect(SiteReport.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            id: { [Op.in]: "approved-site-reports-subquery" }
+          },
+          raw: true
+        })
+      );
+
+      expect(result).toEqual([
+        { year: 2023, month: 1 },
+        { year: 2023, month: 7 },
+        { year: 2024, month: 1 }
+      ]);
+    });
+
+    it("should handle empty site reports", async () => {
+      const mockApprovedSitesQuery = literal("approved-sites");
+
+      (SiteReport.findAll as jest.Mock).mockResolvedValue([]);
+
+      const result = await (
+        service as unknown as { getDistinctDates: (query: unknown) => Promise<unknown[]> }
+      ).getDistinctDates(mockApprovedSitesQuery);
+
+      expect(result).toEqual([]);
+    });
+
+    it("should handle null site reports", async () => {
+      const mockApprovedSitesQuery = literal("approved-sites");
+
+      (SiteReport.findAll as jest.Mock).mockResolvedValue(null);
+
+      const result = await (
+        service as unknown as { getDistinctDates: (query: unknown) => Promise<unknown[]> }
+      ).getDistinctDates(mockApprovedSitesQuery);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("calculateTreesUnderRestoration (private method)", () => {
+    it("should calculate trees under restoration for given dates", async () => {
+      const mockApprovedSitesQuery = literal("approved-sites");
+      const totalTreesGrownGoal = 50000;
+
+      const result = await (
+        service as unknown as {
+          calculateTreesUnderRestoration: (
+            query: unknown,
+            dates: { year: number; month: number }[],
+            goal: number
+          ) => Promise<unknown[]>;
+        }
+      ).calculateTreesUnderRestoration(mockApprovedSitesQuery, mockDistinctDates, totalTreesGrownGoal);
+
+      expect(SiteReport.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            id: { [Op.in]: "approved-site-reports-subquery" }
+          },
+          include: [
+            {
+              model: TreeSpecies,
+              as: "treesPlanted",
+              required: false,
+              where: {
+                hidden: false,
+                collection: "tree-planted"
+              }
+            }
+          ]
+        })
+      );
+
+      expect(result).toHaveLength(3);
+      expect(result[0]).toHaveProperty("dueDate");
+      expect(result[0]).toHaveProperty("treeSpeciesAmount");
+      expect(result[0]).toHaveProperty("treeSpeciesPercentage");
+    });
+
+    it("should return empty array when no distinct dates", async () => {
+      const mockApprovedSitesQuery = literal("approved-sites");
+      const totalTreesGrownGoal = 50000;
+
+      const result = await (
+        service as unknown as {
+          calculateTreesUnderRestoration: (
+            query: unknown,
+            dates: { year: number; month: number }[],
+            goal: number
+          ) => Promise<unknown[]>;
+        }
+      ).calculateTreesUnderRestoration(mockApprovedSitesQuery, [], totalTreesGrownGoal);
+
+      expect(result).toEqual([]);
+    });
+
+    it("should handle site reports with null dueAt", async () => {
+      const mockApprovedSitesQuery = literal("approved-sites");
+      const totalTreesGrownGoal = 50000;
+
+      const siteReportsWithNullDates = [
+        {
+          id: 1,
+          dueAt: null,
+          treesPlanted: [{ amount: 1000 }]
+        },
+        {
+          id: 2,
+          dueAt: new Date("2023-01-15T00:00:00.000Z"),
+          treesPlanted: [{ amount: 2000 }]
+        }
+      ];
+
+      (SiteReport.findAll as jest.Mock).mockResolvedValue(siteReportsWithNullDates);
+
+      const result = await (
+        service as unknown as {
+          calculateTreesUnderRestoration: (
+            query: unknown,
+            dates: { year: number; month: number }[],
+            goal: number
+          ) => Promise<unknown[]>;
+        }
+      ).calculateTreesUnderRestoration(mockApprovedSitesQuery, mockDistinctDates, totalTreesGrownGoal);
+
+      // Should only process reports with valid dueAt dates
+      expect(result).toHaveLength(3);
+    });
+
+    it("should calculate percentage correctly with zero goal", async () => {
+      const mockApprovedSitesQuery = literal("approved-sites");
+      const totalTreesGrownGoal = 0;
+
+      const result = await (
+        service as unknown as {
+          calculateTreesUnderRestoration: (
+            query: unknown,
+            dates: { year: number; month: number }[],
+            goal: number
+          ) => Promise<unknown[]>;
+        }
+      ).calculateTreesUnderRestoration(mockApprovedSitesQuery, mockDistinctDates, totalTreesGrownGoal);
+
+      expect(result).toHaveLength(3);
+      result.forEach((item: unknown) => {
+        expect((item as { treeSpeciesPercentage: number }).treeSpeciesPercentage).toBe(0);
+      });
+    });
+
+    it("should handle reports with null tree species amounts", async () => {
+      const mockApprovedSitesQuery = literal("approved-sites");
+      const totalTreesGrownGoal = 50000;
+
+      const siteReportsWithNullAmounts = [
+        {
+          id: 1,
+          dueAt: new Date("2023-01-15T00:00:00.000Z"),
+          treesPlanted: [{ amount: null }, { amount: 1000 }]
+        }
+      ];
+
+      (SiteReport.findAll as jest.Mock).mockResolvedValue(siteReportsWithNullAmounts);
+
+      const result = await (
+        service as unknown as {
+          calculateTreesUnderRestoration: (
+            query: unknown,
+            dates: { year: number; month: number }[],
+            goal: number
+          ) => Promise<unknown[]>;
+        }
+      ).calculateTreesUnderRestoration(mockApprovedSitesQuery, mockDistinctDates, totalTreesGrownGoal);
+
+      expect(result).toHaveLength(3);
+      // Should handle null amounts gracefully
+      expect(result[0]).toHaveProperty("treeSpeciesAmount");
+    });
+
+    it("should handle reports with null treesPlanted", async () => {
+      const mockApprovedSitesQuery = literal("approved-sites");
+      const totalTreesGrownGoal = 50000;
+
+      const siteReportsWithNullTreesPlanted = [
+        {
+          id: 1,
+          dueAt: new Date("2023-01-15T00:00:00.000Z"),
+          treesPlanted: null
+        }
+      ];
+
+      (SiteReport.findAll as jest.Mock).mockResolvedValue(siteReportsWithNullTreesPlanted);
+
+      const result = await (
+        service as unknown as {
+          calculateTreesUnderRestoration: (
+            query: unknown,
+            dates: { year: number; month: number }[],
+            goal: number
+          ) => Promise<unknown[]>;
+        }
+      ).calculateTreesUnderRestoration(mockApprovedSitesQuery, mockDistinctDates, totalTreesGrownGoal);
+
+      expect(result).toHaveLength(3);
+      // Should handle null treesPlanted gracefully
+      expect(result[0]).toHaveProperty("treeSpeciesAmount");
+    });
+
+    it("should format date correctly", async () => {
+      const mockApprovedSitesQuery = literal("approved-sites");
+      const totalTreesGrownGoal = 50000;
+
+      const result = await (
+        service as unknown as {
+          calculateTreesUnderRestoration: (
+            query: unknown,
+            dates: { year: number; month: number }[],
+            goal: number
+          ) => Promise<unknown[]>;
+        }
+      ).calculateTreesUnderRestoration(mockApprovedSitesQuery, mockDistinctDates, totalTreesGrownGoal);
+
+      expect(result[0]).toHaveProperty("dueDate");
+      expect((result[0] as { dueDate: Date }).dueDate).toBeInstanceOf(Date);
+      expect((result[0] as { dueDate: Date }).dueDate.getTime()).not.toBeNaN();
+
+      // Check specific date formatting
+      const firstResult = result[0] as { dueDate: Date };
+      expect(firstResult.dueDate.getFullYear()).toBe(2023);
+      expect(firstResult.dueDate.getMonth()).toBe(0); // January is 0
+      expect(firstResult.dueDate.getDate()).toBe(1);
+    });
+
+    it("should round percentage to 3 decimal places", async () => {
+      const mockApprovedSitesQuery = literal("approved-sites");
+      const totalTreesGrownGoal = 333; // Will create repeating decimals
+
+      const siteReportsForRounding = [
+        {
+          id: 1,
+          dueAt: new Date("2023-01-15T00:00:00.000Z"),
+          treesPlanted: [{ amount: 100 }] // 100/333 = 30.030030...%
+        }
+      ];
+
+      (SiteReport.findAll as jest.Mock).mockResolvedValue(siteReportsForRounding);
+
+      const result = await (
+        service as unknown as {
+          calculateTreesUnderRestoration: (
+            query: unknown,
+            dates: { year: number; month: number }[],
+            goal: number
+          ) => Promise<unknown[]>;
+        }
+      ).calculateTreesUnderRestoration(mockApprovedSitesQuery, [{ year: 2023, month: 1 }], totalTreesGrownGoal);
+
+      expect(result).toHaveLength(1);
+      const percentage = (result[0] as { treeSpeciesPercentage: number }).treeSpeciesPercentage;
+      expect(percentage).toBe(30.03); // Should be rounded to 3 decimal places
+      expect(percentage.toString().split(".")[1]?.length ?? 0).toBeLessThanOrEqual(3);
+    });
+  });
+});

--- a/apps/dashboard-service/src/dashboard/dto/tree-restoration-goal.service.ts
+++ b/apps/dashboard-service/src/dashboard/dto/tree-restoration-goal.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from "@nestjs/common";
+import { Project, Site, SiteReport, TreeSpecies } from "@terramatch-microservices/database/entities";
+import { DashboardQueryDto } from "./dashboard-query.dto";
+import { DashboardProjectsQueryBuilder } from "../dashboard-query.builder";
+
+@Injectable()
+export class TreeRestorationGoalService {
+  async getTreeRestorationGoal(query: DashboardQueryDto) {
+    const projectsBuilder = new DashboardProjectsQueryBuilder(Project, [
+      {
+        association: "organisation",
+        attributes: ["uuid", "name", "type"]
+      }
+    ]).queryFilters(query);
+
+    const projectIds: number[] = await projectsBuilder.pluckIds();
+
+    return {
+      forProfitTreeCount: await this.getForProfitTreeCount(projectIds)
+    };
+  }
+
+  private async getForProfitTreeCount(projectIds: number[]) {
+    const projects = await Project.findAll({
+      where: { id: projectIds },
+      include: [
+        {
+          association: "organisation",
+          attributes: ["type"]
+        }
+      ]
+    });
+
+    const forProfitProjectIds = projects
+      .filter(project => project.organisation?.type === "for-profit-organization")
+      .map(project => project.id);
+
+    const approvedSitesQuery = await Site.approvedIdsProjectsSubquery(forProfitProjectIds);
+    const approvedSiteReportsQuery = await SiteReport.approvedIdsSubquery(approvedSitesQuery);
+
+    return (
+      (await TreeSpecies.visible().collection("tree-planted").siteReports(approvedSiteReportsQuery).sum("amount")) ?? 0
+    );
+  }
+}

--- a/apps/dashboard-service/src/dashboard/dto/tree-restoration-goal.service.ts
+++ b/apps/dashboard-service/src/dashboard/dto/tree-restoration-goal.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@nestjs/common";
 import { Project, Site, SiteReport, TreeSpecies } from "@terramatch-microservices/database/entities";
 import { DashboardQueryDto } from "./dashboard-query.dto";
 import { DashboardProjectsQueryBuilder } from "../dashboard-query.builder";
+import { Op } from "sequelize";
 
 @Injectable()
 export class TreeRestorationGoalService {
@@ -32,14 +33,16 @@ export class TreeRestorationGoalService {
       .filter(project => project.organisation?.type === "non-profit-organization")
       .map(project => project.id);
 
-    const [forProfitTreeCount, nonProfitTreeCount] = await Promise.all([
+    const [forProfitTreeCount, nonProfitTreeCount, totalTreesGrownGoal] = await Promise.all([
       this.getTreeCount(forProfitProjectIds),
-      this.getTreeCount(nonProfitProjectIds)
+      this.getTreeCount(nonProfitProjectIds),
+      projectsBuilder.sum("treesGrownGoal")
     ]);
 
     return {
       forProfitTreeCount,
-      nonProfitTreeCount
+      nonProfitTreeCount,
+      totalTreesGrownGoal: totalTreesGrownGoal ?? 0
     };
   }
 

--- a/apps/dashboard-service/src/dashboard/dto/tree-restoration-goal.service.ts
+++ b/apps/dashboard-service/src/dashboard/dto/tree-restoration-goal.service.ts
@@ -2,7 +2,12 @@ import { Injectable } from "@nestjs/common";
 import { Project, Site, SiteReport, TreeSpecies } from "@terramatch-microservices/database/entities";
 import { DashboardQueryDto } from "./dashboard-query.dto";
 import { DashboardProjectsQueryBuilder } from "../dashboard-query.builder";
-import { Op } from "sequelize";
+import { Op, fn, col, literal } from "sequelize";
+
+interface DateResult {
+  year: number;
+  month: number;
+}
 
 @Injectable()
 export class TreeRestorationGoalService {
@@ -39,10 +44,24 @@ export class TreeRestorationGoalService {
       projectsBuilder.sum("treesGrownGoal")
     ]);
 
+    const distinctDates = await this.getDistinctDates(projectIds);
+    const [
+      treesUnderRestorationActualTotal,
+      treesUnderRestorationActualForProfit,
+      treesUnderRestorationActualNonProfit
+    ] = await Promise.all([
+      this.calculateTreesUnderRestoration(projectIds, distinctDates, totalTreesGrownGoal ?? 0),
+      this.calculateTreesUnderRestoration(forProfitProjectIds, distinctDates, totalTreesGrownGoal ?? 0),
+      this.calculateTreesUnderRestoration(nonProfitProjectIds, distinctDates, totalTreesGrownGoal ?? 0)
+    ]);
+
     return {
       forProfitTreeCount,
       nonProfitTreeCount,
-      totalTreesGrownGoal: totalTreesGrownGoal ?? 0
+      totalTreesGrownGoal: totalTreesGrownGoal ?? 0,
+      treesUnderRestorationActualTotal,
+      treesUnderRestorationActualForProfit,
+      treesUnderRestorationActualNonProfit
     };
   }
 
@@ -55,5 +74,82 @@ export class TreeRestorationGoalService {
     return (
       (await TreeSpecies.visible().collection("tree-planted").siteReports(approvedSiteReportsQuery).sum("amount")) ?? 0
     );
+  }
+
+  private async getDistinctDates(projectIds: number[]) {
+    if (projectIds.length === 0) return [];
+
+    const approvedSitesQuery = await Site.approvedIdsProjectsSubquery(projectIds);
+    const approvedSiteReportsQuery = await SiteReport.approvedIdsSubquery(approvedSitesQuery);
+
+    const siteReports = (await SiteReport.findAll({
+      where: {
+        id: { [Op.in]: approvedSiteReportsQuery }
+      },
+      attributes: [
+        [fn("YEAR", col("due_at")), "year"],
+        [fn("MONTH", col("due_at")), "month"]
+      ],
+      group: [fn("YEAR", col("due_at")), fn("MONTH", col("due_at"))],
+      order: [
+        [fn("YEAR", col("due_at")), "ASC"],
+        [fn("MONTH", col("due_at")), "ASC"]
+      ],
+      raw: true
+    })) as unknown as DateResult[];
+
+    return siteReports.map(report => ({
+      year: report.year,
+      month: report.month
+    }));
+  }
+
+  private async calculateTreesUnderRestoration(
+    projectIds: number[],
+    distinctDates: { year: number; month: number }[],
+    totalTreesGrownGoal: number
+  ) {
+    if (projectIds.length === 0 || distinctDates.length === 0) return [];
+
+    const approvedSitesQuery = await Site.approvedIdsProjectsSubquery(projectIds);
+    const approvedSiteReportsQuery = await SiteReport.approvedIdsSubquery(approvedSitesQuery);
+
+    const results = await Promise.all(
+      distinctDates.map(async ({ year, month }) => {
+        const siteReports = await SiteReport.findAll({
+          where: {
+            id: { [Op.in]: approvedSiteReportsQuery },
+            [Op.and]: [literal(`YEAR(due_at) = ${year}`), literal(`MONTH(due_at) = ${month}`)]
+          },
+          include: [
+            {
+              model: TreeSpecies,
+              as: "treesPlanted",
+              required: false,
+              where: {
+                hidden: false,
+                collection: "tree-planted"
+              }
+            }
+          ]
+        });
+
+        const treeSpeciesAmount = siteReports.reduce((sum, report) => {
+          return sum + (report.treesPlanted?.reduce((reportSum, tree) => reportSum + (tree.amount ?? 0), 0) ?? 0);
+        }, 0);
+
+        const formattedDate = new Date(year, month - 1, 1);
+        const percentage =
+          totalTreesGrownGoal > 0 ? Number(((treeSpeciesAmount / totalTreesGrownGoal) * 100).toFixed(3)) : 0;
+
+        return {
+          dueDate: formattedDate,
+          treeSpeciesAmount,
+          treeSpeciesPercentage: percentage
+        };
+      })
+    );
+
+    return results;
   }
 }

--- a/apps/dashboard-service/src/dashboard/dto/tree-restoration-goal.service.ts
+++ b/apps/dashboard-service/src/dashboard/dto/tree-restoration-goal.service.ts
@@ -94,7 +94,7 @@ export class TreeRestorationGoalService {
       raw: true
     })) as unknown as DateResult[];
 
-    return siteReports.map(report => ({
+    return (siteReports ?? []).map(report => ({
       year: report.year,
       month: report.month
     }));
@@ -141,7 +141,7 @@ export class TreeRestorationGoalService {
       }
     });
 
-    const results = distinctDates.map(({ year, month }) => {
+    return distinctDates.map(({ year, month }) => {
       const key = `${year}-${month}`;
       const siteReportsForDate = siteReportsByDate.get(key) ?? [];
 
@@ -159,7 +159,5 @@ export class TreeRestorationGoalService {
         treeSpeciesPercentage: percentage
       };
     });
-
-    return results;
   }
 }

--- a/apps/dashboard-service/src/dashboard/tree-restoration-goal.controller.spec.ts
+++ b/apps/dashboard-service/src/dashboard/tree-restoration-goal.controller.spec.ts
@@ -1,0 +1,354 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { TreeRestorationGoalController } from "./tree-restoration-goal.controller";
+import { TreeRestorationGoalService } from "./dto/tree-restoration-goal.service";
+import { CacheService } from "./dto/cache.service";
+import { DashboardQueryDto } from "./dto/dashboard-query.dto";
+
+describe("TreeRestorationGoalController", () => {
+  let controller: TreeRestorationGoalController;
+  let treeRestorationGoalService: jest.Mocked<TreeRestorationGoalService>;
+  let cacheService: jest.Mocked<CacheService>;
+
+  const mockServiceResponse = {
+    forProfitTreeCount: 1961902,
+    nonProfitTreeCount: 23027107,
+    totalTreesGrownGoal: 40532875,
+    treesUnderRestorationActualTotal: [
+      {
+        dueDate: new Date("2022-09-01T04:00:00.000Z"),
+        treeSpeciesAmount: 3859827,
+        treeSpeciesPercentage: 9.523
+      },
+      {
+        dueDate: new Date("2023-01-01T04:00:00.000Z"),
+        treeSpeciesAmount: 2849029,
+        treeSpeciesPercentage: 7.029
+      }
+    ],
+    treesUnderRestorationActualForProfit: [
+      {
+        dueDate: new Date("2022-09-01T04:00:00.000Z"),
+        treeSpeciesAmount: 557880,
+        treeSpeciesPercentage: 1.376
+      }
+    ],
+    treesUnderRestorationActualNonProfit: [
+      {
+        dueDate: new Date("2022-09-01T04:00:00.000Z"),
+        treeSpeciesAmount: 3301947,
+        treeSpeciesPercentage: 8.146
+      }
+    ]
+  };
+
+  const mockCachedData = {
+    forProfitTreeCount: 1500000,
+    nonProfitTreeCount: 20000000,
+    totalTreesGrownGoal: 35000000,
+    treesUnderRestorationActualTotal: [
+      {
+        dueDate: new Date("2023-01-01T04:00:00.000Z"),
+        treeSpeciesAmount: 2500000,
+        treeSpeciesPercentage: 7.143
+      }
+    ],
+    treesUnderRestorationActualForProfit: [
+      {
+        dueDate: new Date("2023-01-01T04:00:00.000Z"),
+        treeSpeciesAmount: 500000,
+        treeSpeciesPercentage: 1.429
+      }
+    ],
+    treesUnderRestorationActualNonProfit: [
+      {
+        dueDate: new Date("2023-01-01T04:00:00.000Z"),
+        treeSpeciesAmount: 2000000,
+        treeSpeciesPercentage: 5.714
+      }
+    ]
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TreeRestorationGoalController],
+      providers: [
+        {
+          provide: TreeRestorationGoalService,
+          useValue: {
+            getTreeRestorationGoal: jest.fn()
+          }
+        },
+        {
+          provide: CacheService,
+          useValue: {
+            getCacheKeyFromQuery: jest.fn(),
+            get: jest.fn(),
+            set: jest.fn()
+          }
+        }
+      ]
+    }).compile();
+
+    controller = module.get<TreeRestorationGoalController>(TreeRestorationGoalController);
+    treeRestorationGoalService = module.get(TreeRestorationGoalService);
+    cacheService = module.get(CacheService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("getTreeRestorationGoal", () => {
+    it("should return service result when cache is empty", async () => {
+      const query: DashboardQueryDto = {
+        country: "BEN",
+        programmes: ["terrafund"]
+      };
+
+      cacheService.getCacheKeyFromQuery.mockReturnValue("test-cache-key");
+      cacheService.get.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+      treeRestorationGoalService.getTreeRestorationGoal.mockResolvedValue(mockServiceResponse);
+      cacheService.set.mockResolvedValue(undefined);
+
+      const result = await controller.getTreeRestorationGoal(query);
+
+      expect(cacheService.getCacheKeyFromQuery).toHaveBeenCalledWith(query);
+      expect(cacheService.get).toHaveBeenCalledWith("dashboard:tree-restoration-goal|test-cache-key:timestamp");
+      expect(cacheService.get).toHaveBeenCalledWith("dashboard:tree-restoration-goal|test-cache-key");
+      expect(treeRestorationGoalService.getTreeRestorationGoal).toHaveBeenCalledWith(query);
+      expect(cacheService.set).toHaveBeenCalledTimes(2);
+      expect(result).toEqual(mockServiceResponse);
+    });
+
+    it("should return cached data when cache exists", async () => {
+      const query: DashboardQueryDto = {
+        organisationType: ["non-profit-organization"]
+      };
+
+      const lastUpdatedAt = "2024-01-01T00:00:00.000Z";
+
+      cacheService.getCacheKeyFromQuery.mockReturnValue("cached-key");
+      cacheService.get.mockResolvedValueOnce(lastUpdatedAt).mockResolvedValueOnce(mockCachedData);
+
+      const result = await controller.getTreeRestorationGoal(query);
+
+      expect(cacheService.getCacheKeyFromQuery).toHaveBeenCalledWith(query);
+      expect(cacheService.get).toHaveBeenCalledWith("dashboard:tree-restoration-goal|cached-key:timestamp");
+      expect(cacheService.get).toHaveBeenCalledWith("dashboard:tree-restoration-goal|cached-key");
+      expect(treeRestorationGoalService.getTreeRestorationGoal).not.toHaveBeenCalled();
+
+      expect(result).toBeDefined();
+      if (result !== undefined && !Array.isArray(result) && "data" in result) {
+        const jsonApiResult = result as unknown as {
+          data: {
+            attributes: {
+              lastUpdatedAt: string | null;
+              forProfitTreeCount: number;
+              nonProfitTreeCount: number;
+            };
+          };
+        };
+        expect(jsonApiResult.data.attributes.lastUpdatedAt).toBe(lastUpdatedAt);
+        expect(jsonApiResult.data.attributes.forProfitTreeCount).toBe(mockCachedData.forProfitTreeCount);
+        expect(jsonApiResult.data.attributes.nonProfitTreeCount).toBe(mockCachedData.nonProfitTreeCount);
+      } else {
+        fail("Expected JSON API response structure with data property");
+      }
+    });
+
+    it("should handle empty query object", async () => {
+      const query: DashboardQueryDto = {};
+
+      cacheService.getCacheKeyFromQuery.mockReturnValue("empty-query-key");
+      cacheService.get.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+      treeRestorationGoalService.getTreeRestorationGoal.mockResolvedValue(mockServiceResponse);
+
+      const result = await controller.getTreeRestorationGoal(query);
+
+      expect(treeRestorationGoalService.getTreeRestorationGoal).toHaveBeenCalledWith(query);
+      expect(result).toEqual(mockServiceResponse);
+    });
+
+    it("should handle query with all possible filters", async () => {
+      const query: DashboardQueryDto = {
+        organisationType: ["for-profit-organization", "non-profit-organization"],
+        country: "CMR",
+        programmes: ["terrafund", "ppc"],
+        projectUuid: "uuid-123",
+        landscapes: ["landscape1", "landscape2"],
+        cohort: "cohort-2024"
+      };
+
+      cacheService.getCacheKeyFromQuery.mockReturnValue("full-query-key");
+      cacheService.get.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+      treeRestorationGoalService.getTreeRestorationGoal.mockResolvedValue(mockServiceResponse);
+
+      const result = await controller.getTreeRestorationGoal(query);
+
+      expect(treeRestorationGoalService.getTreeRestorationGoal).toHaveBeenCalledWith(query);
+      expect(result).toEqual(mockServiceResponse);
+    });
+
+    it("should handle cached data with null timestamp", async () => {
+      const query: DashboardQueryDto = { country: "KEN" };
+
+      cacheService.getCacheKeyFromQuery.mockReturnValue("null-timestamp-key");
+      cacheService.get.mockResolvedValueOnce(null).mockResolvedValueOnce(mockCachedData);
+
+      const result = await controller.getTreeRestorationGoal(query);
+
+      expect(result).toBeDefined();
+      if (result !== undefined && !Array.isArray(result) && "data" in result) {
+        const jsonApiResult = result as unknown as {
+          data: {
+            attributes: {
+              lastUpdatedAt: string | null;
+              forProfitTreeCount: number;
+            };
+          };
+        };
+        expect(jsonApiResult.data.attributes.lastUpdatedAt).toBeNull();
+        expect(jsonApiResult.data.attributes.forProfitTreeCount).toBe(mockCachedData.forProfitTreeCount);
+      } else {
+        fail("Expected JSON API response structure with data property");
+      }
+    });
+
+    it("should preserve Date objects in cached response", async () => {
+      const query: DashboardQueryDto = { programmes: ["ppc"] };
+
+      cacheService.getCacheKeyFromQuery.mockReturnValue("date-preservation-key");
+      cacheService.get.mockResolvedValueOnce("2024-06-01T00:00:00.000Z").mockResolvedValueOnce(mockCachedData);
+
+      const result = await controller.getTreeRestorationGoal(query);
+
+      expect(result).toBeDefined();
+      if (result !== undefined && !Array.isArray(result) && "data" in result) {
+        const jsonApiResult = result as unknown as {
+          data: {
+            attributes: {
+              treesUnderRestorationActualTotal: Array<{
+                dueDate: Date;
+                treeSpeciesAmount: number;
+                treeSpeciesPercentage: number;
+              }>;
+            };
+          };
+        };
+        expect(jsonApiResult.data.attributes.treesUnderRestorationActualTotal).toHaveLength(1);
+        expect(jsonApiResult.data.attributes.treesUnderRestorationActualTotal[0].dueDate).toBeInstanceOf(Date);
+        expect(jsonApiResult.data.attributes.treesUnderRestorationActualTotal[0].dueDate.getTime()).not.toBeNaN();
+      } else {
+        fail("Expected JSON API response structure with data property");
+      }
+    });
+
+    it("should cache service result with proper timestamp", async () => {
+      const query: DashboardQueryDto = { landscapes: ["test-landscape"] };
+      const mockDate = new Date("2024-12-01T12:00:00.000Z");
+      jest.spyOn(global, "Date").mockImplementation(() => mockDate);
+
+      cacheService.getCacheKeyFromQuery.mockReturnValue("timestamp-test-key");
+      cacheService.get.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+      treeRestorationGoalService.getTreeRestorationGoal.mockResolvedValue(mockServiceResponse);
+
+      await controller.getTreeRestorationGoal(query);
+
+      expect(cacheService.set).toHaveBeenCalledWith(
+        "dashboard:tree-restoration-goal|timestamp-test-key",
+        JSON.stringify(mockServiceResponse)
+      );
+      expect(cacheService.set).toHaveBeenCalledWith(
+        "dashboard:tree-restoration-goal|timestamp-test-key:timestamp",
+        mockDate.toISOString()
+      );
+
+      jest.restoreAllMocks();
+    });
+
+    it("should handle empty arrays in restoration data when no cache", async () => {
+      const query: DashboardQueryDto = { cohort: "empty-cohort" };
+      const emptyServiceResponse = {
+        ...mockServiceResponse,
+        treesUnderRestorationActualTotal: [],
+        treesUnderRestorationActualForProfit: [],
+        treesUnderRestorationActualNonProfit: []
+      };
+
+      cacheService.getCacheKeyFromQuery.mockReturnValue("empty-arrays-key");
+      cacheService.get.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+      treeRestorationGoalService.getTreeRestorationGoal.mockResolvedValue(emptyServiceResponse);
+
+      const result = await controller.getTreeRestorationGoal(query);
+
+      expect(result).toEqual(emptyServiceResponse);
+      expect((result as typeof emptyServiceResponse).treesUnderRestorationActualTotal).toEqual([]);
+      expect((result as typeof emptyServiceResponse).treesUnderRestorationActualForProfit).toEqual([]);
+      expect((result as typeof emptyServiceResponse).treesUnderRestorationActualNonProfit).toEqual([]);
+    });
+
+    it("should handle zero values correctly when no cache", async () => {
+      const query: DashboardQueryDto = { projectUuid: "zero-project" };
+      const zeroServiceResponse = {
+        forProfitTreeCount: 0,
+        nonProfitTreeCount: 0,
+        totalTreesGrownGoal: 0,
+        treesUnderRestorationActualTotal: [
+          {
+            dueDate: new Date("2024-01-01T00:00:00.000Z"),
+            treeSpeciesAmount: 0,
+            treeSpeciesPercentage: 0
+          }
+        ],
+        treesUnderRestorationActualForProfit: [],
+        treesUnderRestorationActualNonProfit: []
+      };
+
+      cacheService.getCacheKeyFromQuery.mockReturnValue("zero-values-key");
+      cacheService.get.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+      treeRestorationGoalService.getTreeRestorationGoal.mockResolvedValue(zeroServiceResponse);
+
+      const result = await controller.getTreeRestorationGoal(query);
+
+      expect(result).toEqual(zeroServiceResponse);
+      expect((result as typeof zeroServiceResponse).forProfitTreeCount).toBe(0);
+      expect((result as typeof zeroServiceResponse).nonProfitTreeCount).toBe(0);
+      expect((result as typeof zeroServiceResponse).totalTreesGrownGoal).toBe(0);
+      expect((result as typeof zeroServiceResponse).treesUnderRestorationActualTotal[0].treeSpeciesAmount).toBe(0);
+      expect((result as typeof zeroServiceResponse).treesUnderRestorationActualTotal[0].treeSpeciesPercentage).toBe(0);
+    });
+
+    it("should handle cached data with empty arrays", async () => {
+      const query: DashboardQueryDto = { cohort: "empty-cached-cohort" };
+      const emptyCachedData = {
+        ...mockCachedData,
+        treesUnderRestorationActualTotal: [],
+        treesUnderRestorationActualForProfit: [],
+        treesUnderRestorationActualNonProfit: []
+      };
+
+      cacheService.getCacheKeyFromQuery.mockReturnValue("empty-cached-arrays-key");
+      cacheService.get.mockResolvedValueOnce("2024-01-01T00:00:00.000Z").mockResolvedValueOnce(emptyCachedData);
+
+      const result = await controller.getTreeRestorationGoal(query);
+
+      expect(result).toBeDefined();
+      if (result !== undefined && !Array.isArray(result) && "data" in result) {
+        const jsonApiResult = result as unknown as {
+          data: {
+            attributes: {
+              treesUnderRestorationActualTotal: unknown[];
+              treesUnderRestorationActualForProfit: unknown[];
+              treesUnderRestorationActualNonProfit: unknown[];
+            };
+          };
+        };
+        expect(jsonApiResult.data.attributes.treesUnderRestorationActualTotal).toEqual([]);
+        expect(jsonApiResult.data.attributes.treesUnderRestorationActualForProfit).toEqual([]);
+        expect(jsonApiResult.data.attributes.treesUnderRestorationActualNonProfit).toEqual([]);
+      } else {
+        fail("Expected JSON API response structure with data property");
+      }
+    });
+  });
+});

--- a/apps/dashboard-service/src/dashboard/tree-restoration-goal.controller.ts
+++ b/apps/dashboard-service/src/dashboard/tree-restoration-goal.controller.ts
@@ -4,16 +4,44 @@ import { DashboardQueryDto } from "./dto/dashboard-query.dto";
 import { JsonApiResponse } from "@terramatch-microservices/common/decorators";
 import { TreeRestorationGoalDto } from "./dto/tree-restoration-goal.dto";
 import { TreeRestorationGoalService } from "./dto/tree-restoration-goal.service";
+import { CacheService } from "./dto/cache.service";
+import { buildJsonApi, getStableRequestQuery } from "@terramatch-microservices/common/util/json-api-builder";
 
 @Controller("dashboard/v3/treeRestorationGoal")
 export class TreeRestorationGoalController {
-  constructor(private readonly treeRestorationGoalService: TreeRestorationGoalService) {}
+  constructor(
+    private readonly treeRestorationGoalService: TreeRestorationGoalService,
+    private readonly cacheService: CacheService
+  ) {}
 
   @Get()
   @JsonApiResponse([TreeRestorationGoalDto])
   @ApiOperation({ operationId: "getTreeRestorationGoal", summary: "Get tree restoration goal statistics" })
   async getTreeRestorationGoal(@Query() query: DashboardQueryDto) {
-    const result = await this.treeRestorationGoalService.getTreeRestorationGoal(query);
-    return result;
+    const cacheKey = `dashboard:tree-restoration-goal|${this.cacheService.getCacheKeyFromQuery(query)}`;
+    const timestampKey = `${cacheKey}:timestamp`;
+    const lastUpdatedAt = await this.cacheService.get(timestampKey);
+    const cachedData = await this.cacheService.get(cacheKey);
+
+    if (cachedData == null) {
+      const result = await this.treeRestorationGoalService.getTreeRestorationGoal(query);
+      const timestamp = new Date().toISOString();
+      await this.cacheService.set(cacheKey, JSON.stringify(result));
+      await this.cacheService.set(timestampKey, timestamp);
+      return result;
+    }
+
+    const document = buildJsonApi(TreeRestorationGoalDto);
+    const stableQuery = getStableRequestQuery(query);
+
+    document.addData(
+      stableQuery,
+      new TreeRestorationGoalDto({
+        ...cachedData,
+        lastUpdatedAt
+      })
+    );
+
+    return document.serialize();
   }
 }

--- a/apps/dashboard-service/src/dashboard/tree-restoration-goal.controller.ts
+++ b/apps/dashboard-service/src/dashboard/tree-restoration-goal.controller.ts
@@ -1,0 +1,19 @@
+import { Get, Query, Controller } from "@nestjs/common";
+import { ApiOperation } from "@nestjs/swagger";
+import { DashboardQueryDto } from "./dto/dashboard-query.dto";
+import { JsonApiResponse } from "@terramatch-microservices/common/decorators";
+import { TreeRestorationGoalDto } from "./dto/tree-restoration-goal.dto";
+import { TreeRestorationGoalService } from "./dto/tree-restoration-goal.service";
+
+@Controller("dashboard/v3/treeRestorationGoal")
+export class TreeRestorationGoalController {
+  constructor(private readonly treeRestorationGoalService: TreeRestorationGoalService) {}
+
+  @Get()
+  @JsonApiResponse([TreeRestorationGoalDto])
+  @ApiOperation({ operationId: "getTreeRestorationGoal", summary: "Get tree restoration goal statistics" })
+  async getTreeRestorationGoal(@Query() query: DashboardQueryDto) {
+    const result = await this.treeRestorationGoalService.getTreeRestorationGoal(query);
+    return result;
+  }
+}


### PR DESCRIPTION
This gets the data for tree restoration goals. 
Here there is no need for delayedjob instance because the largest query now takes up to 3 secs. 
So it only has a cache.