### PR TITLE
[TM-2412] Linked fields in v3

### DIFF
--- a/apps/dashboard-service/src/dashboard/dashboard-entities.controller.spec.ts
+++ b/apps/dashboard-service/src/dashboard/dashboard-entities.controller.spec.ts
@@ -7,7 +7,7 @@ import { DashboardSitePolygonsProcessor } from "./processors/dashboard-sitepolyg
 import { CacheService } from "./dto/cache.service";
 import { DashboardEntityParamsDto, DashboardEntityWithUuidDto } from "./dto/dashboard-entity.dto";
 import { DashboardQueryDto } from "./dto/dashboard-query.dto";
-import { DashboardProjectsLightDto, DashboardProjectsFullDto } from "./dto/dashboard-projects.dto";
+import { DashboardProjectsFullDto, DashboardProjectsLightDto } from "./dto/dashboard-projects.dto";
 import { DashboardSitePolygonsLightDto } from "./dto/dashboard-sitepolygons.dto";
 import { Project, SitePolygon } from "@terramatch-microservices/database/entities";
 import { PolicyService } from "@terramatch-microservices/common";
@@ -37,7 +37,7 @@ jest.mock("./dashboard-query.builder");
 jest.mock("@terramatch-microservices/common/util/json-api-builder", () => ({
   buildJsonApi: jest.fn().mockImplementation(() => ({
     addData: jest.fn().mockReturnThis(),
-    addIndexData: jest.fn().mockReturnThis(),
+    addIndex: jest.fn().mockReturnThis(),
     serialize: jest.fn().mockReturnValue({
       data: [],
       included: [],
@@ -69,6 +69,13 @@ describe("DashboardEntitiesController", () => {
   let app: INestApplication;
   let jwtService: DeepMocked<JwtService>;
   let mockQueryBuilder: jest.Mocked<DashboardProjectsQueryBuilder>;
+
+  const mockCacheServiceGet = () => {
+    // Fix the cache mock to return the correct structure
+    cacheService.get.mockImplementation(async (cacheKey, factory) =>
+      factory == null ? { data: [], total: 0 } : await factory()
+    );
+  };
 
   beforeEach(async () => {
     // Setup mock query builder
@@ -192,14 +199,7 @@ describe("DashboardEntitiesController", () => {
       }
     ];
 
-    // Fix the cache mock to return the correct structure
-    cacheService.get.mockImplementation(async (cacheKey, factory) => {
-      if (factory !== undefined && factory !== null) {
-        const result = await factory();
-        return result;
-      }
-      return { data: [], total: 0 };
-    });
+    mockCacheServiceGet();
 
     // Mock the processor methods since we're using a real processor instance
     jest.spyOn(mockProcessor, "findMany").mockResolvedValue(mockModels);
@@ -353,13 +353,7 @@ describe("DashboardEntitiesController", () => {
       }
     ] as Project[];
 
-    cacheService.get.mockImplementation(async (cacheKey, factory) => {
-      if (factory !== undefined && factory !== null) {
-        const result = await factory();
-        return result;
-      }
-      return { data: [], total: 0 };
-    });
+    mockCacheServiceGet();
 
     jest.spyOn(mockProcessor, "findMany").mockResolvedValue(mockModels);
     jest.spyOn(mockProcessor, "getLightDto").mockResolvedValue({
@@ -408,13 +402,7 @@ describe("DashboardEntitiesController", () => {
   it("should handle impact stories entity", async () => {
     const params: DashboardEntityParamsDto = { entity: DASHBOARD_IMPACT_STORIES };
     const query: DashboardQueryDto = { country: "KEN" };
-    cacheService.get.mockImplementation(async (cacheKey, factory) => {
-      if (factory !== undefined && factory !== null) {
-        const result = await factory();
-        return result;
-      }
-      return { data: [], total: 0 };
-    });
+    mockCacheServiceGet();
 
     const result = await controller.findAll(params.entity, query);
 
@@ -494,13 +482,7 @@ describe("DashboardEntitiesController", () => {
     ] as unknown as ImpactStory[];
 
     dashboardImpactStoryService.getDashboardImpactStories.mockResolvedValue(mockImpactStories);
-    cacheService.get.mockImplementation(async (cacheKey, factory) => {
-      if (factory !== undefined && factory !== null) {
-        const result = await factory();
-        return result;
-      }
-      return { data: [], total: 0 };
-    });
+    mockCacheServiceGet();
 
     const result = await controller.findAll(params.entity, query);
 
@@ -528,13 +510,7 @@ describe("DashboardEntitiesController", () => {
 
     dashboardImpactStoryService.getDashboardImpactStories.mockResolvedValue(mockImpactStories);
     jest.spyOn(Media, "findAll").mockResolvedValue([]);
-    cacheService.get.mockImplementation(async (cacheKey, factory) => {
-      if (factory !== undefined && factory !== null) {
-        const result = await factory();
-        return result;
-      }
-      return { data: [], total: 0 };
-    });
+    mockCacheServiceGet();
 
     const result = await controller.findAll(params.entity, query);
 
@@ -567,13 +543,7 @@ describe("DashboardEntitiesController", () => {
     const mockMedia = [{ id: 1, modelId: 1 }] as Media[];
     jest.spyOn(Media, "findAll").mockResolvedValue(mockMedia);
     mediaService.getUrl.mockReturnValue("http://example.com/thumb.jpg");
-    cacheService.get.mockImplementation(async (cacheKey, factory) => {
-      if (factory !== undefined && factory !== null) {
-        const result = await factory();
-        return result;
-      }
-      return { data: [], total: 0 };
-    });
+    mockCacheServiceGet();
 
     const result = await controller.findAll(params.entity, query);
 
@@ -598,13 +568,7 @@ describe("DashboardEntitiesController", () => {
 
     dashboardImpactStoryService.getDashboardImpactStories.mockResolvedValue(mockImpactStories);
     jest.spyOn(Media, "findAll").mockResolvedValue([]);
-    cacheService.get.mockImplementation(async (cacheKey, factory) => {
-      if (factory !== undefined && factory !== null) {
-        const result = await factory();
-        return result;
-      }
-      return { data: [], total: 0 };
-    });
+    mockCacheServiceGet();
 
     const result = await controller.findAll(params.entity, query);
 
@@ -632,13 +596,7 @@ describe("DashboardEntitiesController", () => {
 
     dashboardImpactStoryService.getDashboardImpactStories.mockResolvedValue(mockImpactStories);
     jest.spyOn(Media, "findAll").mockResolvedValue([]);
-    cacheService.get.mockImplementation(async (cacheKey, factory) => {
-      if (factory !== undefined && factory !== null) {
-        const result = await factory();
-        return result;
-      }
-      return { data: [], total: 0 };
-    });
+    mockCacheServiceGet();
 
     const result = await controller.findAll(params.entity, query);
 
@@ -675,13 +633,7 @@ describe("DashboardEntitiesController", () => {
 
     dashboardImpactStoryService.getDashboardImpactStories.mockResolvedValue(mockImpactStories);
     jest.spyOn(Media, "findAll").mockResolvedValue([]);
-    cacheService.get.mockImplementation(async (cacheKey, factory) => {
-      if (factory !== undefined && factory !== null) {
-        const result = await factory();
-        return result;
-      }
-      return { data: [], total: 0 };
-    });
+    mockCacheServiceGet();
 
     const result = await controller.findAll(params.entity, query);
 
@@ -772,14 +724,7 @@ describe("DashboardEntitiesController", () => {
     );
     mockProcessor.findMany.mockResolvedValue([mockSitePolygon]);
     mockProcessor.getLightDto.mockResolvedValue(mockDtoResult);
-
-    cacheService.get.mockImplementation(async (cacheKey, factory) => {
-      if (factory !== undefined && factory !== null) {
-        const result = await factory();
-        return result;
-      }
-      return { data: [], total: 0 };
-    });
+    mockCacheServiceGet();
 
     const result = await controller.findAll(params.entity, query);
 

--- a/apps/dashboard-service/src/dashboard/dashboard-entities.controller.spec.ts
+++ b/apps/dashboard-service/src/dashboard/dashboard-entities.controller.spec.ts
@@ -26,27 +26,13 @@ import {
 } from "./constants/dashboard-entities.constants";
 import { ImpactStory } from "@terramatch-microservices/database/entities/impact-story.entity";
 import { Media } from "@terramatch-microservices/database/entities/media.entity";
+import { serialize } from "@terramatch-microservices/common/util/testing";
 
 jest.mock("@nestjs/jwt");
 const MockJwtService = JwtService as jest.MockedClass<typeof JwtService>;
 
 // Mock the dashboard-query.builder module
 jest.mock("./dashboard-query.builder");
-
-// Mock the json-api-builder module
-jest.mock("@terramatch-microservices/common/util/json-api-builder", () => ({
-  buildJsonApi: jest.fn().mockImplementation(() => ({
-    addData: jest.fn().mockReturnThis(),
-    addIndex: jest.fn().mockReturnThis(),
-    serialize: jest.fn().mockReturnValue({
-      data: [],
-      included: [],
-      meta: { resourceType: "dashboardProjects" }
-    })
-  })),
-  getStableRequestQuery: jest.fn().mockImplementation(query => query),
-  getDtoType: jest.fn().mockReturnValue("dashboardProjects")
-}));
 
 jest.mock("@terramatch-microservices/database/entities", () => ({
   ...jest.requireActual("@terramatch-microservices/database/entities"),
@@ -214,18 +200,14 @@ describe("DashboardEntitiesController", () => {
       };
     });
 
-    const result = await controller.findAll(params.entity, query);
+    const result = serialize(await controller.findAll(params.entity, query));
 
     expect(result).toBeDefined();
     expect(result.data).toBeDefined();
-    expect(result.included).toBeDefined();
     expect(result.meta).toBeDefined();
 
     expect(Array.isArray(result.data)).toBe(true);
-    expect(result.data).toHaveLength(0);
-
-    expect(Array.isArray(result.included)).toBe(true);
-    expect(result.included).toHaveLength(0);
+    expect(result.data).toHaveLength(2);
 
     expect(cacheService.getCacheKeyFromQuery).toHaveBeenCalledWith(query);
     expect(cacheService.get).toHaveBeenCalledWith(`dashboard:${params.entity}|test-cache-key`, expect.any(Function));
@@ -266,11 +248,10 @@ describe("DashboardEntitiesController", () => {
     const getFullDtoSpy = jest.spyOn(mockProcessor, "getFullDto").mockResolvedValue(mockDtoResult);
     const getLightDtoSpy = jest.spyOn(mockProcessor, "getLightDto");
 
-    const result = await controller.findOne(params.entity, params.uuid);
+    const result = serialize(await controller.findOne(params.entity, params.uuid));
 
     expect(result).toBeDefined();
     expect(result.data).toBeDefined();
-    expect(result.included).toBeDefined();
     expect(result.meta).toBeDefined();
 
     expect(findOneSpy).toHaveBeenCalledWith(params.uuid);
@@ -310,11 +291,10 @@ describe("DashboardEntitiesController", () => {
     const getFullDtoSpy = jest.spyOn(mockProcessor, "getFullDto").mockResolvedValue(mockFullDtoResult);
     const getLightDtoSpy = jest.spyOn(mockProcessor, "getLightDto");
 
-    const result = await controller.findOne(params.entity, params.uuid);
+    const result = serialize(await controller.findOne(params.entity, params.uuid));
 
     expect(result).toBeDefined();
     expect(result.data).toBeDefined();
-    expect(result.included).toBeDefined();
     expect(result.meta).toBeDefined();
 
     expect(findOneSpy).toHaveBeenCalledWith(params.uuid);
@@ -367,7 +347,7 @@ describe("DashboardEntitiesController", () => {
       })
     });
 
-    const result = await controller.findAll(params.entity, query);
+    const result = serialize(await controller.findAll(params.entity, query));
 
     expect(cacheService.get).toHaveBeenCalledWith(`dashboard:${params.entity}|test-cache-key`, expect.any(Function));
     expect(dashboardEntitiesService.createDashboardProcessor).toHaveBeenCalledWith(params.entity);
@@ -404,11 +384,10 @@ describe("DashboardEntitiesController", () => {
     const query: DashboardQueryDto = { country: "KEN" };
     mockCacheServiceGet();
 
-    const result = await controller.findAll(params.entity, query);
+    const result = serialize(await controller.findAll(params.entity, query));
 
     expect(result).toBeDefined();
     expect(result.data).toBeDefined();
-    expect(result.included).toBeDefined();
     expect(result.meta).toBeDefined();
 
     expect(dashboardImpactStoryService.getDashboardImpactStories).toHaveBeenCalledWith({
@@ -454,7 +433,7 @@ describe("DashboardEntitiesController", () => {
     jest.spyOn(Media, "findAll").mockResolvedValue([]);
     mediaService.getUrl.mockReturnValue("");
 
-    const result = await controller.findOne(params.entity, params.uuid);
+    const result = serialize(await controller.findOne(params.entity, params.uuid));
     expect(result).toBeDefined();
   });
 
@@ -484,7 +463,7 @@ describe("DashboardEntitiesController", () => {
     dashboardImpactStoryService.getDashboardImpactStories.mockResolvedValue(mockImpactStories);
     mockCacheServiceGet();
 
-    const result = await controller.findAll(params.entity, query);
+    const result = serialize(await controller.findAll(params.entity, query));
 
     expect(result).toBeDefined();
     expect(dashboardImpactStoryService.getDashboardImpactStories).toHaveBeenCalledWith({
@@ -512,7 +491,7 @@ describe("DashboardEntitiesController", () => {
     jest.spyOn(Media, "findAll").mockResolvedValue([]);
     mockCacheServiceGet();
 
-    const result = await controller.findAll(params.entity, query);
+    const result = serialize(await controller.findAll(params.entity, query));
 
     expect(result).toBeDefined();
     expect(Media.findAll).toHaveBeenCalledWith({
@@ -545,7 +524,7 @@ describe("DashboardEntitiesController", () => {
     mediaService.getUrl.mockReturnValue("http://example.com/thumb.jpg");
     mockCacheServiceGet();
 
-    const result = await controller.findAll(params.entity, query);
+    const result = serialize(await controller.findAll(params.entity, query));
 
     expect(result).toBeDefined();
     expect(mediaService.getUrl).toHaveBeenCalledWith(mockMedia[0]);
@@ -570,7 +549,7 @@ describe("DashboardEntitiesController", () => {
     jest.spyOn(Media, "findAll").mockResolvedValue([]);
     mockCacheServiceGet();
 
-    const result = await controller.findAll(params.entity, query);
+    const result = serialize(await controller.findAll(params.entity, query));
 
     expect(result).toBeDefined();
     expect(dashboardImpactStoryService.getDashboardImpactStories).toHaveBeenCalledWith({
@@ -598,7 +577,7 @@ describe("DashboardEntitiesController", () => {
     jest.spyOn(Media, "findAll").mockResolvedValue([]);
     mockCacheServiceGet();
 
-    const result = await controller.findAll(params.entity, query);
+    const result = serialize(await controller.findAll(params.entity, query));
 
     expect(result).toBeDefined();
     expect(dashboardImpactStoryService.getDashboardImpactStories).toHaveBeenCalledWith({
@@ -635,7 +614,7 @@ describe("DashboardEntitiesController", () => {
     jest.spyOn(Media, "findAll").mockResolvedValue([]);
     mockCacheServiceGet();
 
-    const result = await controller.findAll(params.entity, query);
+    const result = serialize(await controller.findAll(params.entity, query));
 
     expect(result).toBeDefined();
     expect(result.data).toBeDefined();
@@ -674,7 +653,7 @@ describe("DashboardEntitiesController", () => {
       mockProcessor as unknown as ReturnType<typeof dashboardEntitiesService.createDashboardProcessor>
     );
 
-    const result = await controller.findOne(params.entity, params.uuid);
+    const result = serialize(await controller.findOne(params.entity, params.uuid));
 
     expect(result).toBeDefined();
     expect(mockProcessor.findOne).toHaveBeenCalledWith(params.uuid);
@@ -701,7 +680,7 @@ describe("DashboardEntitiesController", () => {
       mockProcessor as unknown as ReturnType<typeof dashboardEntitiesService.createDashboardProcessor>
     );
 
-    const result = await controller.findOne(params.entity, params.uuid);
+    const result = serialize(await controller.findOne(params.entity, params.uuid));
 
     expect(result).toBeDefined();
     expect(mockProcessor.findOne).toHaveBeenCalledWith(params.uuid);
@@ -714,6 +693,8 @@ describe("DashboardEntitiesController", () => {
     const query: DashboardQueryDto = {};
     const mockSitePolygon = { uuid: "site-uuid-1", name: "Test Site" } as unknown as SitePolygon;
     const mockProcessor = createMock<DashboardSitePolygonsProcessor>();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockProcessor as any).LIGHT_DTO = DashboardSitePolygonsLightDto;
     const mockDtoResult = {
       id: "site-uuid-1",
       dto: new DashboardSitePolygonsLightDto(mockSitePolygon)
@@ -726,7 +707,7 @@ describe("DashboardEntitiesController", () => {
     mockProcessor.getLightDto.mockResolvedValue(mockDtoResult);
     mockCacheServiceGet();
 
-    const result = await controller.findAll(params.entity, query);
+    const result = serialize(await controller.findAll(params.entity, query));
 
     expect(result).toBeDefined();
     expect(dashboardEntitiesService.createDashboardProcessor).toHaveBeenCalledWith(params.entity);
@@ -750,7 +731,7 @@ describe("DashboardEntitiesController", () => {
     mockProcessor.findOne.mockResolvedValue(mockSitePolygon);
     mockProcessor.getLightDto.mockResolvedValue(mockDto);
 
-    const result = await controller.findOne(params.entity, params.uuid);
+    const result = serialize(await controller.findOne(params.entity, params.uuid));
 
     expect(result).toBeDefined();
     expect(mockProcessor.findOne).toHaveBeenCalledWith(params.uuid);

--- a/apps/dashboard-service/src/dashboard/dashboard-entities.controller.ts
+++ b/apps/dashboard-service/src/dashboard/dashboard-entities.controller.ts
@@ -102,13 +102,11 @@ export class DashboardEntitiesController {
 
         document.addData(dto.uuid, dto);
       }
-      return document
-        .addIndex({
-          requestPath: `/dashboard/v3/${entity}${getStableRequestQuery(query)}`,
-          total,
-          pageNumber: 1
-        })
-        .serialize();
+      return document.addIndex({
+        requestPath: `/dashboard/v3/${entity}${getStableRequestQuery(query)}`,
+        total,
+        pageNumber: 1
+      });
     }
 
     if (entity === DASHBOARD_PROJECTS) {
@@ -151,13 +149,11 @@ export class DashboardEntitiesController {
             : new DtoClass(model);
         document.addData(id, dto);
       }
-      return document
-        .addIndex({
-          requestPath: `/dashboard/v3/${entity}${getStableRequestQuery(query)}`,
-          total,
-          pageNumber: 1
-        })
-        .serialize();
+      return document.addIndex({
+        requestPath: `/dashboard/v3/${entity}${getStableRequestQuery(query)}`,
+        total,
+        pageNumber: 1
+      });
     }
 
     if (entity === DASHBOARD_SITEPOLYGONS) {
@@ -180,13 +176,11 @@ export class DashboardEntitiesController {
       for (const { id, model } of data) {
         document.addData(id, new DtoClass(model));
       }
-      return document
-        .addIndex({
-          requestPath: `/dashboard/v3/${entity}${getStableRequestQuery(query)}`,
-          total,
-          pageNumber: 1
-        })
-        .serialize();
+      return document.addIndex({
+        requestPath: `/dashboard/v3/${entity}${getStableRequestQuery(query)}`,
+        total,
+        pageNumber: 1
+      });
     }
 
     throw new NotFoundException(`Entity type ${entity} is not supported for listing`);
@@ -254,9 +248,7 @@ export class DashboardEntitiesController {
         category
       });
 
-      const document = buildJsonApi(DashboardImpactStoryFullDto);
-      document.addData(uuid, dto);
-      return document.serialize();
+      return buildJsonApi(DashboardImpactStoryFullDto).addData(uuid, dto);
     }
 
     if (entity === DASHBOARD_PROJECTS) {
@@ -266,9 +258,7 @@ export class DashboardEntitiesController {
         throw new NotFoundException(`${entity} with UUID ${uuid} not found`);
       }
       const { id, dto } = await processor.getFullDto(model);
-      const document = buildJsonApi(processor.FULL_DTO);
-      document.addData(id, dto);
-      return document.serialize();
+      return buildJsonApi(processor.FULL_DTO).addData(id, dto);
     }
 
     if (entity === DASHBOARD_SITEPOLYGONS) {
@@ -278,9 +268,7 @@ export class DashboardEntitiesController {
         throw new NotFoundException(`${entity} with UUID ${uuid} not found`);
       }
       const { id, dto } = await processor.getLightDto(model);
-      const document = buildJsonApi(processor.LIGHT_DTO);
-      document.addData(id, dto);
-      return document.serialize();
+      return buildJsonApi(processor.LIGHT_DTO).addData(id, dto);
     }
 
     throw new NotFoundException(`Entity type ${entity} is not supported for single entity retrieval`);

--- a/apps/dashboard-service/src/dashboard/dashboard-projects.controller.ts
+++ b/apps/dashboard-service/src/dashboard/dashboard-projects.controller.ts
@@ -24,11 +24,9 @@ export class DashboardProjectsController {
     const data = await this.cacheService.get(cacheKey, () => this.dashboardProjectsService.getDashboardProjects(query));
 
     const document = buildJsonApi(DashboardProjectsLightDto);
-
     data.forEach((project: DashboardProjectsLightDto) => {
       document.addData(project.uuid, project);
     });
-
-    return document.serialize();
+    return document;
   }
 }

--- a/apps/dashboard-service/src/dashboard/dashboard-sitepolygons.controller.ts
+++ b/apps/dashboard-service/src/dashboard/dashboard-sitepolygons.controller.ts
@@ -27,6 +27,6 @@ export class DashboardSitePolygonsController {
     data.forEach((sitePolygon: DashboardSitePolygonsLightDto) => {
       document.addData(sitePolygon.polygonUuid, sitePolygon);
     });
-    return document.serialize();
+    return document;
   }
 }

--- a/apps/dashboard-service/src/dashboard/hectares-restoration.controller.spec.ts
+++ b/apps/dashboard-service/src/dashboard/hectares-restoration.controller.spec.ts
@@ -4,6 +4,7 @@ import { createMock, DeepMocked } from "@golevelup/ts-jest";
 import { DashboardQueryDto } from "./dto/dashboard-query.dto";
 import { HectaresRestorationController } from "./hectares-restoration.controller";
 import { HectaresRestorationService } from "./hectares-restoration.service";
+import { serialize } from "@terramatch-microservices/common/util/testing";
 
 const getTotalsResult = () => {
   return {
@@ -53,7 +54,7 @@ describe("HectaresRestorationController", () => {
 
     hectaresRestorationService.getResults.mockResolvedValue(getTotalsResult());
 
-    const response = await controller.getHectaresRestoration(query);
+    const response = serialize(await controller.getHectaresRestoration(query));
 
     expect(response).toBeDefined();
     expect(response.data).toBeDefined();
@@ -69,7 +70,7 @@ describe("HectaresRestorationController", () => {
     cacheService.get.mockResolvedValue(getTotalsResult());
 
     const query = { projectUuid: "uuid1" } as DashboardQueryDto;
-    const response = await controller.getHectaresRestoration(query);
+    const response = serialize(await controller.getHectaresRestoration(query));
 
     expect(response).toBeDefined();
     expect(response.data).toBeDefined();

--- a/apps/dashboard-service/src/dashboard/hectares-restoration.controller.ts
+++ b/apps/dashboard-service/src/dashboard/hectares-restoration.controller.ts
@@ -22,9 +22,7 @@ export class HectaresRestorationController {
   async getHectaresRestoration(@Query() query: DashboardQueryDto) {
     const cacheKey = `dashboard:hectares-restoration|${this.cacheService.getCacheKeyFromQuery(query)}`;
     const cachedData = await this.cacheService.get(cacheKey, () => this.hectaresRestorationService.getResults(query));
-    const document = buildJsonApi(HectareRestorationDto);
     const stableQuery = getStableRequestQuery(query);
-    document.addData(stableQuery, new HectareRestorationDto(cachedData));
-    return document.serialize();
+    return buildJsonApi(HectareRestorationDto).addData(stableQuery, new HectareRestorationDto(cachedData));
   }
 }

--- a/apps/dashboard-service/src/dashboard/total-jobs-created.controller.spec.ts
+++ b/apps/dashboard-service/src/dashboard/total-jobs-created.controller.spec.ts
@@ -5,21 +5,7 @@ import { TotalJobsCreatedService } from "./total-jobs-created.service";
 import { createMock, DeepMocked } from "@golevelup/ts-jest";
 import { DashboardQueryDto } from "./dto/dashboard-query.dto";
 import { TotalJobsCreatedDto } from "./dto/total-jobs-created.dto";
-
-jest.mock("@terramatch-microservices/common/util/json-api-builder", () => ({
-  buildJsonApi: jest.fn().mockImplementation(() => ({
-    addData: jest.fn().mockReturnThis(),
-    serialize: jest.fn().mockReturnValue({
-      data: {
-        type: "totalJobsCreated",
-        id: "test-id",
-        attributes: {}
-      },
-      meta: { resourceType: "totalJobsCreated" }
-    })
-  })),
-  getStableRequestQuery: jest.fn().mockImplementation(query => query)
-}));
+import { serialize } from "@terramatch-microservices/common/util/testing";
 
 const getTotalsResult = (): TotalJobsCreatedDto => {
   return {
@@ -93,7 +79,7 @@ describe("TotalJobsCreatedController", () => {
       const expectedResult = getTotalsResult();
       totalJobsCreatedService.getTotals.mockResolvedValue(expectedResult);
 
-      const response = await controller.getTotalJobsCreated(query);
+      const response = serialize(await controller.getTotalJobsCreated(query));
 
       expect(response).toBeDefined();
       expect(response.data).toBeDefined();
@@ -112,7 +98,7 @@ describe("TotalJobsCreatedController", () => {
       cacheService.get.mockResolvedValue(cachedResult);
       const query: DashboardQueryDto = { country: "Kenya" };
 
-      const response = await controller.getTotalJobsCreated(query);
+      const response = serialize(await controller.getTotalJobsCreated(query));
 
       expect(response).toBeDefined();
       expect(response.data).toBeDefined();
@@ -154,7 +140,7 @@ describe("TotalJobsCreatedController", () => {
       const expectedResult = getTotalsResult();
       totalJobsCreatedService.getTotals.mockResolvedValue(expectedResult);
 
-      const response = await controller.getTotalJobsCreated(query);
+      const response = serialize(await controller.getTotalJobsCreated(query));
 
       expect(response).toBeDefined();
       expect(response.data).toBeDefined();
@@ -175,7 +161,7 @@ describe("TotalJobsCreatedController", () => {
       const expectedResult = getTotalsResult();
       totalJobsCreatedService.getTotals.mockResolvedValue(expectedResult);
 
-      const response = await controller.getTotalJobsCreated(query);
+      const response = serialize(await controller.getTotalJobsCreated(query));
 
       expect(response).toBeDefined();
       expect(response.data).toBeDefined();

--- a/apps/dashboard-service/src/dashboard/total-jobs-created.controller.ts
+++ b/apps/dashboard-service/src/dashboard/total-jobs-created.controller.ts
@@ -24,11 +24,7 @@ export class TotalJobsCreatedController {
     const cacheKey = `dashboard:jobs-created|${this.cacheService.getCacheKeyFromQuery(query)}`;
     const data = await this.cacheService.get(cacheKey, () => this.jobsCreatedService.getTotals(query));
 
-    const document = buildJsonApi(TotalJobsCreatedDto);
     const stableQuery = getStableRequestQuery(query);
-
-    document.addData(stableQuery, new TotalJobsCreatedDto(data));
-
-    return document.serialize();
+    return buildJsonApi(TotalJobsCreatedDto).addData(stableQuery, new TotalJobsCreatedDto(data));
   }
 }

--- a/apps/dashboard-service/src/dashboard/total-section-header.controller.spec.ts
+++ b/apps/dashboard-service/src/dashboard/total-section-header.controller.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { TotalSectionHeaderController } from "./total-section-header.controller";
 import { CacheService } from "./dto/cache.service";
 import { DashboardQueryDto } from "./dto/dashboard-query.dto";
+import { serialize } from "@terramatch-microservices/common/util/testing";
 
 jest.mock("@terramatch-microservices/database/entities", () => ({
   DelayedJob: {
@@ -40,7 +41,7 @@ describe("TotalSectionHeaderController", () => {
     cacheService.get.mockResolvedValue(null);
 
     const query = {} as DashboardQueryDto;
-    const response = await controller.getTotalSectionHeader(query);
+    const response = serialize(await controller.getTotalSectionHeader(query));
 
     expect(response).toBeDefined();
     expect(response.data).toBeDefined();
@@ -66,7 +67,7 @@ describe("TotalSectionHeaderController", () => {
     cacheService.getTimestampForTotalSectionHeader.mockResolvedValue("2025-01-01T00:00:00.000Z");
 
     const query = {} as DashboardQueryDto;
-    const response = await controller.getTotalSectionHeader(query);
+    const response = serialize(await controller.getTotalSectionHeader(query));
 
     expect(response).toBeDefined();
     expect(response.data).toBeDefined();

--- a/apps/dashboard-service/src/dashboard/total-section-header.controller.ts
+++ b/apps/dashboard-service/src/dashboard/total-section-header.controller.ts
@@ -29,7 +29,7 @@ export class TotalSectionHeaderController {
       await this.cacheService.getTotalSectionHeader(cacheKey, query, delayedJob.id);
       const delayedJobDto = populateDto(new DelayedJobDto(), delayedJob);
 
-      return buildJsonApi(DelayedJobDto).addData(delayedJob.uuid, delayedJobDto).document.serialize();
+      return buildJsonApi(DelayedJobDto).addData(delayedJob.uuid, delayedJobDto);
     }
 
     const {
@@ -42,10 +42,9 @@ export class TotalSectionHeaderController {
       totalTreesRestoredGoal
     } = cachedData;
 
-    const document = buildJsonApi(TotalSectionHeaderDto);
     const stableQuery = getStableRequestQuery(query);
 
-    document.addData(
+    return buildJsonApi(TotalSectionHeaderDto).addData(
       stableQuery,
       new TotalSectionHeaderDto({
         totalNonProfitCount,
@@ -58,7 +57,5 @@ export class TotalSectionHeaderController {
         lastUpdatedAt
       })
     );
-
-    return document.serialize();
   }
 }

--- a/apps/dashboard-service/src/dashboard/tree-restoration-goal.controller.spec.ts
+++ b/apps/dashboard-service/src/dashboard/tree-restoration-goal.controller.spec.ts
@@ -3,15 +3,7 @@ import { TreeRestorationGoalController } from "./tree-restoration-goal.controlle
 import { TreeRestorationGoalService } from "./dto/tree-restoration-goal.service";
 import { CacheService } from "./dto/cache.service";
 import { DashboardQueryDto } from "./dto/dashboard-query.dto";
-
-// Mock the json-api-builder module
-jest.mock("@terramatch-microservices/common/util/json-api-builder", () => ({
-  buildJsonApi: jest.fn().mockImplementation(() => ({
-    addData: jest.fn(),
-    serialize: jest.fn().mockReturnValue({ mockSerialized: true })
-  })),
-  getStableRequestQuery: jest.fn().mockImplementation(query => query)
-}));
+import { serialize } from "@terramatch-microservices/common/util/testing";
 
 describe("TreeRestorationGoalController", () => {
   let controller: TreeRestorationGoalController;
@@ -136,7 +128,7 @@ describe("TreeRestorationGoalController", () => {
       // Mock Date constructor to return consistent timestamp
       jest.spyOn(global, "Date").mockImplementation(() => mockDate);
 
-      const result = await controller.getTreeRestorationGoal(query);
+      await controller.getTreeRestorationGoal(query);
 
       expect(cacheService.getCacheKeyFromQuery).toHaveBeenCalledWith(query);
       expect(treeRestorationGoalService.getTreeRestorationGoal).toHaveBeenCalledWith(query);
@@ -144,7 +136,6 @@ describe("TreeRestorationGoalController", () => {
         "dashboard:tree-restoration-goal|test-cache-key:timestamp",
         mockTimestamp
       );
-      expect(result).toEqual({ mockSerialized: true });
 
       jest.restoreAllMocks();
     });
@@ -164,7 +155,7 @@ describe("TreeRestorationGoalController", () => {
         // Mock cache.get for data key (cache hit)
         .mockResolvedValueOnce(mockCachedData);
 
-      const result = await controller.getTreeRestorationGoal(query);
+      await controller.getTreeRestorationGoal(query);
 
       expect(cacheService.getCacheKeyFromQuery).toHaveBeenCalledWith(query);
       expect(cacheService.get).toHaveBeenCalledWith(
@@ -173,7 +164,6 @@ describe("TreeRestorationGoalController", () => {
       );
       expect(cacheService.get).toHaveBeenCalledWith("dashboard:tree-restoration-goal|cached-key", expect.any(Function));
       expect(treeRestorationGoalService.getTreeRestorationGoal).not.toHaveBeenCalled();
-      expect(result).toEqual({ mockSerialized: true });
     });
 
     it("should handle empty query object", async () => {
@@ -191,10 +181,8 @@ describe("TreeRestorationGoalController", () => {
       treeRestorationGoalService.getTreeRestorationGoal.mockResolvedValue(mockServiceResponse);
       jest.spyOn(global, "Date").mockImplementation(() => mockDate);
 
-      const result = await controller.getTreeRestorationGoal(query);
-
+      await controller.getTreeRestorationGoal(query);
       expect(treeRestorationGoalService.getTreeRestorationGoal).toHaveBeenCalledWith(query);
-      expect(result).toEqual({ mockSerialized: true });
 
       jest.restoreAllMocks();
     });
@@ -222,10 +210,8 @@ describe("TreeRestorationGoalController", () => {
       treeRestorationGoalService.getTreeRestorationGoal.mockResolvedValue(mockServiceResponse);
       jest.spyOn(global, "Date").mockImplementation(() => mockDate);
 
-      const result = await controller.getTreeRestorationGoal(query);
-
+      await controller.getTreeRestorationGoal(query);
       expect(treeRestorationGoalService.getTreeRestorationGoal).toHaveBeenCalledWith(query);
-      expect(result).toEqual({ mockSerialized: true });
 
       jest.restoreAllMocks();
     });
@@ -252,9 +238,8 @@ describe("TreeRestorationGoalController", () => {
       treeRestorationGoalService.getTreeRestorationGoal.mockResolvedValue(emptyServiceResponse);
       jest.spyOn(global, "Date").mockImplementation(() => mockDate);
 
-      const result = await controller.getTreeRestorationGoal(query);
-
-      expect(result).toEqual({ mockSerialized: true });
+      const result = serialize(await controller.getTreeRestorationGoal(query));
+      expect(result).toBeDefined();
 
       jest.restoreAllMocks();
     });
@@ -289,9 +274,8 @@ describe("TreeRestorationGoalController", () => {
       const mockDate = new Date(mockTimestamp);
       jest.spyOn(global, "Date").mockImplementation(() => mockDate);
 
-      const result = await controller.getTreeRestorationGoal(query);
-
-      expect(result).toEqual({ mockSerialized: true });
+      const result = serialize(await controller.getTreeRestorationGoal(query));
+      expect(result).toBeDefined();
 
       jest.restoreAllMocks();
     });
@@ -312,9 +296,8 @@ describe("TreeRestorationGoalController", () => {
       // Mock cache hits
       cacheService.get.mockResolvedValueOnce(mockTimestamp).mockResolvedValueOnce(emptyCachedData);
 
-      const result = await controller.getTreeRestorationGoal(query);
-
-      expect(result).toEqual({ mockSerialized: true });
+      const result = serialize(await controller.getTreeRestorationGoal(query));
+      expect(result).toBeDefined();
     });
 
     it("should set timestamp when data is fetched from service", async () => {

--- a/apps/dashboard-service/src/dashboard/tree-restoration-goal.controller.ts
+++ b/apps/dashboard-service/src/dashboard/tree-restoration-goal.controller.ts
@@ -30,17 +30,13 @@ export class TreeRestorationGoalController {
       return data;
     });
 
-    const document = buildJsonApi(TreeRestorationGoalDto);
     const stableQuery = getStableRequestQuery(query);
-
-    document.addData(
+    return buildJsonApi(TreeRestorationGoalDto).addData(
       stableQuery,
       new TreeRestorationGoalDto({
         ...result,
         lastUpdatedAt
       })
     );
-
-    return document.serialize();
   }
 }

--- a/apps/dashboard-service/src/main.ts
+++ b/apps/dashboard-service/src/main.ts
@@ -7,6 +7,7 @@ import { AppModule } from "./app.module";
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 import { TMLogger } from "@terramatch-microservices/common/util/tm-logger";
 import { NestExpressApplication } from "@nestjs/platform-express";
+import { DocumentBuilderInterceptor } from "@terramatch-microservices/common/util/document-builder-interceptor";
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
@@ -34,6 +35,8 @@ async function bootstrap() {
       transformOptions: { enableImplicitConversion: true, exposeDefaultValues: true }
     })
   );
+
+  app.useGlobalInterceptors(new DocumentBuilderInterceptor());
 
   const port = process.env.NODE_ENV === "production" ? 80 : process.env.DASHBOARD_SERVICE_PORT ?? 4060;
   await app.listen(port);

--- a/apps/entity-service/src/app.module.ts
+++ b/apps/entity-service/src/app.module.ts
@@ -21,6 +21,7 @@ import { ImpactStoryService } from "./entities/impact-story.service";
 import { DisturbancesController } from "./entities/disturbances.controller";
 import { DisturbanceService } from "./entities/disturbance.service";
 import { OptionLabelsController } from "./forms/option-labels.controller";
+import { LinkedFieldsController } from "./forms/linked-fields.controller";
 
 @Module({
   imports: [SentryModule.forRoot(), CommonModule, HealthModule],
@@ -37,7 +38,8 @@ import { OptionLabelsController } from "./forms/option-labels.controller";
     DisturbancesController,
     EntitiesController,
     EntityAssociationsController,
-    OptionLabelsController
+    OptionLabelsController,
+    LinkedFieldsController
   ],
   providers: [
     {

--- a/apps/entity-service/src/entities/demographic.controller.spec.ts
+++ b/apps/entity-service/src/entities/demographic.controller.spec.ts
@@ -8,6 +8,7 @@ import { DemographicsController } from "./demographics.controller";
 import { DemographicService } from "./demographic.service";
 import { DemographicQueryDto } from "./dto/demographic-query.dto";
 import { ProjectFactory } from "@terramatch-microservices/database/factories";
+import { serialize } from "@terramatch-microservices/common/util/testing";
 
 describe("DemographicsController", () => {
   let controller: DemographicsController;
@@ -41,7 +42,7 @@ describe("DemographicsController", () => {
 
       demographicService.getDemographics.mockResolvedValue(mockResponse);
 
-      const result = await controller.demographicsIndex(new DemographicQueryDto());
+      const result = serialize(await controller.demographicsIndex(new DemographicQueryDto()));
       expect(demographicService.getDemographics).toHaveBeenCalledTimes(1);
       expect(result).toBeDefined();
     });
@@ -69,7 +70,7 @@ describe("DemographicsController", () => {
       policyService.getPermissions.mockResolvedValue(["framework-ppc"]);
       demographicService.getDemographics.mockResolvedValue(mockResponse);
 
-      const result = await controller.demographicsIndex(new DemographicQueryDto());
+      const result = serialize(await controller.demographicsIndex(new DemographicQueryDto()));
       expect(result).toBeDefined();
       expect(Array.isArray(result.data) ? result.data.length : 0).toBe(2);
       expect(demographicService.getDemographics).toHaveBeenCalledTimes(1);

--- a/apps/entity-service/src/entities/demographics.controller.ts
+++ b/apps/entity-service/src/entities/demographics.controller.ts
@@ -52,12 +52,10 @@ export class DemographicsController {
         document.addData(demographic.uuid, new DemographicDto(demographic, additionalProps));
       }
     }
-    return document
-      .addIndex({
-        requestPath: `/entities/v3/demographics${getStableRequestQuery(params)}`,
-        total: paginationTotal,
-        pageNumber: pageNumber
-      })
-      .serialize();
+    return document.addIndex({
+      requestPath: `/entities/v3/demographics${getStableRequestQuery(params)}`,
+      total: paginationTotal,
+      pageNumber: pageNumber
+    });
   }
 }

--- a/apps/entity-service/src/entities/disturbance.controller.spec.ts
+++ b/apps/entity-service/src/entities/disturbance.controller.spec.ts
@@ -8,6 +8,7 @@ import { SiteReportFactory } from "@terramatch-microservices/database/factories"
 import { DisturbancesController } from "./disturbances.controller";
 import { DisturbanceService } from "./disturbance.service";
 import { DisturbanceQueryDto } from "./dto/disturbance-query.dto";
+import { serialize } from "@terramatch-microservices/common/util/testing";
 
 describe("DisturbanceController", () => {
   let controller: DisturbancesController;
@@ -41,7 +42,7 @@ describe("DisturbanceController", () => {
 
       disturbanceService.getDisturbances.mockResolvedValue(mockResponse);
 
-      const result = await controller.disturbancesIndex(new DisturbanceQueryDto());
+      const result = serialize(await controller.disturbancesIndex(new DisturbanceQueryDto()));
       expect(disturbanceService.getDisturbances).toHaveBeenCalledTimes(1);
       expect(result).toBeDefined();
     });
@@ -69,7 +70,7 @@ describe("DisturbanceController", () => {
       policyService.getPermissions.mockResolvedValue(["framework-ppc"]);
       disturbanceService.getDisturbances.mockResolvedValue(mockResponse);
 
-      const result = await controller.disturbancesIndex(new DisturbanceQueryDto());
+      const result = serialize(await controller.disturbancesIndex(new DisturbanceQueryDto()));
       expect(result).toBeDefined();
       expect(Array.isArray(result.data) ? result.data.length : 0).toBe(2);
       expect(disturbanceService.getDisturbances).toHaveBeenCalledTimes(1);

--- a/apps/entity-service/src/entities/disturbances.controller.ts
+++ b/apps/entity-service/src/entities/disturbances.controller.ts
@@ -53,12 +53,10 @@ export class DisturbancesController {
         document.addData(disturbance.uuid, new DisturbanceDto(disturbance, additionalProps));
       }
     }
-    return document
-      .addIndex({
-        requestPath: `/entities/v3/disturbances${getStableRequestQuery(params)}`,
-        total: paginationTotal,
-        pageNumber: pageNumber
-      })
-      .serialize();
+    return document.addIndex({
+      requestPath: `/entities/v3/disturbances${getStableRequestQuery(params)}`,
+      total: paginationTotal,
+      pageNumber: pageNumber
+    });
   }
 }

--- a/apps/entity-service/src/entities/disturbances.controller.ts
+++ b/apps/entity-service/src/entities/disturbances.controller.ts
@@ -33,12 +33,10 @@ export class DisturbancesController {
   async disturbancesIndex(@Query() params: DisturbanceQueryDto) {
     const { data, paginationTotal, pageNumber } = await this.disturbanceService.getDisturbances(params);
     const document = buildJsonApi(DisturbanceDto, { pagination: "number" });
-    const indexIds: string[] = [];
 
     if (data.length !== 0) {
       await this.policyService.authorize("read", data);
       for (const disturbance of data) {
-        indexIds.push(disturbance.uuid);
         const { disturbanceableType: laravelType, disturbanceableId } = disturbance;
         const model = LARAVEL_MODELS[laravelType];
         if (model == null) {
@@ -52,17 +50,15 @@ export class DisturbancesController {
         }
         const entityType = LARAVEL_MODEL_TYPES[laravelType];
         const additionalProps = { entityType, entityUuid: entity.uuid };
-        const disturbanceDto = new DisturbanceDto(disturbance, additionalProps);
-        document.addData(disturbance.uuid, disturbanceDto);
+        document.addData(disturbance.uuid, new DisturbanceDto(disturbance, additionalProps));
       }
     }
-    document.addIndexData({
-      resource: "disturbances",
-      requestPath: `/entities/v3/disturbances${getStableRequestQuery(params)}`,
-      ids: indexIds,
-      total: paginationTotal,
-      pageNumber: pageNumber
-    });
-    return document.serialize();
+    return document
+      .addIndex({
+        requestPath: `/entities/v3/disturbances${getStableRequestQuery(params)}`,
+        total: paginationTotal,
+        pageNumber: pageNumber
+      })
+      .serialize();
   }
 }

--- a/apps/entity-service/src/entities/entities.controller.spec.ts
+++ b/apps/entity-service/src/entities/entities.controller.spec.ts
@@ -12,6 +12,7 @@ import { EntityQueryDto } from "./dto/entity-query.dto";
 import { faker } from "@faker-js/faker";
 import { EntityUpdateData } from "./dto/entity-update.dto";
 import { HybridSupportProps } from "@terramatch-microservices/common/dto/hybrid-support.dto";
+import { serialize } from "@terramatch-microservices/common/util/testing";
 
 class StubProcessor extends EntityProcessor<Project, ProjectLightDto, ProjectFullDto, EntityUpdateData> {
   LIGHT_DTO = ProjectLightDto;
@@ -74,7 +75,7 @@ describe("EntitiesController", () => {
       policyService.getPermissions.mockResolvedValue(["projects-read"]);
       policyService.authorize.mockResolvedValue();
 
-      const result = await controller.entityIndex({ entity: "projects" }, {} as EntityQueryDto);
+      const result = serialize(await controller.entityIndex({ entity: "projects" }, {} as EntityQueryDto));
       expect(processor.getLightDto).toHaveBeenCalledTimes(2);
       expect(result.meta.indices?.[0]?.pageNumber).toBe(1);
       expect(result.meta.indices?.[0]?.total).toBe(2);
@@ -98,7 +99,7 @@ describe("EntitiesController", () => {
       const project = await ProjectFactory.create();
       processor.findOne.mockResolvedValue(project);
       policyService.authorize.mockResolvedValue();
-      const result = await controller.entityGet({ entity: "projects", uuid: "asdf" });
+      const result = serialize(await controller.entityGet({ entity: "projects", uuid: "asdf" }));
       expect(processor.getFullDto).toHaveBeenCalledWith(project);
       expect(result.meta.resourceType).toBe("projects");
     });
@@ -122,7 +123,7 @@ describe("EntitiesController", () => {
       const project = await ProjectFactory.create();
       processor.findOne.mockResolvedValue(project);
       policyService.authorize.mockResolvedValue();
-      const result = await controller.entityDelete({ entity: "projects", uuid: project.uuid });
+      const result = serialize(await controller.entityDelete({ entity: "projects", uuid: project.uuid }));
       expect(processor.delete).toHaveBeenCalledWith(project);
       expect(result.meta.resourceType).toBe("projects");
       expect(result.meta.resourceId).toBe(project.uuid);

--- a/apps/entity-service/src/entities/entities.controller.ts
+++ b/apps/entity-service/src/entities/entities.controller.ts
@@ -55,7 +55,7 @@ export class EntitiesController {
     const processor = this.entitiesService.createEntityProcessor<T>(entity);
     const document = buildJsonApi(processor.LIGHT_DTO, { pagination: "number" });
     await processor.addIndex(document, query);
-    return document.serialize();
+    return document;
   }
 
   @Get(":entity/:uuid")
@@ -84,10 +84,8 @@ export class EntitiesController {
 
     await this.policyService.authorize("read", model);
 
-    const document = buildJsonApi(processor.FULL_DTO);
     const { id, dto } = await processor.getFullDto(model);
-    document.addData(id, dto);
-    return document.serialize();
+    return buildJsonApi(processor.FULL_DTO).addData(id, dto);
   }
 
   @Delete(":entity/:uuid")
@@ -148,9 +146,7 @@ export class EntitiesController {
 
     await processor.update(model, updatePayload.data.attributes);
 
-    const document = buildJsonApi(processor.FULL_DTO);
     const { id, dto } = await processor.getFullDto(model);
-    document.addData(id, dto);
-    return document.serialize();
+    return buildJsonApi(processor.FULL_DTO).addData(id, dto);
   }
 }

--- a/apps/entity-service/src/entities/entity-associations.controller.spec.ts
+++ b/apps/entity-service/src/entities/entity-associations.controller.spec.ts
@@ -8,6 +8,7 @@ import { AssociationProcessor } from "./processors/association-processor";
 import { DemographicDto } from "./dto/demographic.dto";
 import { DemographicFactory, ProjectReportFactory } from "@terramatch-microservices/database/factories";
 import { NotFoundException, UnauthorizedException } from "@nestjs/common";
+import { serialize } from "@terramatch-microservices/common/util/testing";
 
 class StubProcessor extends AssociationProcessor<Demographic, DemographicDto> {
   DTO = DemographicDto;
@@ -94,13 +95,15 @@ describe("EntityAssociationsController", () => {
       const pr = await ProjectReportFactory.create();
       await DemographicFactory.forProjectReportWorkday.create({ demographicalId: pr.id });
       await DemographicFactory.forProjectReportJobs.create({ demographicalId: pr.id });
-      const result = await controller.associationIndex(
-        {
-          entity: "projectReports",
-          uuid: pr.uuid,
-          association: "demographics"
-        },
-        {}
+      const result = serialize(
+        await controller.associationIndex(
+          {
+            entity: "projectReports",
+            uuid: pr.uuid,
+            association: "demographics"
+          },
+          {}
+        )
       );
 
       const processor = entitiesService.createAssociationProcessor.mock.results[0].value;

--- a/apps/entity-service/src/entities/entity-associations.controller.ts
+++ b/apps/entity-service/src/entities/entity-associations.controller.ts
@@ -44,6 +44,6 @@ export class EntityAssociationsController {
     await this.policyService.authorize("read", baseEntity);
     const document = buildJsonApi(processor.DTO, { forceDataArray: true });
     await processor.addDtos(document);
-    return document.serialize();
+    return document;
   }
 }

--- a/apps/entity-service/src/entities/file-upload.controller.ts
+++ b/apps/entity-service/src/entities/file-upload.controller.ts
@@ -52,8 +52,7 @@ export class FileUploadController {
     const model = await mediaOwnerProcessor.getBaseEntity();
     await this.policyService.authorize("uploadFiles", model);
     const media = await this.fileUploadService.uploadFile(model, entity, collection, file, body);
-    const document = buildJsonApi(MediaDto);
-    document.addData(
+    return buildJsonApi(MediaDto).addData(
       media.uuid,
       new MediaDto(media, {
         url: this.mediaService.getUrl(media),
@@ -62,6 +61,5 @@ export class FileUploadController {
         entityUuid: model.uuid
       })
     );
-    return document.serialize();
   }
 }

--- a/apps/entity-service/src/entities/impact-stories.controller.spec.ts
+++ b/apps/entity-service/src/entities/impact-stories.controller.spec.ts
@@ -4,8 +4,9 @@ import { ImpactStoryService } from "./impact-story.service";
 import { EntitiesService } from "./entities.service";
 import { ImpactStory, Media } from "@terramatch-microservices/database/entities";
 import { NotFoundException } from "@nestjs/common";
-import { JsonApiDocument, Resource } from "@terramatch-microservices/common/util/json-api-builder";
+import { Resource } from "@terramatch-microservices/common/util/json-api-builder";
 import { ImpactStoryQueryDto } from "./dto/impact-story-query.dto";
+import { serialize } from "@terramatch-microservices/common/util/testing";
 
 describe("ImpactStoriesController", () => {
   let controller: ImpactStoriesController;
@@ -105,7 +106,7 @@ describe("ImpactStoriesController", () => {
   describe("impactStoryIndex", () => {
     it("should return paginated impact stories with media and countries", async () => {
       const query: ImpactStoryQueryDto = { page: { number: 1 } };
-      const result = (await controller.impactStoryIndex(query)) as JsonApiDocument;
+      const result = serialize(await controller.impactStoryIndex(query));
 
       expect(result).toBeDefined();
       expect(result.data).toBeDefined();
@@ -126,7 +127,7 @@ describe("ImpactStoriesController", () => {
       });
 
       const query: ImpactStoryQueryDto = { page: { number: 1 } };
-      const result = (await controller.impactStoryIndex(query)) as JsonApiDocument;
+      const result = serialize(await controller.impactStoryIndex(query));
 
       expect(result.data).toBeDefined();
       expect(result.meta.indices?.[0].total).toBe(0);
@@ -138,7 +139,7 @@ describe("ImpactStoriesController", () => {
   describe("impactStoryGet", () => {
     it("should return a single impact story with media and countries", async () => {
       const params = { uuid: "test-uuid" };
-      const result = (await controller.impactStoryGet(params)) as JsonApiDocument;
+      const result = serialize(await controller.impactStoryGet(params));
 
       expect(result).toBeDefined();
       expect(result.data).toBeDefined();

--- a/apps/entity-service/src/entities/impact-stories.controller.ts
+++ b/apps/entity-service/src/entities/impact-stories.controller.ts
@@ -60,13 +60,11 @@ export class ImpactStoriesController {
       }
     }
 
-    return document
-      .addIndex({
-        requestPath: `/entities/v3/impactStories${getStableRequestQuery(params)}`,
-        total: paginationTotal,
-        pageNumber: pageNumber
-      })
-      .serialize();
+    return document.addIndex({
+      requestPath: `/entities/v3/impactStories${getStableRequestQuery(params)}`,
+      total: paginationTotal,
+      pageNumber: pageNumber
+    });
   }
 
   @Get(":uuid")
@@ -99,19 +97,17 @@ export class ImpactStoriesController {
       twitterUrl: impactStory.organisation?.twitterUrl
     };
 
-    return buildJsonApi(ImpactStoryFullDto)
-      .addData(
-        uuid,
-        new ImpactStoryFullDto(impactStory, {
-          organization,
-          ...(this.entitiesService.mapMediaCollection(
-            mediaCollection,
-            ImpactStory.MEDIA,
-            "projects",
-            impactStory.uuid
-          ) as ImpactStoryMedia)
-        })
-      )
-      .document.serialize();
+    return buildJsonApi(ImpactStoryFullDto).addData(
+      uuid,
+      new ImpactStoryFullDto(impactStory, {
+        organization,
+        ...(this.entitiesService.mapMediaCollection(
+          mediaCollection,
+          ImpactStory.MEDIA,
+          "projects",
+          impactStory.uuid
+        ) as ImpactStoryMedia)
+      })
+    );
   }
 }

--- a/apps/entity-service/src/entities/impact-stories.controller.ts
+++ b/apps/entity-service/src/entities/impact-stories.controller.ts
@@ -28,7 +28,6 @@ export class ImpactStoriesController {
   async impactStoryIndex(@Query() params: ImpactStoryQueryDto) {
     const { data, paginationTotal, pageNumber } = await this.impactStoryService.getImpactStories(params);
     const document = buildJsonApi(ImpactStoryLightDto, { pagination: "number" });
-    const indexIds: string[] = [];
 
     if (data.length !== 0) {
       const mediaByStory = await this.impactStoryService.getMediaForStories(data);
@@ -37,8 +36,6 @@ export class ImpactStoriesController {
       const countriesMap = await this.impactStoryService.getCountriesForOrganizations(organizationCountries);
 
       for (const impact of data) {
-        indexIds.push(impact.uuid);
-
         const mediaCollection = mediaByStory[impact.id] ?? [];
         const orgCountries = (impact.organisation?.countries ?? [])
           .map(iso => countriesMap.get(iso))
@@ -63,14 +60,13 @@ export class ImpactStoriesController {
       }
     }
 
-    document.addIndexData({
-      resource: "impactStories",
-      requestPath: `/entities/v3/impactStories${getStableRequestQuery(params)}`,
-      ids: indexIds,
-      total: paginationTotal,
-      pageNumber: pageNumber
-    });
-    return document.serialize();
+    return document
+      .addIndex({
+        requestPath: `/entities/v3/impactStories${getStableRequestQuery(params)}`,
+        total: paginationTotal,
+        pageNumber: pageNumber
+      })
+      .serialize();
   }
 
   @Get(":uuid")

--- a/apps/entity-service/src/entities/processors/association-processor.spec.ts
+++ b/apps/entity-service/src/entities/processors/association-processor.spec.ts
@@ -76,7 +76,7 @@ describe("AssociationProcessor", () => {
       expect(result.meta.indices?.[0]).toMatchObject({
         resource: "demographics",
         requestPath: `/entities/v3/projectReports/${projectReportUuid}/demographics`,
-        ids: [uuid]
+        ids: undefined
       });
     });
 

--- a/apps/entity-service/src/entities/processors/association-processor.ts
+++ b/apps/entity-service/src/entities/processors/association-processor.ts
@@ -77,7 +77,7 @@ export abstract class AssociationProcessor<M extends UuidModel, D extends Associ
     }
 
     const resource = getDtoType(this.DTO);
-    document.addIndexData({
+    document.addIndex({
       resource,
       requestPath: `/entities/v3/${this.entityType}/${this.entityUuid}/${resource}`,
       ids: indexIds

--- a/apps/entity-service/src/entities/processors/entity-processor.ts
+++ b/apps/entity-service/src/entities/processors/entity-processor.ts
@@ -125,7 +125,7 @@ export abstract class EntityProcessor<
       }
     }
 
-    document.addIndexData({ ...indexData, ids: indexIds });
+    document.addIndex({ ...indexData, ids: indexIds });
 
     if (models.length > 0 && !sideloaded && query.sideloads != null && query.sideloads.length > 0) {
       for (const model of models) {

--- a/apps/entity-service/src/entities/processors/media.processor.spec.ts
+++ b/apps/entity-service/src/entities/processors/media.processor.spec.ts
@@ -46,7 +46,7 @@ describe("MediaProcessor", () => {
     expect(result.meta.indices?.[0]).toMatchObject({
       resource: "media",
       requestPath: `/entities/v3/${entityType}/${entityUuid}/media${getStableRequestQuery(query)}`,
-      ids: response.map(({ uuid }) => uuid)
+      ids: undefined
     });
   }
 

--- a/apps/entity-service/src/entities/processors/media.processor.ts
+++ b/apps/entity-service/src/entities/processors/media.processor.ts
@@ -120,9 +120,8 @@ export class MediaProcessor extends AssociationProcessor<Media, MediaDto> {
     return models;
   }
 
-  private async getFinancialReportModels(financialReport: FinancialReport) {
-    const models: QueryModelType[] = this.getBaseEntityModels(financialReport);
-    return models;
+  private async getFinancialReportModels(financialReport: FinancialReport): Promise<QueryModelType[]> {
+    return this.getBaseEntityModels(financialReport);
   }
 
   _queryBuilder: PaginatedQueryBuilder<Media> | null = null;
@@ -237,7 +236,7 @@ export class MediaProcessor extends AssociationProcessor<Media, MediaDto> {
     const total = await this.getTotal();
 
     const resource = getDtoType(this.DTO);
-    document.addIndexData({
+    document.addIndex({
       resource,
       requestPath: `/entities/v3/${this.entityType}/${this.entityUuid}/${resource}${getStableRequestQuery(this.query)}`,
       total,

--- a/apps/entity-service/src/entities/project-pitches.controller.spec.ts
+++ b/apps/entity-service/src/entities/project-pitches.controller.spec.ts
@@ -6,6 +6,7 @@ import { ProjectPitchService } from "./project-pitch.service";
 import { BadRequestException, NotFoundException } from "@nestjs/common";
 import { PolicyService } from "@terramatch-microservices/common";
 import { ProjectPitchQueryDto } from "./dto/project-pitch-query.dto";
+import { serialize } from "@terramatch-microservices/common/util/testing";
 
 describe("ProjectPitchesController", () => {
   let controller: ProjectPitchesController;
@@ -39,7 +40,7 @@ describe("ProjectPitchesController", () => {
 
       projectPitchService.getProjectPitches.mockResolvedValue(mockResponse);
 
-      const result = await controller.projectPitchIndex(new ProjectPitchQueryDto());
+      const result = serialize(await controller.projectPitchIndex(new ProjectPitchQueryDto()));
       expect(projectPitchService.getProjectPitches).toHaveBeenCalledTimes(1);
       expect(result).toBeDefined();
     });
@@ -56,7 +57,7 @@ describe("ProjectPitchesController", () => {
       policyService.getPermissions.mockResolvedValue(["framework-ppc"]);
       projectPitchService.getProjectPitches.mockResolvedValue(mockResponse);
 
-      const result = await controller.projectPitchIndex(new ProjectPitchQueryDto());
+      const result = serialize(await controller.projectPitchIndex(new ProjectPitchQueryDto()));
       expect(result).toBeDefined();
       expect(Array.isArray(result.data) ? result.data.length : 0).toBe(2);
       expect(projectPitchService.getProjectPitches).toHaveBeenCalledTimes(1);
@@ -85,7 +86,7 @@ describe("ProjectPitchesController", () => {
         } as ProjectPitch);
         projectPitchService.getProjectPitch.mockResolvedValue(mockProjectPitch);
 
-        const result = await controller.projectPitchGet({ uuid: "1" });
+        const result = serialize(await controller.projectPitchGet({ uuid: "1" }));
         expect(result).toBeDefined();
         expect(result.data?.["id"]).toBe("1");
         expect(projectPitchService.getProjectPitch).toHaveBeenCalledWith("1");

--- a/apps/entity-service/src/entities/project-pitches.controller.ts
+++ b/apps/entity-service/src/entities/project-pitches.controller.ts
@@ -26,23 +26,20 @@ export class ProjectPitchesController {
   async projectPitchIndex(@Query() params: ProjectPitchQueryDto) {
     const { data, paginationTotal, pageNumber } = await this.projectPitchService.getProjectPitches(params);
     const document = buildJsonApi(ProjectPitchDto, { pagination: "number" });
-    const indexIds: string[] = [];
     if (data.length !== 0) {
       await this.policyService.authorize("read", data);
       for (const pitch of data) {
-        indexIds.push(pitch.uuid);
         const pitchDto = new ProjectPitchDto(pitch);
         document.addData(pitchDto.uuid, pitchDto);
       }
     }
-    document.addIndexData({
-      resource: "projectPitches",
-      requestPath: `/entities/v3/projectPitches${getStableRequestQuery(params)}`,
-      ids: indexIds,
-      total: paginationTotal,
-      pageNumber: pageNumber
-    });
-    return document.serialize();
+    return document
+      .addIndex({
+        requestPath: `/entities/v3/projectPitches${getStableRequestQuery(params)}`,
+        total: paginationTotal,
+        pageNumber: pageNumber
+      })
+      .serialize();
   }
 
   @Get(":uuid")

--- a/apps/entity-service/src/entities/project-pitches.controller.ts
+++ b/apps/entity-service/src/entities/project-pitches.controller.ts
@@ -33,13 +33,11 @@ export class ProjectPitchesController {
         document.addData(pitchDto.uuid, pitchDto);
       }
     }
-    return document
-      .addIndex({
-        requestPath: `/entities/v3/projectPitches${getStableRequestQuery(params)}`,
-        total: paginationTotal,
-        pageNumber: pageNumber
-      })
-      .serialize();
+    return document.addIndex({
+      requestPath: `/entities/v3/projectPitches${getStableRequestQuery(params)}`,
+      total: paginationTotal,
+      pageNumber: pageNumber
+    });
   }
 
   @Get(":uuid")
@@ -53,6 +51,6 @@ export class ProjectPitchesController {
   async projectPitchGet(@Param() { uuid }: ProjectPitchParamDto) {
     const result = await this.projectPitchService.getProjectPitch(uuid);
     await this.policyService.authorize("read", result);
-    return buildJsonApi(ProjectPitchDto).addData(uuid, new ProjectPitchDto(result)).document.serialize();
+    return buildJsonApi(ProjectPitchDto).addData(uuid, new ProjectPitchDto(result));
   }
 }

--- a/apps/entity-service/src/entities/tasks.controller.spec.ts
+++ b/apps/entity-service/src/entities/tasks.controller.spec.ts
@@ -9,6 +9,7 @@ import { Task } from "@terramatch-microservices/database/entities";
 import { BadRequestException } from "@nestjs/common";
 import { Resource } from "@terramatch-microservices/common/util";
 import { TaskLightDto } from "./dto/task.dto";
+import { serialize } from "@terramatch-microservices/common/util/testing";
 
 describe("TasksController", () => {
   let controller: TasksController;
@@ -53,7 +54,7 @@ describe("TasksController", () => {
       service.getTasks.mockResolvedValue({ tasks, total: tasks.length });
       policyService.authorize.mockResolvedValue();
 
-      const result = await controller.taskIndex({});
+      const result = serialize(await controller.taskIndex({}));
       expect(policyService.authorize).toHaveBeenCalledWith("read", tasks);
       expect(result.meta.indices?.[0]?.pageNumber).toBe(1);
       expect(result.meta.indices?.[0]?.total).toBe(2);

--- a/apps/entity-service/src/entities/tasks.controller.ts
+++ b/apps/entity-service/src/entities/tasks.controller.ts
@@ -43,13 +43,11 @@ export class TasksController {
       }
     }
 
-    return document
-      .addIndex({
-        requestPath: `/entities/v3/tasks${getStableRequestQuery(query)}`,
-        total,
-        pageNumber: query.page?.number ?? 1
-      })
-      .serialize();
+    return document.addIndex({
+      requestPath: `/entities/v3/tasks${getStableRequestQuery(query)}`,
+      total,
+      pageNumber: query.page?.number ?? 1
+    });
   }
 
   @Get(":uuid")
@@ -75,7 +73,7 @@ export class TasksController {
   async taskGet(@Param() { uuid }: SingleTaskDto) {
     const task = await this.tasksService.getTask(uuid);
     await this.policyService.authorize("read", task);
-    return (await this.tasksService.addFullTaskDto(buildJsonApi(TaskFullDto), task)).serialize();
+    return await this.tasksService.addFullTaskDto(buildJsonApi(TaskFullDto), task);
   }
 
   @Patch(":uuid")
@@ -119,6 +117,6 @@ export class TasksController {
       }
     }
 
-    return (await this.tasksService.addFullTaskDto(buildJsonApi(TaskFullDto), task)).serialize();
+    return await this.tasksService.addFullTaskDto(buildJsonApi(TaskFullDto), task);
   }
 }

--- a/apps/entity-service/src/entities/tasks.controller.ts
+++ b/apps/entity-service/src/entities/tasks.controller.ts
@@ -35,25 +35,21 @@ export class TasksController {
   async taskIndex(@Query() query: TaskQueryDto) {
     const { tasks, total } = await this.tasksService.getTasks(query);
     const document = buildJsonApi(TaskLightDto, { pagination: "number" });
-    const indexIds: string[] = [];
     if (tasks.length !== 0) {
       await this.policyService.authorize("read", tasks);
 
       for (const task of tasks) {
-        indexIds.push(task.uuid);
         document.addData(task.uuid, new TaskLightDto(task));
       }
     }
 
-    document.addIndexData({
-      resource: "tasks",
-      requestPath: `/entities/v3/tasks${getStableRequestQuery(query)}`,
-      ids: indexIds,
-      total,
-      pageNumber: query.page?.number ?? 1
-    });
-
-    return document.serialize();
+    return document
+      .addIndex({
+        requestPath: `/entities/v3/tasks${getStableRequestQuery(query)}`,
+        total,
+        pageNumber: query.page?.number ?? 1
+      })
+      .serialize();
   }
 
   @Get(":uuid")

--- a/apps/entity-service/src/forms/dto/linked-field-query.dto.ts
+++ b/apps/entity-service/src/forms/dto/linked-field-query.dto.ts
@@ -1,0 +1,11 @@
+import { FORM_TYPES, FormType } from "@terramatch-microservices/common/linkedFields/configuration";
+import { ApiProperty } from "@nestjs/swagger";
+import { IsArray, IsIn, IsOptional } from "class-validator";
+
+export class LinkedFieldQueryDto {
+  @ApiProperty({ enum: FORM_TYPES, isArray: true, required: false })
+  @IsOptional()
+  @IsArray()
+  @IsIn(FORM_TYPES, { each: true })
+  formTypes?: FormType[];
+}

--- a/apps/entity-service/src/forms/dto/linked-field.dto.ts
+++ b/apps/entity-service/src/forms/dto/linked-field.dto.ts
@@ -20,12 +20,12 @@ export class LinkedFieldDto {
   @ApiProperty({ enum: INPUT_TYPES })
   inputType: InputType;
 
-  @ApiProperty({ nullable: true })
+  @ApiProperty({ nullable: true, type: String })
   optionListKey: string | null;
 
-  @ApiProperty({ nullable: true })
+  @ApiProperty({ nullable: true, type: String })
   multiChoice: boolean | null;
 
-  @ApiProperty({ nullable: true })
+  @ApiProperty({ nullable: true, type: String })
   collection: string | null;
 }

--- a/apps/entity-service/src/forms/dto/linked-field.dto.ts
+++ b/apps/entity-service/src/forms/dto/linked-field.dto.ts
@@ -1,0 +1,31 @@
+import { JsonApiDto } from "@terramatch-microservices/common/decorators";
+import { ApiProperty } from "@nestjs/swagger";
+import { INPUT_TYPES, InputType } from "@terramatch-microservices/common/linkedFields/types";
+import { FORM_TYPES, FormType } from "@terramatch-microservices/common/linkedFields/configuration";
+
+@JsonApiDto({ type: "linkedFields", id: "string" })
+export class LinkedFieldDto {
+  @ApiProperty({ description: "Linked field id" })
+  id: string;
+
+  @ApiProperty({ enum: FORM_TYPES })
+  formType: FormType;
+
+  @ApiProperty()
+  label: string;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty({ enum: INPUT_TYPES })
+  inputType: InputType;
+
+  @ApiProperty({ nullable: true })
+  optionListKey: string | null;
+
+  @ApiProperty({ nullable: true })
+  multiChoice: boolean | null;
+
+  @ApiProperty({ nullable: true })
+  collection: string | null;
+}

--- a/apps/entity-service/src/forms/dto/option-label.dto.ts
+++ b/apps/entity-service/src/forms/dto/option-label.dto.ts
@@ -6,9 +6,12 @@ export class OptionLabelDto {
   @ApiProperty({ description: "Option label slug" })
   slug: string;
 
+  @ApiProperty({ nullable: true, type: String })
+  altValue: string | null;
+
   @ApiProperty({ description: "Option label text in requesting user's locale, if available" })
   label: string;
 
-  @ApiProperty({ description: "Option label text in English", nullable: true })
+  @ApiProperty({ description: "Option label text in English", type: String, nullable: true })
   imageUrl: string | null;
 }

--- a/apps/entity-service/src/forms/linked-fields.controller.ts
+++ b/apps/entity-service/src/forms/linked-fields.controller.ts
@@ -1,0 +1,62 @@
+import { Controller, Get, Query } from "@nestjs/common";
+import { ApiOperation } from "@nestjs/swagger";
+import { ExceptionResponse, JsonApiResponse } from "@terramatch-microservices/common/decorators";
+import { LinkedFieldDto } from "./dto/linked-field.dto";
+import { FormType, LinkedFieldsConfiguration } from "@terramatch-microservices/common/linkedFields/configuration";
+import { buildJsonApi, DocumentBuilder, getStableRequestQuery } from "@terramatch-microservices/common/util";
+import {
+  isField,
+  isRelation,
+  LinkedField,
+  LinkedFile,
+  LinkedRelation
+} from "@terramatch-microservices/common/linkedFields/types";
+import { populateDto } from "@terramatch-microservices/common/dto/json-api-attributes";
+import { isEmpty } from "lodash";
+import { BadRequestException } from "@nestjs/common/exceptions/bad-request.exception";
+import { LinkedFieldQueryDto } from "./dto/linked-field-query.dto";
+
+const fieldAdder =
+  (document: DocumentBuilder, formType: FormType, nameSuffix: string) =>
+  ([id, field]: [string, LinkedField | LinkedFile | LinkedRelation]) => {
+    document.addData(
+      id,
+      populateDto<LinkedFieldDto>(new LinkedFieldDto(), {
+        id,
+        formType,
+        label: field.label,
+        name: `${field.label}${nameSuffix}`,
+        inputType: field.inputType,
+        optionListKey: isField(field) ? field.optionListKey ?? null : null,
+        multiChoice: !isRelation(field) ? field.multiChoice ?? null : null,
+        collection: isRelation(field) ? field.collection ?? null : null
+      })
+    );
+  };
+
+@Controller("forms/v3/linkedFields")
+export class LinkedFieldsController {
+  @Get()
+  @ApiOperation({ operationId: "linkedFieldsIndex" })
+  @JsonApiResponse({ data: LinkedFieldDto, hasMany: true })
+  @ExceptionResponse(BadRequestException, { description: "None of the requested formTypes were found." })
+  async linkedFieldsIndex(@Query() { formTypes }: LinkedFieldQueryDto) {
+    formTypes ??= Object.keys(LinkedFieldsConfiguration) as FormType[];
+
+    const document = buildJsonApi(LinkedFieldDto, { forceDataArray: true });
+    for (const formType of formTypes) {
+      const configuration = LinkedFieldsConfiguration[formType];
+      if (configuration == null) continue;
+
+      const nameSuffix = ` (${configuration.label})`;
+      const addFields = fieldAdder(document, formType, nameSuffix);
+      Object.entries(configuration.fields).forEach(addFields);
+      Object.entries(configuration.fileCollections).forEach(addFields);
+      Object.entries(configuration.relations).forEach(addFields);
+    }
+
+    let requestPath = "/forms/v3/linkedFields";
+    if (!isEmpty(formTypes)) requestPath += getStableRequestQuery({ formTypes });
+    return document.addIndex({ requestPath });
+  }
+}

--- a/apps/entity-service/src/forms/option-labels.controller.spec.ts
+++ b/apps/entity-service/src/forms/option-labels.controller.spec.ts
@@ -1,11 +1,16 @@
 import { OptionLabelModel, OptionLabelsController } from "./option-labels.controller";
 import { Test } from "@nestjs/testing";
-import { FormOptionListOption, FormQuestion, User } from "@terramatch-microservices/database/entities";
-import { FormOptionListOptionFactory, FormQuestionOptionFactory } from "@terramatch-microservices/database/factories";
+import { FormOptionList, FormOptionListOption, FormQuestion, User } from "@terramatch-microservices/database/entities";
+import {
+  FormOptionListFactory,
+  FormOptionListOptionFactory,
+  FormQuestionOptionFactory
+} from "@terramatch-microservices/database/factories";
 import { faker } from "@faker-js/faker";
 import { ValidLocale } from "@terramatch-microservices/database/constants/locale";
 import { I18nTranslationFactory } from "@terramatch-microservices/database/factories/i18n-translation.factory";
 import { serialize } from "@terramatch-microservices/common/util/testing";
+import { NotFoundException } from "@nestjs/common";
 
 const mockLocale = (locale: ValidLocale) => {
   jest.spyOn(User, "findOne").mockResolvedValue({ locale } as User);
@@ -113,6 +118,44 @@ describe("OptionsLabelsController", () => {
           id: slug,
           type: "optionLabels",
           attributes: { slug, imageUrl: imageUrl ?? null, label: translation?.shortValue ?? translation?.longValue }
+        });
+      }
+    });
+  });
+
+  describe("findList", () => {
+    beforeEach(async () => {
+      await FormOptionListOption.truncate();
+      await FormOptionList.truncate();
+    });
+
+    it("should throw an error if listKey does not exist", async () => {
+      await expect(controller.findList("fake-list-key", { authenticatedUserId: 123 })).rejects.toThrow(
+        NotFoundException
+      );
+    });
+
+    it("should throw an error if the listKey has no associated options", async () => {
+      const { key } = await FormOptionListFactory.create();
+      await expect(controller.findList(key, { authenticatedUserId: 123 })).rejects.toThrow(NotFoundException);
+    });
+
+    it("should throw if no locale is found", async () => {
+      await expect(controller.findList("fake-list-key", { authenticatedUserId: -1 })).rejects.toThrow(
+        "Locale is required"
+      );
+    });
+
+    it("should return the options associated with the listKey", async () => {
+      const { key, id } = await FormOptionListFactory.create();
+      const options = await FormOptionListOptionFactory.createMany(5, { formOptionListId: id });
+      const document = serialize(await controller.findList(key, { authenticatedUserId: 123 }));
+      expect(document.data).toHaveLength(options.length);
+      for (const { slug, label, imageUrl } of options) {
+        expect(document.data).toContainEqual({
+          id: slug,
+          type: "optionLabels",
+          attributes: { slug, label, imageUrl: imageUrl ?? null }
         });
       }
     });

--- a/apps/entity-service/src/forms/option-labels.controller.spec.ts
+++ b/apps/entity-service/src/forms/option-labels.controller.spec.ts
@@ -63,7 +63,7 @@ describe("OptionsLabelsController", () => {
         expect(document.data).toContainEqual({
           id: slug,
           type: "optionLabels",
-          attributes: { slug, label, imageUrl: imageUrl ?? null }
+          attributes: { slug, label, imageUrl: imageUrl ?? null, altValue: null }
         });
       }
     });
@@ -85,7 +85,7 @@ describe("OptionsLabelsController", () => {
         expect(document.data).toContainEqual({
           id: slug,
           type: "optionLabels",
-          attributes: { slug, label, imageUrl: imageUrl ?? null }
+          attributes: { slug, label, imageUrl: imageUrl ?? null, altValue: null }
         });
       }
     });
@@ -117,7 +117,12 @@ describe("OptionsLabelsController", () => {
         expect(document.data).toContainEqual({
           id: slug,
           type: "optionLabels",
-          attributes: { slug, imageUrl: imageUrl ?? null, label: translation?.shortValue ?? translation?.longValue }
+          attributes: {
+            slug,
+            imageUrl: imageUrl ?? null,
+            label: translation?.shortValue ?? translation?.longValue,
+            altValue: null
+          }
         });
       }
     });
@@ -155,7 +160,7 @@ describe("OptionsLabelsController", () => {
         expect(document.data).toContainEqual({
           id: slug,
           type: "optionLabels",
-          attributes: { slug, label, imageUrl: imageUrl ?? null }
+          attributes: { slug, label, imageUrl: imageUrl ?? null, altValue: null }
         });
       }
     });

--- a/apps/entity-service/src/forms/option-labels.controller.spec.ts
+++ b/apps/entity-service/src/forms/option-labels.controller.spec.ts
@@ -5,6 +5,7 @@ import { FormOptionListOptionFactory, FormQuestionOptionFactory } from "@terrama
 import { faker } from "@faker-js/faker";
 import { ValidLocale } from "@terramatch-microservices/database/constants/locale";
 import { I18nTranslationFactory } from "@terramatch-microservices/database/factories/i18n-translation.factory";
+import { serialize } from "@terramatch-microservices/common/util/testing";
 
 const mockLocale = (locale: ValidLocale) => {
   jest.spyOn(User, "findOne").mockResolvedValue({ locale } as User);
@@ -47,9 +48,11 @@ describe("OptionsLabelsController", () => {
       await FormOptionListOptionFactory.create();
 
       mockLocale("en-US");
-      const document = await controller.optionLabelsIndex(options.map(({ slug }) => slug) as string[], {
-        authenticatedUserId: 123
-      });
+      const document = serialize(
+        await controller.optionLabelsIndex(options.map(({ slug }) => slug) as string[], {
+          authenticatedUserId: 123
+        })
+      );
       expect(document.data).toHaveLength(options.length);
       for (const { slug, label, imageUrl } of options) {
         expect(document.data).toContainEqual({
@@ -67,9 +70,11 @@ describe("OptionsLabelsController", () => {
       options.push((await FormQuestionOptionFactory.create()) as OptionLabelModel);
 
       mockLocale("en-US");
-      const document = await controller.optionLabelsIndex(options.map(({ slug }) => slug) as string[], {
-        authenticatedUserId: 123
-      });
+      const document = serialize(
+        await controller.optionLabelsIndex(options.map(({ slug }) => slug) as string[], {
+          authenticatedUserId: 123
+        })
+      );
       expect(document.data).toHaveLength(options.length);
       for (const { slug, label, imageUrl } of options) {
         expect(document.data).toContainEqual({
@@ -96,9 +101,11 @@ describe("OptionsLabelsController", () => {
       const translations = [translation1, translation2];
 
       mockLocale("es-MX");
-      const document = await controller.optionLabelsIndex(options.map(({ slug }) => slug) as string[], {
-        authenticatedUserId: 123
-      });
+      const document = serialize(
+        await controller.optionLabelsIndex(options.map(({ slug }) => slug) as string[], {
+          authenticatedUserId: 123
+        })
+      );
       expect(document.data).toHaveLength(options.length);
       for (const { slug, labelId, imageUrl } of options) {
         const translation = translations.find(({ i18nItemId }) => i18nItemId === labelId);

--- a/apps/entity-service/src/forms/option-labels.controller.ts
+++ b/apps/entity-service/src/forms/option-labels.controller.ts
@@ -15,7 +15,13 @@ import { buildJsonApi, DocumentBuilder, getStableRequestQuery } from "@terramatc
 import { populateDto } from "@terramatch-microservices/common/dto/json-api-attributes";
 import { ValidLocale } from "@terramatch-microservices/database/constants/locale";
 
-export type OptionLabelModel = { slug: string; label: string | null; labelId: number | null; imageUrl: string | null };
+export type OptionLabelModel = {
+  slug: string;
+  label: string | null;
+  labelId: number | null;
+  imageUrl: string | null;
+  altValue?: string | null;
+};
 
 @Controller("forms/v3/optionLabels")
 export class OptionLabelsController {
@@ -31,7 +37,7 @@ export class OptionLabelsController {
 
     const listOptions = (await FormOptionListOption.findAll({
       where: { slug: ids },
-      attributes: ["slug", "label", "labelId", "imageUrl"]
+      attributes: ["slug", "label", "labelId", "imageUrl", "altValue"]
     })) as OptionLabelModel[];
 
     const missingSlugs = filter(ids, slug => !listOptions.some(option => option.slug === slug));
@@ -70,7 +76,7 @@ export class OptionLabelsController {
       include: [
         {
           association: "listOptions",
-          attributes: ["slug", "label", "labelId", "imageUrl"]
+          attributes: ["slug", "label", "labelId", "imageUrl", "altValue"]
         }
       ]
     });
@@ -110,7 +116,8 @@ export class OptionLabelsController {
             translations[labelModel.labelId ?? ""]?.[0]?.shortValue ??
             translations[labelModel.labelId ?? ""]?.[0]?.longValue ??
             labelModel.label ??
-            ""
+            "",
+          altValue: labelModel.altValue ?? null
         })
       );
     });

--- a/apps/entity-service/src/forms/option-labels.controller.ts
+++ b/apps/entity-service/src/forms/option-labels.controller.ts
@@ -10,7 +10,7 @@ import {
   I18nTranslation,
   User
 } from "@terramatch-microservices/database/entities";
-import { buildJsonApi, getDtoType, getStableRequestQuery } from "@terramatch-microservices/common/util";
+import { buildJsonApi, getStableRequestQuery } from "@terramatch-microservices/common/util";
 import { populateDto } from "@terramatch-microservices/common/dto/json-api-attributes";
 import { ValidLocale } from "@terramatch-microservices/database/constants/locale";
 
@@ -48,19 +48,11 @@ export class OptionLabelsController {
 
     const options = uniqBy([...listOptions, ...formQuestions], "slug");
     const document = buildJsonApi<OptionLabelDto>(OptionLabelDto, { forceDataArray: true });
-    const indexIds: string[] = [];
     for (const dto of await this.getOptionLabelDtos(options, locale)) {
-      indexIds.push(dto.slug);
       document.addData(dto.slug, dto);
     }
 
-    document.addIndexData({
-      resource: getDtoType(OptionLabelDto),
-      requestPath: `/forms/v3/optionLabels${getStableRequestQuery({ ids })}`,
-      ids: indexIds
-    });
-
-    return document.serialize();
+    return document.addIndex({ requestPath: `/forms/v3/optionLabels${getStableRequestQuery({ ids })}` }).serialize();
   }
 
   private async getOptionLabelDtos(listOptions: OptionLabelModel[], locale: ValidLocale) {

--- a/apps/entity-service/src/forms/option-labels.controller.ts
+++ b/apps/entity-service/src/forms/option-labels.controller.ts
@@ -52,7 +52,7 @@ export class OptionLabelsController {
       document.addData(dto.slug, dto);
     }
 
-    return document.addIndex({ requestPath: `/forms/v3/optionLabels${getStableRequestQuery({ ids })}` }).serialize();
+    return document.addIndex({ requestPath: `/forms/v3/optionLabels${getStableRequestQuery({ ids })}` });
   }
 
   private async getOptionLabelDtos(listOptions: OptionLabelModel[], locale: ValidLocale) {

--- a/apps/entity-service/src/main.ts
+++ b/apps/entity-service/src/main.ts
@@ -7,6 +7,7 @@ import { AppModule } from "./app.module";
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 import { TMLogger } from "@terramatch-microservices/common/util/tm-logger";
 import { NestExpressApplication } from "@nestjs/platform-express";
+import { DocumentBuilderInterceptor } from "@terramatch-microservices/common/util/document-builder-interceptor";
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
@@ -35,6 +36,8 @@ async function bootstrap() {
       transformOptions: { enableImplicitConversion: true, exposeDefaultValues: true }
     })
   );
+
+  app.useGlobalInterceptors(new DocumentBuilderInterceptor());
 
   const port = process.env.NODE_ENV === "production" ? 80 : process.env.ENTITY_SERVICE_PORT ?? 4050;
   await app.listen(port);

--- a/apps/entity-service/src/trees/trees.controller.spec.ts
+++ b/apps/entity-service/src/trees/trees.controller.spec.ts
@@ -6,6 +6,7 @@ import { BadRequestException, NotFoundException, UnauthorizedException } from "@
 import { Resource } from "@terramatch-microservices/common/util";
 import { PolicyService } from "@terramatch-microservices/common";
 import { ProjectFactory, SiteFactory, SiteReportFactory } from "@terramatch-microservices/database/factories";
+import { serialize } from "@terramatch-microservices/common/util/testing";
 
 describe("TreesController", () => {
   let controller: TreesController;
@@ -40,7 +41,7 @@ describe("TreesController", () => {
         { taxonId: "wfo-0000002583", scientificName: "Cirsium carolinianum" },
         { taxonId: "wfo-0000003963", scientificName: "Cirsium carniolicum" }
       ]);
-      const result = await controller.searchScientificNames("cirs");
+      const result = serialize(await controller.searchScientificNames("cirs"));
       expect(treeService.searchScientificNames).toHaveBeenCalledWith("cirs");
       const data = result.data as Resource[];
       expect(data.length).toBe(2);
@@ -69,7 +70,7 @@ describe("TreesController", () => {
       treeService.getEstablishmentTrees.mockResolvedValue({ "non-tree": ["Coffee", "Banana"] });
       treeService.getPreviousPlanting.mockResolvedValue(stubData);
       const { uuid } = await SiteReportFactory.create();
-      const result = await controller.getEstablishmentData({ entity: "siteReports", uuid });
+      const result = serialize(await controller.getEstablishmentData({ entity: "siteReports", uuid }));
       expect(treeService.getEstablishmentTrees).toHaveBeenCalledWith("siteReports", uuid);
       expect(treeService.getPreviousPlanting).toHaveBeenCalledWith("siteReports", uuid);
       const resource = result.data as Resource;
@@ -96,7 +97,7 @@ describe("TreesController", () => {
       treeService.getEstablishmentTrees.mockResolvedValue({ "non-tree": ["Coffee", "Banana"] });
       treeService.getAssociatedReportCounts.mockResolvedValue(stubData);
       const { uuid } = await SiteFactory.create();
-      const result = await controller.getReportCounts({ entity: "sites", uuid });
+      const result = serialize(await controller.getReportCounts({ entity: "sites", uuid }));
       expect(treeService.getEstablishmentTrees).toHaveBeenCalledWith("sites", uuid);
       expect(treeService.getAssociatedReportCounts).toHaveBeenCalledWith("sites", uuid);
       const resource = result.data as Resource;
@@ -108,7 +109,7 @@ describe("TreesController", () => {
     it("should skip establishment for a non-establishment type", async () => {
       treeService.getAssociatedReportCounts.mockResolvedValue({ "tree-planted": { Acacia: { amount: 123 } } });
       const { uuid } = await ProjectFactory.create();
-      const result = await controller.getReportCounts({ entity: "projects", uuid });
+      const result = serialize(await controller.getReportCounts({ entity: "projects", uuid }));
       expect(treeService.getEstablishmentTrees).not.toHaveBeenCalled();
       expect((result.data as Resource).attributes.establishmentTrees).toBeUndefined();
     });
@@ -116,7 +117,7 @@ describe("TreesController", () => {
     it("should skip report counts for a non-report-counts type", async () => {
       treeService.getEstablishmentTrees.mockResolvedValue({ "tree-planted": ["Acacia"] });
       const { uuid } = await SiteReportFactory.create();
-      const result = await controller.getReportCounts({ entity: "siteReports", uuid });
+      const result = serialize(await controller.getReportCounts({ entity: "siteReports", uuid }));
       expect(treeService.getAssociatedReportCounts).not.toHaveBeenCalled();
       expect((result.data as Resource).attributes.reportCounts).toBeUndefined();
     });

--- a/apps/entity-service/src/trees/trees.controller.ts
+++ b/apps/entity-service/src/trees/trees.controller.ts
@@ -8,7 +8,7 @@ import {
   UnauthorizedException
 } from "@nestjs/common";
 import { isEstablishmentEntity, isReportCountEntity, TreeService } from "./tree.service";
-import { buildJsonApi, getDtoType, getStableRequestQuery } from "@terramatch-microservices/common/util";
+import { buildJsonApi, getStableRequestQuery } from "@terramatch-microservices/common/util";
 import { ScientificNameDto } from "./dto/scientific-name.dto";
 import { ApiExtraModels, ApiOperation } from "@nestjs/swagger";
 import { ExceptionResponse, JsonApiResponse } from "@terramatch-microservices/common/decorators";
@@ -38,19 +38,13 @@ export class TreesController {
     if (isEmpty(search)) throw new BadRequestException("search query param is required");
 
     const document = buildJsonApi(ScientificNameDto, { forceDataArray: true });
-    const indexIds: string[] = [];
     for (const treeSpecies of await this.treeService.searchScientificNames(search)) {
-      indexIds.push(treeSpecies.taxonId);
       document.addData(treeSpecies.taxonId, populateDto(new ScientificNameDto(), treeSpecies));
     }
 
-    document.addIndexData({
-      resource: getDtoType(ScientificNameDto),
-      requestPath: `/trees/v3/scientificNames${getStableRequestQuery({ search })}`,
-      ids: indexIds
-    });
-
-    return document.serialize();
+    return document
+      .addIndex({ requestPath: `/trees/v3/scientificNames${getStableRequestQuery({ search })}` })
+      .serialize();
   }
 
   @Get("establishments/:entity/:uuid")

--- a/apps/entity-service/src/trees/trees.controller.ts
+++ b/apps/entity-service/src/trees/trees.controller.ts
@@ -42,9 +42,7 @@ export class TreesController {
       document.addData(treeSpecies.taxonId, populateDto(new ScientificNameDto(), treeSpecies));
     }
 
-    return document
-      .addIndex({ requestPath: `/trees/v3/scientificNames${getStableRequestQuery({ search })}` })
-      .serialize();
+    return document.addIndex({ requestPath: `/trees/v3/scientificNames${getStableRequestQuery({ search })}` });
   }
 
   @Get("establishments/:entity/:uuid")
@@ -63,12 +61,10 @@ export class TreesController {
 
     // The ID for this DTO is formed of "entityType|entityUuid". This is a virtual resource, not directly
     // backed by a single DB table.
-    return buildJsonApi(EstablishmentsTreesDto)
-      .addData(
-        `${entity}|${uuid}`,
-        populateDto(new EstablishmentsTreesDto(), { establishmentTrees, previousPlantingCounts })
-      )
-      .document.serialize();
+    return buildJsonApi(EstablishmentsTreesDto).addData(
+      `${entity}|${uuid}`,
+      populateDto(new EstablishmentsTreesDto(), { establishmentTrees, previousPlantingCounts })
+    );
   }
 
   @Get("reportCounts/:entity/:uuid")
@@ -91,9 +87,10 @@ export class TreesController {
 
     // The ID for this DTO is formed of "entityType|entityUuid". This is a virtual resource, not directly
     // backed by a single DB table.
-    return buildJsonApi(TreeReportCountsDto)
-      .addData(`${entity}|${uuid}`, populateDto(new TreeReportCountsDto(), { establishmentTrees, reportCounts }))
-      .document.serialize();
+    return buildJsonApi(TreeReportCountsDto).addData(
+      `${entity}|${uuid}`,
+      populateDto(new TreeReportCountsDto(), { establishmentTrees, reportCounts })
+    );
   }
 
   private async authorizeRead(entity: EntityType, uuid: string) {

--- a/apps/job-service/src/jobs/delayed-jobs.controller.spec.ts
+++ b/apps/job-service/src/jobs/delayed-jobs.controller.spec.ts
@@ -7,6 +7,7 @@ import { v4 as uuidv4 } from "uuid";
 import { NotFoundException } from "@nestjs/common";
 import { plainToClass } from "class-transformer";
 import { validate } from "class-validator";
+import { serialize } from "@terramatch-microservices/common/util/testing";
 
 describe("DelayedJobsController", () => {
   let controller: DelayedJobsController;
@@ -40,7 +41,7 @@ describe("DelayedJobsController", () => {
       } as DelayedJob);
 
       const request = { authenticatedUserId };
-      const result = await controller.getRunningJobs(request);
+      const result = serialize(await controller.getRunningJobs(request));
 
       const data = Array.isArray(result.data) ? result.data : [result.data];
 
@@ -60,7 +61,7 @@ describe("DelayedJobsController", () => {
       } as DelayedJob);
 
       const request = { authenticatedUserId };
-      const result = await controller.getRunningJobs(request);
+      const result = serialize(await controller.getRunningJobs(request));
 
       const data = Array.isArray(result.data) ? result.data : [result.data];
 
@@ -83,7 +84,7 @@ describe("DelayedJobsController", () => {
       } as DelayedJob);
 
       const request = { authenticatedUserId };
-      const result = await controller.getRunningJobs(request);
+      const result = serialize(await controller.getRunningJobs(request));
 
       const data = Array.isArray(result.data) ? result.data : [result.data];
 
@@ -106,7 +107,7 @@ describe("DelayedJobsController", () => {
         metadata: { entity_name: "TestEntity" } // Adding entity_name
       } as DelayedJob);
 
-      const result = await controller.findOne(job.uuid);
+      const result = serialize(await controller.findOne(job.uuid));
       const jobData = Array.isArray(result.data) ? result.data[0] : result.data;
       expect(jobData?.id).toBe(job.uuid);
     });
@@ -153,7 +154,7 @@ describe("DelayedJobsController", () => {
 
       const request = { authenticatedUserId };
 
-      const result = await controller.bulkUpdateJobs(payload, request);
+      const result = serialize(await controller.bulkUpdateJobs(payload, request));
       expect(result.data).toHaveLength(2);
       expect(result.data![0].id).toBe(job.uuid);
       expect(result.data![0].attributes.entityName).toBeUndefined();
@@ -197,7 +198,7 @@ describe("DelayedJobsController", () => {
 
       const request = { authenticatedUserId };
 
-      const result = await controller.bulkUpdateJobs(payload, request);
+      const result = serialize(await controller.bulkUpdateJobs(payload, request));
       expect(result.data).toHaveLength(2);
       expect(result.data![0].id).toBe(job1.uuid);
       expect(result.data![1].id).toBe(job2.uuid);
@@ -259,7 +260,7 @@ describe("DelayedJobsController", () => {
       };
       const request = { authenticatedUserId };
 
-      const result = await controller.bulkUpdateJobs(payload, request);
+      const result = serialize(await controller.bulkUpdateJobs(payload, request));
       expect(result.data).toHaveLength(2);
       expect(result.data![0].id).toBe(pendingJob.uuid);
       expect(result.data![0].attributes.entityName).toBe("TestEntityPending");

--- a/apps/job-service/src/jobs/delayed-jobs.controller.ts
+++ b/apps/job-service/src/jobs/delayed-jobs.controller.ts
@@ -12,7 +12,7 @@ import {
 import { ApiOperation } from "@nestjs/swagger";
 import { Op } from "sequelize";
 import { ExceptionResponse, JsonApiResponse } from "@terramatch-microservices/common/decorators";
-import { buildJsonApi, getDtoType, JsonApiDocument } from "@terramatch-microservices/common/util";
+import { buildJsonApi, JsonApiDocument } from "@terramatch-microservices/common/util";
 import { DelayedJob } from "@terramatch-microservices/database/entities";
 import { DelayedJobBulkUpdateBodyDto } from "./dto/delayed-job-update.dto";
 import { populateDto } from "@terramatch-microservices/common/dto/json-api-attributes";
@@ -44,13 +44,10 @@ export class DelayedJobsController {
     );
 
     const document = buildJsonApi(DelayedJobDto, { forceDataArray: true });
-    const indexIds: string[] = [];
     jobsWithEntityNames.forEach(job => {
-      indexIds.push(job.uuid);
       document.addData(job.uuid, populateDto(new DelayedJobDto(), job));
     });
-    document.addIndexData({ resource: getDtoType(DelayedJobDto), requestPath: "/jobs/v3/delayedJobs", ids: indexIds });
-    return document.serialize();
+    return document.addIndex({ requestPath: "/jobs/v3/delayedJobs" }).serialize();
   }
 
   @Get(":uuid")

--- a/apps/job-service/src/jobs/delayed-jobs.controller.ts
+++ b/apps/job-service/src/jobs/delayed-jobs.controller.ts
@@ -12,7 +12,7 @@ import {
 import { ApiOperation } from "@nestjs/swagger";
 import { Op } from "sequelize";
 import { ExceptionResponse, JsonApiResponse } from "@terramatch-microservices/common/decorators";
-import { buildJsonApi, JsonApiDocument } from "@terramatch-microservices/common/util";
+import { buildJsonApi } from "@terramatch-microservices/common/util";
 import { DelayedJob } from "@terramatch-microservices/database/entities";
 import { DelayedJobBulkUpdateBodyDto } from "./dto/delayed-job-update.dto";
 import { populateDto } from "@terramatch-microservices/common/dto/json-api-attributes";
@@ -27,7 +27,7 @@ export class DelayedJobsController {
   })
   @JsonApiResponse({ data: DelayedJobDto, hasMany: true })
   @ExceptionResponse(UnauthorizedException, { description: "Authentication failed." })
-  async getRunningJobs(@Request() { authenticatedUserId }): Promise<JsonApiDocument> {
+  async getRunningJobs(@Request() { authenticatedUserId }) {
     const runningJobs = await DelayedJob.findAll({
       where: {
         isAcknowledged: false,
@@ -47,7 +47,7 @@ export class DelayedJobsController {
     jobsWithEntityNames.forEach(job => {
       document.addData(job.uuid, populateDto(new DelayedJobDto(), job));
     });
-    return document.addIndex({ requestPath: "/jobs/v3/delayedJobs" }).serialize();
+    return document.addIndex({ requestPath: "/jobs/v3/delayedJobs" });
   }
 
   @Get(":uuid")
@@ -61,11 +61,11 @@ export class DelayedJobsController {
   // Note: Since jobs are very generic and we don't track which resources are related to a given
   // job, there is no effective way to make a policy for jobs until we expand the service to
   // include an owner ID on the job table.
-  async findOne(@Param("uuid") pathUUID: string): Promise<JsonApiDocument> {
+  async findOne(@Param("uuid") pathUUID: string) {
     const job = await DelayedJob.findOne({ where: { uuid: pathUUID } });
     if (job == null) throw new NotFoundException();
 
-    return buildJsonApi(DelayedJobDto).addData(pathUUID, populateDto(new DelayedJobDto(), job)).document.serialize();
+    return buildJsonApi(DelayedJobDto).addData(pathUUID, populateDto(new DelayedJobDto(), job));
   }
 
   @Patch("bulk-update")
@@ -80,10 +80,7 @@ export class DelayedJobsController {
   @ExceptionResponse(NotFoundException, {
     description: "One or more jobs specified in the payload could not be found."
   })
-  async bulkUpdateJobs(
-    @Body() bulkUpdateJobsDto: DelayedJobBulkUpdateBodyDto,
-    @Request() { authenticatedUserId }
-  ): Promise<JsonApiDocument> {
+  async bulkUpdateJobs(@Body() bulkUpdateJobsDto: DelayedJobBulkUpdateBodyDto, @Request() { authenticatedUserId }) {
     const jobUpdates = bulkUpdateJobsDto.data;
     const jobs = await DelayedJob.findAll({
       where: {
@@ -116,6 +113,6 @@ export class DelayedJobsController {
       jsonApiBuilder.addData(job.uuid, populateDto(new DelayedJobDto(), job));
     });
 
-    return jsonApiBuilder.serialize();
+    return jsonApiBuilder;
   }
 }

--- a/apps/job-service/src/main.ts
+++ b/apps/job-service/src/main.ts
@@ -8,6 +8,7 @@ import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 import { TMLogger } from "@terramatch-microservices/common/util/tm-logger";
 import { AppModule } from "./app.module";
 import { NestExpressApplication } from "@nestjs/platform-express";
+import { DocumentBuilderInterceptor } from "@terramatch-microservices/common/util/document-builder-interceptor";
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
@@ -35,6 +36,8 @@ async function bootstrap() {
       transformOptions: { enableImplicitConversion: true, exposeDefaultValues: true }
     })
   );
+
+  app.useGlobalInterceptors(new DocumentBuilderInterceptor());
 
   const port = process.env.NODE_ENV === "production" ? 80 : process.env.JOB_SERVICE_PORT ?? 4020;
   await app.listen(port);

--- a/apps/research-service/src/bounding-boxes/bounding-box.controller.spec.ts
+++ b/apps/research-service/src/bounding-boxes/bounding-box.controller.spec.ts
@@ -3,10 +3,10 @@ import { BoundingBoxController } from "./bounding-box.controller";
 import { BoundingBoxService } from "./bounding-box.service";
 import { BoundingBoxDto } from "./dto/bounding-box.dto";
 import { BoundingBoxQueryDto } from "./dto/bounding-box-query.dto";
-import { JsonApiDocument } from "@terramatch-microservices/common/util";
 import { BadRequestException, NotFoundException } from "@nestjs/common";
-import { PolygonGeometry, Project, Site, SitePolygon, ProjectPitch } from "@terramatch-microservices/database/entities";
+import { PolygonGeometry, Project, ProjectPitch, Site, SitePolygon } from "@terramatch-microservices/database/entities";
 import { populateDto } from "@terramatch-microservices/common/dto/json-api-attributes";
+import { serialize } from "@terramatch-microservices/common/util/testing";
 
 jest.mock("@terramatch-microservices/database/util/subquery.builder", () => ({
   Subquery: {
@@ -106,7 +106,7 @@ describe("BoundingBoxController", () => {
       expectedArgs: BoundingBoxServiceArgs,
       expectedId: string
     ) => {
-      const result = (await controller.getBoundingBox(queryParams)) as JsonApiDocument;
+      const result = serialize(await controller.getBoundingBox(queryParams));
 
       expect(mockBoundingBoxService[expectedService]).toHaveBeenCalledWith(...expectedArgs);
 

--- a/apps/research-service/src/bounding-boxes/bounding-box.controller.ts
+++ b/apps/research-service/src/bounding-boxes/bounding-box.controller.ts
@@ -1,13 +1,13 @@
-import { Controller, Get, Query, BadRequestException, NotFoundException } from "@nestjs/common";
-import { ApiTags, ApiOperation } from "@nestjs/swagger";
+import { BadRequestException, Controller, Get, NotFoundException, Query } from "@nestjs/common";
+import { ApiOperation, ApiTags } from "@nestjs/swagger";
 import { BoundingBoxService } from "./bounding-box.service";
 import { BoundingBoxQueryDto } from "./dto/bounding-box-query.dto";
 import { BoundingBoxDto } from "./dto/bounding-box.dto";
 import { ExceptionResponse, JsonApiResponse } from "@terramatch-microservices/common/decorators";
 import { NoBearerAuth } from "@terramatch-microservices/common/guards";
-import { buildJsonApi, getStableRequestQuery, JsonApiDocument } from "@terramatch-microservices/common/util";
+import { buildJsonApi, getStableRequestQuery } from "@terramatch-microservices/common/util";
 import { isEmpty } from "lodash";
-import { Project, Site, LandscapeGeometry, ProjectPitch } from "@terramatch-microservices/database/entities";
+import { LandscapeGeometry, Project, ProjectPitch, Site } from "@terramatch-microservices/database/entities";
 
 type ParameterType = "polygonUuid" | "siteUuid" | "projectUuid" | "projectPitchUuid" | "country/landscapes";
 
@@ -29,7 +29,7 @@ export class BoundingBoxController {
   @ExceptionResponse(NotFoundException, {
     description: "Requested resource not found"
   })
-  async getBoundingBox(@Query() query: BoundingBoxQueryDto): Promise<JsonApiDocument> {
+  async getBoundingBox(@Query() query: BoundingBoxQueryDto) {
     const providedParams: ParameterType[] = [];
 
     if (!isEmpty(query.polygonUuid)) {
@@ -70,8 +70,10 @@ export class BoundingBoxController {
     const id = getStableRequestQuery(query);
     switch (providedParams[0]) {
       case "polygonUuid": {
-        const result = await this.boundingBoxService.getPolygonBoundingBox(query.polygonUuid ?? "");
-        return buildJsonApi(BoundingBoxDto).addData(id, result).document.serialize();
+        return buildJsonApi(BoundingBoxDto).addData(
+          id,
+          await this.boundingBoxService.getPolygonBoundingBox(query.polygonUuid ?? "")
+        );
       }
 
       case "siteUuid": {
@@ -86,8 +88,7 @@ export class BoundingBoxController {
           throw new NotFoundException(`Site with UUID ${siteUuid} not found`);
         }
 
-        const result = await this.boundingBoxService.getSiteBoundingBox(siteUuid);
-        return buildJsonApi(BoundingBoxDto).addData(id, result).document.serialize();
+        return buildJsonApi(BoundingBoxDto).addData(id, await this.boundingBoxService.getSiteBoundingBox(siteUuid));
       }
 
       case "projectUuid": {
@@ -102,8 +103,10 @@ export class BoundingBoxController {
           throw new NotFoundException(`Project with UUID ${projectUuid} not found`);
         }
 
-        const result = await this.boundingBoxService.getProjectBoundingBox(projectUuid);
-        return buildJsonApi(BoundingBoxDto).addData(id, result).document.serialize();
+        return buildJsonApi(BoundingBoxDto).addData(
+          id,
+          await this.boundingBoxService.getProjectBoundingBox(projectUuid)
+        );
       }
 
       case "projectPitchUuid": {
@@ -118,8 +121,10 @@ export class BoundingBoxController {
           throw new NotFoundException(`Project pitch with UUID ${projectPitchUuid} not found`);
         }
 
-        const result = await this.boundingBoxService.getProjectPitchBoundingBox(projectPitchUuid);
-        return buildJsonApi(BoundingBoxDto).addData(id, result).document.serialize();
+        return buildJsonApi(BoundingBoxDto).addData(
+          id,
+          await this.boundingBoxService.getProjectPitchBoundingBox(projectPitchUuid)
+        );
       }
 
       case "country/landscapes": {
@@ -140,8 +145,10 @@ export class BoundingBoxController {
           }
         }
 
-        const result = await this.boundingBoxService.getCountryLandscapeBoundingBox(country ?? "", landscapes);
-        return buildJsonApi(BoundingBoxDto).addData(id, result).document.serialize();
+        return buildJsonApi(BoundingBoxDto).addData(
+          id,
+          await this.boundingBoxService.getCountryLandscapeBoundingBox(country ?? "", landscapes)
+        );
       }
     }
   }

--- a/apps/research-service/src/main.ts
+++ b/apps/research-service/src/main.ts
@@ -8,6 +8,7 @@ import { AppModule } from "./app.module";
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 import { TMLogger } from "@terramatch-microservices/common/util/tm-logger";
 import { NestExpressApplication } from "@nestjs/platform-express";
+import { DocumentBuilderInterceptor } from "@terramatch-microservices/common/util/document-builder-interceptor";
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
@@ -35,6 +36,8 @@ async function bootstrap() {
       transformOptions: { enableImplicitConversion: true, exposeDefaultValues: true }
     })
   );
+
+  app.useGlobalInterceptors(new DocumentBuilderInterceptor());
 
   const port = process.env.NODE_ENV === "production" ? 80 : process.env.RESEARCH_SERVICE_PROXY_PORT ?? 4030;
   await app.listen(port);

--- a/apps/research-service/src/site-polygons/site-polygons.controller.spec.ts
+++ b/apps/research-service/src/site-polygons/site-polygons.controller.spec.ts
@@ -12,6 +12,7 @@ import { SitePolygonBulkUpdateBodyDto } from "./dto/site-polygon-update.dto";
 import { Transaction } from "sequelize";
 import { SitePolygonFullDto, SitePolygonLightDto } from "./dto/site-polygon.dto";
 import { LandscapeSlug } from "@terramatch-microservices/database/types/landscapeGeometry";
+import { serialize } from "@terramatch-microservices/common/util/testing";
 
 describe("SitePolygonsController", () => {
   let controller: SitePolygonsController;
@@ -126,7 +127,7 @@ describe("SitePolygonsController", () => {
       policyService.authorize.mockResolvedValue(undefined);
       const sitePolygon = await SitePolygonFactory.build();
       mockQueryBuilder([sitePolygon], 1);
-      const result = await controller.findMany({});
+      const result = serialize(await controller.findMany({}));
       expect(result.meta).not.toBe(null);
       expect(result.meta!.indices?.[0].total).toBe(1);
       expect(result.meta!.indices?.[0].cursor).toBe(sitePolygon.uuid);
@@ -140,7 +141,7 @@ describe("SitePolygonsController", () => {
       policyService.authorize.mockResolvedValue(undefined);
       const sitePolygon = await SitePolygonFactory.build();
       mockQueryBuilder([sitePolygon], 1);
-      const result = await controller.findMany({ page: { size: 5, number: 1 } });
+      const result = serialize(await controller.findMany({ page: { size: 5, number: 1 } }));
       expect(result.meta).not.toBe(null);
       expect(result.meta!.indices?.[0].total).toBe(1);
       expect(result.meta!.indices?.[0].pageNumber).toBe(1);
@@ -153,7 +154,7 @@ describe("SitePolygonsController", () => {
     it("should exclude test projects by default", async () => {
       policyService.authorize.mockResolvedValue(undefined);
       const builder = mockQueryBuilder();
-      const result = await controller.findMany({});
+      const result = serialize(await controller.findMany({}));
       expect(result.meta?.indices?.[0].total).toBe(0);
 
       expect(builder.excludeTestProjects).toHaveBeenCalled();
@@ -217,10 +218,12 @@ describe("SitePolygonsController", () => {
 
       mockQueryBuilder([poly1, poly2], 2);
 
-      const result = await controller.findMany({
-        validationStatus: ["passed", "not_checked"],
-        page: { size: 10, number: 1 }
-      });
+      const result = serialize(
+        await controller.findMany({
+          validationStatus: ["passed", "not_checked"],
+          page: { size: 10, number: 1 }
+        })
+      );
       expect(result.data).toHaveLength(2);
     });
     it("should throw BadRequestException when lightResource is true and pagination is not number-based", async () => {

--- a/apps/research-service/src/site-polygons/site-polygons.controller.ts
+++ b/apps/research-service/src/site-polygons/site-polygons.controller.ts
@@ -8,7 +8,7 @@ import {
   Query,
   UnauthorizedException
 } from "@nestjs/common";
-import { buildJsonApi, getStableRequestQuery, IndexData, JsonApiDocument } from "@terramatch-microservices/common/util";
+import { buildJsonApi, getStableRequestQuery, IndexData } from "@terramatch-microservices/common/util";
 import { ApiExtraModels, ApiOkResponse, ApiOperation } from "@nestjs/swagger";
 import { ExceptionResponse, JsonApiResponse } from "@terramatch-microservices/common/decorators";
 import { SitePolygonFullDto, SitePolygonLightDto } from "./dto/site-polygon.dto";
@@ -52,7 +52,7 @@ export class SitePolygonsController {
   ])
   @ExceptionResponse(UnauthorizedException, { description: "Authentication failed." })
   @ExceptionResponse(BadRequestException, { description: "One or more query param values is invalid." })
-  async findMany(@Query() query: SitePolygonQueryDto): Promise<JsonApiDocument> {
+  async findMany(@Query() query: SitePolygonQueryDto) {
     await this.policyService.authorize("readAll", SitePolygon);
 
     const {
@@ -185,7 +185,7 @@ export class SitePolygonsController {
     };
     if (isNumberPage(query.page)) indexData.pageNumber = query.page.number;
     else indexData.cursor = cursor;
-    return document.addIndex(indexData).serialize();
+    return document.addIndex(indexData);
   }
 
   @Patch()

--- a/apps/research-service/src/site-polygons/site-polygons.controller.ts
+++ b/apps/research-service/src/site-polygons/site-polygons.controller.ts
@@ -8,13 +8,7 @@ import {
   Query,
   UnauthorizedException
 } from "@nestjs/common";
-import {
-  buildJsonApi,
-  getDtoType,
-  getStableRequestQuery,
-  IndexData,
-  JsonApiDocument
-} from "@terramatch-microservices/common/util";
+import { buildJsonApi, getStableRequestQuery, IndexData, JsonApiDocument } from "@terramatch-microservices/common/util";
 import { ApiExtraModels, ApiOkResponse, ApiOperation } from "@nestjs/swagger";
 import { ExceptionResponse, JsonApiResponse } from "@terramatch-microservices/common/decorators";
 import { SitePolygonFullDto, SitePolygonLightDto } from "./dto/site-polygon.dto";
@@ -166,12 +160,12 @@ export class SitePolygonsController {
 
     const dtoType = lightResource ? SitePolygonLightDto : SitePolygonFullDto;
 
-    const indexIds: string[] = [];
     const document = buildJsonApi(dtoType, { pagination: isNumberPage(query.page) ? "number" : "cursor" });
     const sitePolygons = await queryBuilder.execute();
     const associations = await this.sitePolygonService.loadAssociationDtos(sitePolygons, lightResource ?? false);
+    let cursor: string | undefined = undefined;
     for (const sitePolygon of sitePolygons) {
-      indexIds.push(sitePolygon.uuid);
+      if (cursor == null) cursor = sitePolygon.uuid;
       if (lightResource) {
         document.addData(
           sitePolygon.uuid,
@@ -185,17 +179,13 @@ export class SitePolygonsController {
       }
     }
 
-    const indexData: IndexData = {
-      resource: getDtoType(dtoType),
+    const indexData: Partial<IndexData> & { requestPath: string } = {
       requestPath: `/research/v3/sitePolygons${getStableRequestQuery(query)}`,
-      ids: indexIds,
       total: await queryBuilder.paginationTotal()
     };
     if (isNumberPage(query.page)) indexData.pageNumber = query.page.number;
-    else indexData.cursor = indexIds[0];
-    document.addIndexData(indexData);
-
-    return document.serialize();
+    else indexData.cursor = cursor;
+    return document.addIndex(indexData).serialize();
   }
 
   @Patch()

--- a/apps/unified-database-service/src/main.ts
+++ b/apps/unified-database-service/src/main.ts
@@ -8,6 +8,7 @@ import { AppModule } from "./app.module";
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 import { TMLogger } from "@terramatch-microservices/common/util/tm-logger";
 import { NestExpressApplication } from "@nestjs/platform-express";
+import { DocumentBuilderInterceptor } from "@terramatch-microservices/common/util/document-builder-interceptor";
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
@@ -35,6 +36,8 @@ async function bootstrap() {
       transformOptions: { enableImplicitConversion: true, exposeDefaultValues: true }
     })
   );
+
+  app.useGlobalInterceptors(new DocumentBuilderInterceptor());
 
   const port = process.env.NODE_ENV === "production" ? 80 : process.env.UNIFIED_DATABASE_SERVICE_PORT ?? 4040;
   await app.listen(port);

--- a/apps/user-service/src/auth/login.controller.spec.ts
+++ b/apps/user-service/src/auth/login.controller.spec.ts
@@ -4,6 +4,7 @@ import { AuthService } from "./auth.service";
 import { createMock, DeepMocked } from "@golevelup/ts-jest";
 import { UnauthorizedException } from "@nestjs/common";
 import { faker } from "@faker-js/faker";
+import { serialize } from "@terramatch-microservices/common/util/testing";
 
 describe("LoginController", () => {
   let controller: LoginController;
@@ -37,9 +38,11 @@ describe("LoginController", () => {
     const userUuid = faker.string.uuid();
     authService.login.mockResolvedValue({ token, userUuid });
 
-    const result = await controller.create({
-      data: { type: "logins", attributes: { emailAddress: "foo@bar.com", password: "asdfasdfasdf" } }
-    });
+    const result = serialize(
+      await controller.create({
+        data: { type: "logins", attributes: { emailAddress: "foo@bar.com", password: "asdfasdfasdf" } }
+      })
+    );
     expect(result).toMatchObject({ data: { id: userUuid, type: "logins", attributes: { token } } });
   });
 });

--- a/apps/user-service/src/auth/login.controller.ts
+++ b/apps/user-service/src/auth/login.controller.ts
@@ -31,6 +31,6 @@ export class LoginController {
       throw new UnauthorizedException();
     }
 
-    return buildJsonApi(LoginDto).addData(userUuid, populateDto(new LoginDto(), { token })).document.serialize();
+    return buildJsonApi(LoginDto).addData(userUuid, populateDto(new LoginDto(), { token }));
   }
 }

--- a/apps/user-service/src/auth/reset-password.controller.spec.ts
+++ b/apps/user-service/src/auth/reset-password.controller.spec.ts
@@ -4,6 +4,7 @@ import { ResetPasswordController } from "./reset-password.controller";
 import { ResetPasswordService } from "./reset-password.service";
 import { BadRequestException, NotFoundException } from "@nestjs/common";
 import { faker } from "@faker-js/faker";
+import { serialize } from "@terramatch-microservices/common/util/testing";
 
 describe("ResetPasswordController", () => {
   let controller: ResetPasswordController;
@@ -29,7 +30,7 @@ describe("ResetPasswordController", () => {
     const uuid = faker.string.uuid();
     resetPasswordService.sendResetPasswordEmail.mockResolvedValue({ uuid, email });
 
-    const result = await controller.requestReset({ emailAddress: email, callbackUrl: "http://example.com" });
+    const result = serialize(await controller.requestReset({ emailAddress: email, callbackUrl: "http://example.com" }));
     expect(result).toMatchObject({
       data: { id: uuid, type: "passwordResets", attributes: { emailAddress: email } }
     });
@@ -59,7 +60,7 @@ describe("ResetPasswordController", () => {
     resetPasswordService.resetPassword.mockResolvedValue({ uuid, email });
     const token = "fake";
 
-    const result = await controller.resetPassword(token, { newPassword: "superpassword" });
+    const result = serialize(await controller.resetPassword(token, { newPassword: "superpassword" }));
     expect(result).toMatchObject({
       data: { id: uuid, type: "passwordResets", attributes: { emailAddress: email } }
     });

--- a/apps/user-service/src/auth/reset-password.controller.ts
+++ b/apps/user-service/src/auth/reset-password.controller.ts
@@ -1,8 +1,8 @@
-import { Controller, Body, Post, HttpStatus, BadRequestException, Param, Put } from "@nestjs/common";
+import { BadRequestException, Body, Controller, HttpStatus, Param, Post, Put } from "@nestjs/common";
 import { ResetPasswordService } from "./reset-password.service";
 import { ApiOperation } from "@nestjs/swagger";
 import { ExceptionResponse, JsonApiResponse } from "@terramatch-microservices/common/decorators";
-import { buildJsonApi, JsonApiDocument } from "@terramatch-microservices/common/util";
+import { buildJsonApi } from "@terramatch-microservices/common/util";
 import { ResetPasswordRequest } from "./dto/reset-password-request.dto";
 import { ResetPasswordDto } from "./dto/reset-password.dto";
 import { NoBearerAuth } from "@terramatch-microservices/common/guards";
@@ -21,11 +21,12 @@ export class ResetPasswordController {
   })
   @JsonApiResponse(ResetPasswordResponseDto, { status: HttpStatus.CREATED })
   @ExceptionResponse(BadRequestException, { description: "Invalid request or email." })
-  async requestReset(@Body() { emailAddress, callbackUrl }: ResetPasswordRequest): Promise<JsonApiDocument> {
+  async requestReset(@Body() { emailAddress, callbackUrl }: ResetPasswordRequest) {
     const { email, uuid } = await this.resetPasswordService.sendResetPasswordEmail(emailAddress, callbackUrl);
-    return buildJsonApi(ResetPasswordResponseDto)
-      .addData(uuid ?? "no-uuid", populateDto(new ResetPasswordResponseDto(), { emailAddress: email }))
-      .document.serialize();
+    return buildJsonApi(ResetPasswordResponseDto).addData(
+      uuid ?? "no-uuid",
+      populateDto(new ResetPasswordResponseDto(), { emailAddress: email })
+    );
   }
 
   @Put(":token")
@@ -36,13 +37,11 @@ export class ResetPasswordController {
   })
   @JsonApiResponse(ResetPasswordResponseDto)
   @ExceptionResponse(BadRequestException, { description: "Invalid or expired token." })
-  async resetPassword(
-    @Param("token") token: string,
-    @Body() { newPassword }: ResetPasswordDto
-  ): Promise<JsonApiDocument> {
+  async resetPassword(@Param("token") token: string, @Body() { newPassword }: ResetPasswordDto) {
     const { email, uuid } = await this.resetPasswordService.resetPassword(token, newPassword);
-    return buildJsonApi(ResetPasswordResponseDto)
-      .addData(uuid ?? "no-uuid", populateDto(new ResetPasswordResponseDto(), { emailAddress: email }))
-      .document.serialize();
+    return buildJsonApi(ResetPasswordResponseDto).addData(
+      uuid ?? "no-uuid",
+      populateDto(new ResetPasswordResponseDto(), { emailAddress: email })
+    );
   }
 }

--- a/apps/user-service/src/auth/verification-user.controller.spec.ts
+++ b/apps/user-service/src/auth/verification-user.controller.spec.ts
@@ -4,6 +4,7 @@ import { NotFoundException } from "@nestjs/common";
 import { faker } from "@faker-js/faker";
 import { VerificationUserController } from "./verification-user.controller";
 import { VerificationUserService } from "./verification-user.service";
+import { serialize } from "@terramatch-microservices/common/util/testing";
 
 describe("VerificationUserController", () => {
   let controller: VerificationUserController;
@@ -31,7 +32,7 @@ describe("VerificationUserController", () => {
     const uuid = faker.string.uuid();
     verificationUserService.verify.mockResolvedValue({ uuid, isVerified: true });
 
-    const result = await controller.verifyUser({ token: "my token" });
+    const result = serialize(await controller.verifyUser({ token: "my token" }));
     expect(result).toMatchObject({
       data: { id: uuid, type: "verifications", attributes: { verified: true } }
     });

--- a/apps/user-service/src/auth/verification-user.controller.ts
+++ b/apps/user-service/src/auth/verification-user.controller.ts
@@ -1,7 +1,7 @@
-import { Controller, Body, Post, HttpStatus, BadRequestException } from "@nestjs/common";
+import { BadRequestException, Body, Controller, HttpStatus, Post } from "@nestjs/common";
 import { ApiOperation } from "@nestjs/swagger";
 import { ExceptionResponse, JsonApiResponse } from "@terramatch-microservices/common/decorators";
-import { buildJsonApi, JsonApiDocument } from "@terramatch-microservices/common/util";
+import { buildJsonApi } from "@terramatch-microservices/common/util";
 import { VerificationUserService } from "./verification-user.service";
 import { VerificationUserRequest } from "./dto/verification-user-request.dto";
 import { VerificationUserResponseDto } from "./dto/verification-user-response.dto";
@@ -20,10 +20,11 @@ export class VerificationUserController {
   })
   @JsonApiResponse(VerificationUserResponseDto, { status: HttpStatus.CREATED })
   @ExceptionResponse(BadRequestException, { description: "Invalid request" })
-  async verifyUser(@Body() { token }: VerificationUserRequest): Promise<JsonApiDocument> {
+  async verifyUser(@Body() { token }: VerificationUserRequest) {
     const { uuid, isVerified } = await this.verificationUserService.verify(token);
-    return buildJsonApi(VerificationUserResponseDto)
-      .addData(uuid ?? "no-uuid", populateDto(new VerificationUserResponseDto(), { verified: isVerified }))
-      .document.serialize();
+    return buildJsonApi(VerificationUserResponseDto).addData(
+      uuid ?? "no-uuid",
+      populateDto(new VerificationUserResponseDto(), { verified: isVerified })
+    );
   }
 }

--- a/apps/user-service/src/main.ts
+++ b/apps/user-service/src/main.ts
@@ -8,6 +8,7 @@ import { AppModule } from "./app.module";
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 import { TMLogger } from "@terramatch-microservices/common/util/tm-logger";
 import { NestExpressApplication } from "@nestjs/platform-express";
+import { DocumentBuilderInterceptor } from "@terramatch-microservices/common/util/document-builder-interceptor";
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
@@ -35,6 +36,8 @@ async function bootstrap() {
       transformOptions: { enableImplicitConversion: true, exposeDefaultValues: true }
     })
   );
+
+  app.useGlobalInterceptors(new DocumentBuilderInterceptor());
 
   const port = process.env.NODE_ENV === "production" ? 80 : process.env.USER_SERVICE_PORT ?? 4010;
   await app.listen(port);

--- a/apps/user-service/src/organisations/organisations.controller.ts
+++ b/apps/user-service/src/organisations/organisations.controller.ts
@@ -37,6 +37,6 @@ export class OrganisationsController {
     const orgResource = document.addData(organisation.uuid, populateDto(new OrganisationDto(), organisation));
     const userResource = document.addData(user.uuid ?? "no-uuid", new UserDto(user, await user.myFrameworks()));
     userResource.relateTo("org", orgResource, { meta: { userStatus: "na" } });
-    return document.serialize();
+    return document;
   }
 }

--- a/apps/user-service/src/users/users.controller.ts
+++ b/apps/user-service/src/users/users.controller.ts
@@ -15,7 +15,7 @@ import { PolicyService } from "@terramatch-microservices/common";
 import { ApiOperation, ApiParam } from "@nestjs/swagger";
 import { OrganisationDto, UserDto } from "@terramatch-microservices/common/dto";
 import { ExceptionResponse, JsonApiResponse } from "@terramatch-microservices/common/decorators";
-import { buildJsonApi, DocumentBuilder, JsonApiDocument } from "@terramatch-microservices/common/util";
+import { buildJsonApi, DocumentBuilder } from "@terramatch-microservices/common/util";
 import { UserUpdateBody } from "./dto/user-update.dto";
 import { NoBearerAuth } from "@terramatch-microservices/common/guards";
 import { UserCreateBody } from "./dto/user-create.dto";
@@ -63,7 +63,7 @@ export class UsersController {
 
     await this.policyService.authorize("read", user);
 
-    return (await this.addUserResource(buildJsonApi(UserDto), user)).serialize();
+    return await this.addUserResource(buildJsonApi(UserDto), user);
   }
 
   @Patch(":uuid")
@@ -93,7 +93,7 @@ export class UsersController {
       await user.save();
     }
 
-    return (await this.addUserResource(buildJsonApi(UserDto), user)).serialize();
+    return await this.addUserResource(buildJsonApi(UserDto), user);
   }
 
   @Post()
@@ -104,9 +104,9 @@ export class UsersController {
   })
   @JsonApiResponse(USER_RESPONSE_SHAPE)
   @ExceptionResponse(UnauthorizedException, { description: "user creation failed." })
-  async create(@Body() payload: UserCreateBody): Promise<JsonApiDocument> {
+  async create(@Body() payload: UserCreateBody) {
     const user = await this.userCreationService.createNewUser(payload.data.attributes);
-    return (await this.addUserResource(buildJsonApi(UserDto), user)).serialize();
+    return await this.addUserResource(buildJsonApi(UserDto), user);
   }
 
   private async addUserResource(document: DocumentBuilder, user: User) {

--- a/libs/common/src/lib/decorators/json-api-response.decorator.ts
+++ b/libs/common/src/lib/decorators/json-api-response.decorator.ts
@@ -163,24 +163,36 @@ function buildSchema(options: JsonApiOptions) {
         description:
           "The full stable (sorted query param) request path for this request, suitable for use as a store key in the FE React app"
       },
-      total: { type: "number", description: "The total number of records available.", example: 42 }
+      // Ids are only required if this index is for a sideloaded resource.
+      ids: {
+        type: "array",
+        items: { type: "string" },
+        description:
+          "The ordered set of resource IDs for this index. If this is omitted, the ids in the main `data` object of the response should be used.",
+        required: false
+      }
     };
     if (pagination === "cursor") {
       properties["cursor"] = {
         type: "string",
         description: "The cursor for the first record on this page."
       };
+      properties["total"] = { type: "number", description: "The total number of records available.", example: 42 };
     } else if (pagination === "number") {
       properties["pageNumber"] = {
         type: "number",
         description: "The current page number."
       };
+      properties["total"] = { type: "number", description: "The total number of records available.", example: 42 };
+    } else {
+      // Total is not required if this is not a paginated endpoint.
+      properties["total"] = {
+        type: "number",
+        description: "The total number of records available.",
+        example: 42,
+        required: false
+      };
     }
-    properties["ids"] = {
-      type: "array",
-      items: { type: "string" },
-      description: "The ordered set of resource IDs for this page of this index search."
-    };
     addMeta(document, "indices", { type: "array", items: { type: "object", properties } });
   }
 

--- a/libs/common/src/lib/decorators/json-api-response.decorator.ts
+++ b/libs/common/src/lib/decorators/json-api-response.decorator.ts
@@ -155,7 +155,7 @@ function buildSchema(options: JsonApiOptions) {
     }
   }
 
-  if (pagination != null) {
+  if (pagination != null || hasMany) {
     const properties: Dictionary<object> = {
       resource: { type: "string", description: "The resource type for this included index" },
       requestPath: {

--- a/libs/common/src/lib/linkedFields/configuration/configuration.spec.ts
+++ b/libs/common/src/lib/linkedFields/configuration/configuration.spec.ts
@@ -1,0 +1,13 @@
+import { LinkedFieldsConfiguration } from "./index";
+
+describe("LinkedFieldsConfiguration", () => {
+  it("should have unique keys across all configurations field / fileCollections / relations sets", () => {
+    const configurations = Object.values(LinkedFieldsConfiguration);
+    const keys = configurations.flatMap(c => [
+      ...Object.keys(c.fields),
+      ...Object.keys(c.fileCollections),
+      ...Object.keys(c.relations)
+    ]);
+    expect(keys.sort()).toEqual([...new Set(keys).values()].sort());
+  });
+});

--- a/libs/common/src/lib/linkedFields/configuration/financial-report.configuration.ts
+++ b/libs/common/src/lib/linkedFields/configuration/financial-report.configuration.ts
@@ -1,0 +1,23 @@
+import { LinkedFieldConfiguration } from "../types";
+import { FinancialReport } from "@terramatch-microservices/database/entities";
+
+export const FinancialReportConfiguration: LinkedFieldConfiguration = {
+  label: "Financial Report",
+  laravelModelType: FinancialReport.LARAVEL_TYPE,
+  fields: {},
+  fileCollections: {},
+  relations: {
+    "fin-rep-financial-indicators-financial-collection": {
+      property: "financialCollection",
+      label: "Financial collection",
+      resource: "App\\Http\\Resources\\V2\\FinancialIndicatorsResource",
+      inputType: "financialIndicators"
+    },
+    "fin-rep-funding-types": {
+      property: "fundingTypes",
+      label: "Funding Type",
+      resource: "App\\Http\\Resources\\V2\\FundingTypeResource",
+      inputType: "fundingType"
+    }
+  }
+};

--- a/libs/common/src/lib/linkedFields/configuration/financial-report.configuration.ts
+++ b/libs/common/src/lib/linkedFields/configuration/financial-report.configuration.ts
@@ -1,6 +1,7 @@
 import { LinkedFieldConfiguration } from "../types";
 import { FinancialReport } from "@terramatch-microservices/database/entities";
 
+// Note: All field / fileCollection / relation keys _must_ be unique across all LinkedFieldConfigurations.
 export const FinancialReportConfiguration: LinkedFieldConfiguration = {
   label: "Financial Report",
   laravelModelType: FinancialReport.LARAVEL_TYPE,

--- a/libs/common/src/lib/linkedFields/configuration/index.ts
+++ b/libs/common/src/lib/linkedFields/configuration/index.ts
@@ -3,11 +3,19 @@ import { FinancialReportConfiguration } from "./financial-report.configuration";
 import { ProjectPitchConfiguration } from "./project-pitch.configuration";
 import { ProjectConfiguration } from "./project.configuration";
 import { ProjectReportConfiguration } from "./project-report.configuration";
+import { SiteConfiguration } from "./site.configuration";
+import { SiteReportConfiguration } from "./site-report.configuration";
+import { NurseryConfiguration } from "./nursery.configuration";
+import { NurseryReportConfiguration } from "./nursery-report.configuration";
 
 export const LinkedFieldsConfiguration = {
   organisation: OrganisationConfiguration,
   financialReport: FinancialReportConfiguration,
+  nursery: NurseryConfiguration,
+  nurseryReport: NurseryReportConfiguration,
   project: ProjectConfiguration,
   projectPitch: ProjectPitchConfiguration,
-  projectReport: ProjectReportConfiguration
+  projectReport: ProjectReportConfiguration,
+  site: SiteConfiguration,
+  siteReport: SiteReportConfiguration
 } as const;

--- a/libs/common/src/lib/linkedFields/configuration/index.ts
+++ b/libs/common/src/lib/linkedFields/configuration/index.ts
@@ -1,0 +1,5 @@
+import { OrganisationConfig } from "./organisation";
+
+export const LinkedFieldsConfiguration = {
+  organisation: OrganisationConfig
+} as const;

--- a/libs/common/src/lib/linkedFields/configuration/index.ts
+++ b/libs/common/src/lib/linkedFields/configuration/index.ts
@@ -1,5 +1,13 @@
-import { OrganisationConfig } from "./organisation";
+import { OrganisationConfiguration } from "./organisation.configuration";
+import { FinancialReportConfiguration } from "./financial-report.configuration";
+import { ProjectPitchConfiguration } from "./project-pitch.configuration";
+import { ProjectConfiguration } from "./project.configuration";
+import { ProjectReportConfiguration } from "./project-report.configuration";
 
 export const LinkedFieldsConfiguration = {
-  organisation: OrganisationConfig
+  organisation: OrganisationConfiguration,
+  financialReport: FinancialReportConfiguration,
+  project: ProjectConfiguration,
+  projectPitch: ProjectPitchConfiguration,
+  projectReport: ProjectReportConfiguration
 } as const;

--- a/libs/common/src/lib/linkedFields/configuration/index.ts
+++ b/libs/common/src/lib/linkedFields/configuration/index.ts
@@ -7,10 +7,22 @@ import { SiteConfiguration } from "./site.configuration";
 import { SiteReportConfiguration } from "./site-report.configuration";
 import { NurseryConfiguration } from "./nursery.configuration";
 import { NurseryReportConfiguration } from "./nursery-report.configuration";
-import { Dictionary } from "lodash";
 import { LinkedFieldConfiguration } from "../types";
 
-export const LinkedFieldsConfiguration: Dictionary<LinkedFieldConfiguration> = {
+export const FORM_TYPES = [
+  "organisation",
+  "financialReport",
+  "nursery",
+  "nurseryReport",
+  "project",
+  "projectPitch",
+  "projectReport",
+  "site",
+  "siteReport"
+] as const;
+export type FormType = (typeof FORM_TYPES)[number];
+
+export const LinkedFieldsConfiguration: Record<FormType, LinkedFieldConfiguration> = {
   organisation: OrganisationConfiguration,
   financialReport: FinancialReportConfiguration,
   nursery: NurseryConfiguration,

--- a/libs/common/src/lib/linkedFields/configuration/index.ts
+++ b/libs/common/src/lib/linkedFields/configuration/index.ts
@@ -7,8 +7,10 @@ import { SiteConfiguration } from "./site.configuration";
 import { SiteReportConfiguration } from "./site-report.configuration";
 import { NurseryConfiguration } from "./nursery.configuration";
 import { NurseryReportConfiguration } from "./nursery-report.configuration";
+import { Dictionary } from "lodash";
+import { LinkedFieldConfiguration } from "../types";
 
-export const LinkedFieldsConfiguration = {
+export const LinkedFieldsConfiguration: Dictionary<LinkedFieldConfiguration> = {
   organisation: OrganisationConfiguration,
   financialReport: FinancialReportConfiguration,
   nursery: NurseryConfiguration,

--- a/libs/common/src/lib/linkedFields/configuration/nursery-report.configuration.ts
+++ b/libs/common/src/lib/linkedFields/configuration/nursery-report.configuration.ts
@@ -1,0 +1,43 @@
+import { LinkedFieldConfiguration } from "../types";
+import { NurseryReport } from "@terramatch-microservices/database/entities";
+
+export const NurseryReportConfiguration: LinkedFieldConfiguration = {
+  label: "Nursery Report",
+  laravelModelType: NurseryReport.LARAVEL_TYPE,
+  fields: {
+    "nur-rep-title": { property: "title", label: "Title", inputType: "text" },
+    "nur-rep-seedlings-young-trees": {
+      property: "seedlings_young_trees",
+      label: "Seedlings young trees",
+      inputType: "number"
+    },
+    "nur-rep-interesting-facts": { property: "interesting_facts", label: "Interesting facts", inputType: "long-text" },
+    "nur-rep-site-prep": { property: "site_prep", label: "Site prep", inputType: "long-text" },
+    "nur-rep-shared-drive-link": { property: "shared_drive_link", label: "Shared drive link", inputType: "url" }
+  },
+  fileCollections: {
+    "nur-rep-col-file": { property: "file", label: "File", inputType: "file", multiChoice: true },
+    "nur-rep-col-other-additional-documents": {
+      property: "other_additional_documents",
+      label: "Other additional documents",
+      inputType: "file",
+      multiChoice: true
+    },
+    "nur-rep-col-photos": { property: "photos", label: "Photos", inputType: "file", multiChoice: true },
+    "nur-rep-col-tree-seedling-contributions": {
+      property: "tree_seedling_contributions",
+      label: "Tree seedling contributions",
+      inputType: "file",
+      multiChoice: true
+    }
+  },
+  relations: {
+    "nur-rep-rel-tree-species": {
+      property: "treeSpecies",
+      label: "Tree Species",
+      resource: "App\\Http\\Resources\\V2\\TreeSpecies\\TreeSpeciesResource",
+      inputType: "treeSpecies",
+      collection: "nursery-seedling"
+    }
+  }
+};

--- a/libs/common/src/lib/linkedFields/configuration/nursery-report.configuration.ts
+++ b/libs/common/src/lib/linkedFields/configuration/nursery-report.configuration.ts
@@ -1,6 +1,7 @@
 import { LinkedFieldConfiguration } from "../types";
 import { NurseryReport } from "@terramatch-microservices/database/entities";
 
+// Note: All field / fileCollection / relation keys _must_ be unique across all LinkedFieldConfigurations.
 export const NurseryReportConfiguration: LinkedFieldConfiguration = {
   label: "Nursery Report",
   laravelModelType: NurseryReport.LARAVEL_TYPE,

--- a/libs/common/src/lib/linkedFields/configuration/nursery.configuration.ts
+++ b/libs/common/src/lib/linkedFields/configuration/nursery.configuration.ts
@@ -1,0 +1,44 @@
+import { LinkedFieldConfiguration } from "../types";
+import { Nursery } from "@terramatch-microservices/database/entities";
+
+export const NurseryConfiguration: LinkedFieldConfiguration = {
+  label: "Nursery",
+  laravelModelType: Nursery.LARAVEL_TYPE,
+  fields: {
+    "nur-name": { property: "name", label: "Name", inputType: "text" },
+    "nur-type": {
+      property: "type",
+      label: "type",
+      inputType: "select",
+      multiChoice: false,
+      optionListKey: "nursery-type"
+    },
+    "nur-start_date": { property: "start_date", label: "Start date", inputType: "date" },
+    "nur-end_date": { property: "end_date", label: "End date", inputType: "date" },
+    "nur-seedling_grown": { property: "seedling_grown", label: "Seedlings grown", inputType: "number" },
+    "nur-planting_contribution": {
+      property: "planting_contribution",
+      label: "Planting contribution",
+      inputType: "long-text"
+    }
+  },
+  fileCollections: {
+    "nur-col-file": { property: "file", label: "File", inputType: "file", multiChoice: true },
+    "nur-col-other-additional-documents": {
+      property: "other_additional_documents",
+      label: "Other additional documents",
+      inputType: "file",
+      multiChoice: true
+    },
+    "nur-col-photos": { property: "photos", label: "Photos", inputType: "file", multiChoice: true }
+  },
+  relations: {
+    "nur-rel-tree-species": {
+      property: "treeSpecies",
+      label: "Tree Species",
+      resource: "App\\Http\\Resources\\V2\\TreeSpecies\\TreeSpeciesResource",
+      inputType: "treeSpecies",
+      collection: "nursery-seedling"
+    }
+  }
+};

--- a/libs/common/src/lib/linkedFields/configuration/nursery.configuration.ts
+++ b/libs/common/src/lib/linkedFields/configuration/nursery.configuration.ts
@@ -1,6 +1,7 @@
 import { LinkedFieldConfiguration } from "../types";
 import { Nursery } from "@terramatch-microservices/database/entities";
 
+// Note: All field / fileCollection / relation keys _must_ be unique across all LinkedFieldConfigurations.
 export const NurseryConfiguration: LinkedFieldConfiguration = {
   label: "Nursery",
   laravelModelType: Nursery.LARAVEL_TYPE,

--- a/libs/common/src/lib/linkedFields/configuration/organisation.configuration.ts
+++ b/libs/common/src/lib/linkedFields/configuration/organisation.configuration.ts
@@ -28,7 +28,7 @@ export const OrganisationConfiguration: LinkedFieldConfiguration = {
     "org-hq-zip": { property: "hq_zipcode", label: "HQ zipcode", inputType: "text" },
     "org-hq-country": {
       property: "hq_country",
-      label: "HQ Country",
+      label: "HQ country",
       inputType: "select",
       multiChoice: false,
       optionListKey: "gadm-level-0"
@@ -504,8 +504,8 @@ export const OrganisationConfiguration: LinkedFieldConfiguration = {
       optionListKey: "territories-of-operation-collection"
     },
     "org-decisionmaking-structure-description": {
-      property: "descisionmaking_structure_description",
-      label: "Organization's decision-making structure",
+      property: "decisionmaking_structure_description",
+      label: "Organization’s decision-making structure",
       inputType: "long-text"
     },
     "org-decisionmaking-structure-individuals-involved": {
@@ -563,7 +563,6 @@ export const OrganisationConfiguration: LinkedFieldConfiguration = {
       inputType: "text"
     }
   },
-
   fileCollections: {
     "org-fcol-cover": { property: "cover", label: "Cover image", inputType: "file", multiChoice: false },
     "org-fcol-lgl-reg": {
@@ -684,7 +683,6 @@ export const OrganisationConfiguration: LinkedFieldConfiguration = {
       multiChoice: true
     }
   },
-
   relations: {
     "org-funding-types": {
       property: "fundingTypes",

--- a/libs/common/src/lib/linkedFields/configuration/organisation.configuration.ts
+++ b/libs/common/src/lib/linkedFields/configuration/organisation.configuration.ts
@@ -1,7 +1,7 @@
 import { LinkedFieldConfiguration } from "../types";
 import { Organisation } from "@terramatch-microservices/database/entities";
 
-export const OrganisationConfig: LinkedFieldConfiguration = {
+export const OrganisationConfiguration: LinkedFieldConfiguration = {
   label: "Organisation",
   laravelModelType: Organisation.LARAVEL_TYPE,
   fields: {

--- a/libs/common/src/lib/linkedFields/configuration/organisation.configuration.ts
+++ b/libs/common/src/lib/linkedFields/configuration/organisation.configuration.ts
@@ -1,6 +1,7 @@
 import { LinkedFieldConfiguration } from "../types";
 import { Organisation } from "@terramatch-microservices/database/entities";
 
+// Note: All field / fileCollection / relation keys _must_ be unique across all LinkedFieldConfigurations.
 export const OrganisationConfiguration: LinkedFieldConfiguration = {
   label: "Organisation",
   laravelModelType: Organisation.LARAVEL_TYPE,

--- a/libs/common/src/lib/linkedFields/configuration/organisation.ts
+++ b/libs/common/src/lib/linkedFields/configuration/organisation.ts
@@ -1,0 +1,785 @@
+import { LinkedFieldConfiguration } from "../types";
+import { Organisation } from "@terramatch-microservices/database/entities";
+
+export const OrganisationConfig: LinkedFieldConfiguration = {
+  label: "Organisation",
+  laravelModelType: Organisation.LARAVEL_TYPE,
+  fields: {
+    "org-type": {
+      property: "type",
+      label: "Type",
+      inputType: "select",
+      multiChoice: false,
+      optionListKey: "organisation-type"
+    },
+    "org-sub-type": {
+      property: "subtype",
+      label: "Subtype",
+      inputType: "select",
+      multiChoice: false,
+      optionListKey: "business-type"
+    },
+    "org-name": { property: "name", label: "Name", inputType: "text" },
+    "org-phone": { property: "phone", label: "Phone", inputType: "text" },
+    "org-hq-st1": { property: "hq_street_1", label: "HQ street 1", inputType: "text" },
+    "org-hq-st2": { property: "hq_street_2", label: "HQ street 2", inputType: "text" },
+    "org-hq-city": { property: "hq_city", label: "HQ city", inputType: "text" },
+    "org-hq-state": { property: "hq_state", label: "HQ state", inputType: "text" },
+    "org-hq-zip": { property: "hq_zipcode", label: "HQ zipcode", inputType: "text" },
+    "org-hq-country": {
+      property: "hq_country",
+      label: "HQ Country",
+      inputType: "select",
+      multiChoice: false,
+      optionListKey: "gadm-level-0"
+    },
+    "org-countries": {
+      property: "countries",
+      label: "Countries",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "gadm-level-0"
+    },
+    "org-languages": {
+      property: "languages",
+      label: "Languages",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "languages"
+    },
+    "org-fdg-dte": { property: "founding_date", label: "Founding date", inputType: "date" },
+    "org-web-url": { property: "web_url", label: "Web url", inputType: "text" },
+    "org-fb-url": { property: "facebook_url", label: "Facebook url", inputType: "text" },
+    "org-inst-url": { property: "instagram_url", label: "Instagram url", inputType: "text" },
+    "org-lnkn-url": { property: "linkedin_url", label: "Linkedin url", inputType: "text" },
+    "org-twi-url": { property: "twitter_url", label: "Twitter url", inputType: "text" },
+    "org-description": { property: "description", label: "Description", inputType: "long-text" },
+    "org-ldr-shp-team": { property: "leadership_team_txt", label: "Leadership Team Text", inputType: "long-text" },
+    "org-business-model": { property: "business_model", label: "Business Model", inputType: "long-text" },
+    "org-rel-exp-years": {
+      property: "relevant_experience_years",
+      label: "Relevant experience years",
+      inputType: "number"
+    },
+    "org-ha-res-tot": { property: "ha_restored_total", label: "Ha restored total", inputType: "number" },
+    "org-ha-res-3yr": { property: "ha_restored_3year", label: "Ha restored -3 year", inputType: "number" },
+    "org-tre-gro-tot": { property: "trees_grown_total", label: "Trees grown total", inputType: "number" },
+    "org-tre-gro-3yr": { property: "trees_grown_3year", label: "Trees grown -3 year", inputType: "number" },
+    "org-fin_start_month": {
+      property: "fin_start_month",
+      label: "Start of financial year (month)",
+      inputType: "select",
+      multiChoice: false,
+      optionListKey: "months"
+    },
+    "org-fin-bgt-cur-year": { property: "fin_budget_current_year", label: "Budget current year", inputType: "number" },
+    "org-fin-bgt-1year": { property: "fin_budget_1year", label: "Budget -1 year", inputType: "number" },
+    "org-fin-bgt-2year": { property: "fin_budget_2year", label: "Budget -2 year", inputType: "number" },
+    "org-fin-bgt-3year": { property: "fin_budget_3year", label: "Budget -3 year", inputType: "number" },
+    "org-eng-farmers": {
+      property: "engagement_farmers",
+      label: "Engagement farmers",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "engagement-farmers"
+    },
+    "org-eng-women": {
+      property: "engagement_women",
+      label: "Engagement women",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "engagement-women"
+    },
+    "org-eng-youth": {
+      property: "engagement_youth",
+      label: "Engagement youth",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "engagement-youth"
+    },
+    "org-eng-non-youth": {
+      property: "engagement_non_youth",
+      label: "Engagement non-youth",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "engagement-non-youth"
+    },
+    "org-ha-rst-tot": { property: "ha_restored_total", label: "Ha restored Total", inputType: "number" },
+    "org-ha-rst-3year": { property: "ha_restored_3year", label: "Ha restored -3 year", inputType: "number" },
+    "org-community-experience": {
+      property: "community_experience",
+      label: "Community engagement experience",
+      inputType: "long-text"
+    },
+    "org-tot-eng-comty-mbrs-3yr": {
+      property: "total_engaged_community_members_3yr",
+      label: "Total # of community members engaged over the last 3 years",
+      inputType: "number"
+    },
+    "org-total-employees": { property: "total_employees", label: "Total number of employees", inputType: "number" },
+    "org-female-employees": { property: "female_employees", label: "Number of female employees", inputType: "number" },
+    "org-male-employees": { property: "male_employees", label: "Number of male employees", inputType: "number" },
+    "org-young-employees": {
+      property: "young_employees",
+      label: "Number of employees between and including ages 18 and 35",
+      inputType: "number"
+    },
+    "org-temp-employees": { property: "temp_employees", label: "Number of temporary employees", inputType: "number" },
+    "org-ft-perm-employees": {
+      property: "ft_permanent_employees",
+      label: "Number of full-time permanent employees",
+      inputType: "number"
+    },
+    "org-pt-perm-employees": {
+      property: "pt_permanent_employees",
+      label: "Number of part-time permanent employees",
+      inputType: "number"
+    },
+    "org-over-35-employees": {
+      property: "over_35_employees",
+      label: "Number of employees older than 35 years of age",
+      inputType: "number"
+    },
+    "org-additional-comments": {
+      property: "additional_comments",
+      label: "Additional Comments",
+      inputType: "long-text"
+    },
+    "org-engagement-farmers": {
+      property: "engagement_farmers",
+      label: "Enagement: Farmers",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "engagement-farmers"
+    },
+    "org-engagement-women": {
+      property: "engagement_women",
+      label: "Enagement: Women",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "engagement-women"
+    },
+    "org-engagement-youth": {
+      property: "engagement_youth",
+      label: "Enagement: Youth",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "engagement-youth"
+    },
+    "org-add-fund-details": {
+      property: "additional_funding_details",
+      label: "Additional funding details",
+      inputType: "long-text"
+    },
+    "org-total-trees-grown": { property: "total_trees_grown", label: "Total trees grown", inputType: "number" },
+    "org-avg-tree-survival-rate": {
+      property: "avg_tree_survival_rate",
+      label: "Average tree survival rate",
+      inputType: "number"
+    },
+    "org-tree-maint-aftercare-aprch": {
+      property: "tree_maintenance_aftercare_approach",
+      label: "Tree maintenance and aftercare approach",
+      inputType: "long-text"
+    },
+    "org-restored-areas-desc": {
+      property: "restored_areas_description",
+      label: "Restored areas description",
+      inputType: "long-text"
+    },
+    "org-mon-eval-exp": {
+      property: "monitoring_evaluation_experience",
+      label: "Monitoring evaluation experience",
+      inputType: "long-text"
+    },
+    "org-pct-engaged-women-3yr": {
+      property: "percent_engaged_women_3yr",
+      label: "Percent women engaged (3yr)",
+      inputType: "number-percentage"
+    },
+    "org-pct-engaged-men-3yr": {
+      property: "percent_engaged_men_3yr",
+      label: "Percent men engaged (3yr)",
+      inputType: "number-percentage"
+    },
+    "org-pct-engaged-young-3yr": {
+      property: "percent_engaged_under_35_3yr",
+      label: "Percent youth engaged (3yr)",
+      inputType: "number-percentage"
+    },
+    "org-pct-engaged-old-3yr": {
+      property: "percent_engaged_over_35_3yr",
+      label: "Percent non-youth engaged (3yr)",
+      inputType: "number-percentage"
+    },
+    "org-pct-engaged-smallholder-3yr": {
+      property: "percent_engaged_smallholder_3yr",
+      label: "Percent smallholder engaged (3yr)",
+      inputType: "number-percentage"
+    },
+    "org-rev-this-year": {
+      property: "organisation_revenue_this_year",
+      label: "Organization revenue for this year",
+      inputType: "number"
+    },
+    "org-restoration-types-implemented": {
+      property: "restoration_types_implemented",
+      label: "Restoration Intervention Types Implemented",
+      multiChoice: true,
+      inputType: "select"
+    },
+    "org-historic-monitoring-geojson": {
+      property: "historic_monitoring_geojson",
+      label: "Historic monitoring shapefile upload",
+      inputType: "mapInput"
+    },
+    "org-states": {
+      property: "states",
+      label: "States",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "gadm-level-1"
+    },
+    "org-district": { property: "district", label: "District", inputType: "text" },
+    "org-acc-num-1": { property: "account_number_1", label: "Account Number 1", inputType: "text" },
+    "org-acc-num-2": { property: "account_number_2", label: "Account Number 2", inputType: "text" },
+    "org-loan-status-amount": { property: "loan_status_amount", label: "Loan Status Amount", inputType: "number" },
+    "org-loan-status-types": {
+      property: "loan_status_types",
+      label: "Loan Status Types",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "loan-status"
+    },
+    "org-marg-com-appr": {
+      property: "approach_of_marginalized_communities",
+      label: "Approach of Marginalized Communities",
+      inputType: "long-text"
+    },
+    "org-marg-com-eng-num": {
+      property: "community_engagement_numbers_marginalized",
+      label: "Marginalized Community Engagement Numbers",
+      inputType: "long-text"
+    },
+    "org-land-systems": {
+      property: "land_systems",
+      label: "Land Systems",
+      inputType: "select-image",
+      multiChoice: true,
+      optionListKey: "restoration-systems"
+    },
+    "org-fund-utilisation": {
+      property: "fund_utilisation",
+      label: "Fund Utilisation",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "loan-status"
+    },
+    "org-tree-restoration-practices": {
+      property: "tree_restoration_practices",
+      label: "Tree Restoration Practices",
+      inputType: "select-image",
+      multiChoice: true,
+      optionListKey: "restoration-practices"
+    },
+    "org-detailed-interventions": {
+      property: "detailed_intervention_types",
+      label: "Detailed Intervention Types",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "interventions"
+    },
+    "org-com-eng-3yr": {
+      property: "community_members_engaged_3yr",
+      label: "Community Members Engaged (3 years)",
+      inputType: "number"
+    },
+    "org-com-eng-3yr-men": {
+      property: "community_members_engaged_3yr_men",
+      label: "Community Members Engaged - Men (3 years)",
+      inputType: "number"
+    },
+    "org-com-eng-3yr-women": {
+      property: "community_members_engaged_3yr_women",
+      label: "Community Members Engaged - Women (3 years)",
+      inputType: "number"
+    },
+    "org-com-eng-3yr-youth": {
+      property: "community_members_engaged_3yr_youth",
+      label: "Community Members Engaged - Youth (3 years)",
+      inputType: "number"
+    },
+    "org-com-eng-3yr-non-youth": {
+      property: "community_members_engaged_3yr_non_youth",
+      label: "Community Members Engaged - Non-Youth (3 years)",
+      inputType: "number"
+    },
+    "org-com-eng-3yr-smallholder": {
+      property: "community_members_engaged_3yr_smallholder",
+      label: "Community Members Engaged - Smallholder (3 years)",
+      inputType: "number"
+    },
+    "org-com-eng-3yr-backward-class": {
+      property: "community_members_engaged_3yr_backward_class",
+      label: "Community Members Engaged - Backward Class (3 years)",
+      inputType: "number"
+    },
+    "org-total-board-members": {
+      property: "total_board_members",
+      label: "Total Number of Board Members",
+      inputType: "number"
+    },
+    "org-pct-board-women": {
+      property: "pct_board_women",
+      label: "% of board members that are women",
+      inputType: "number-percentage"
+    },
+    "org-pct-board-men": {
+      property: "pct_board_men",
+      label: "% of board members that are men",
+      inputType: "number-percentage"
+    },
+    "org-pct-board-youth": {
+      property: "pct_board_youth",
+      label: "% of board members that are youth",
+      inputType: "number-percentage"
+    },
+    "org-pct-board-non-youth": {
+      property: "pct_board_non_youth",
+      label: "% of board members that are non-youth",
+      inputType: "number-percentage"
+    },
+    "org-field-staff-skills": { property: "field_staff_skills", label: "Field staff skills", inputType: "long-text" },
+    "org-fpc-company": {
+      property: "fpc_company",
+      label: "FPC company",
+      inputType: "radio",
+      multiChoice: false,
+      optionListKey: "yes-no"
+    },
+    "org-num-of-farmers-on-board": {
+      property: "num_of_farmers_on_board",
+      label: "How many farmers on board: FPC company",
+      inputType: "number"
+    },
+    "org-num_of-marginalised-employees": {
+      property: "num_of_marginalised_employees",
+      label: "Number of employees from Marginalised statuses",
+      inputType: "number"
+    },
+    "org-benefactors-fpc-company": {
+      property: "benefactors_fpc_company",
+      label: "Supporters/benefactors: FPC company",
+      inputType: "long-text"
+    },
+    "org-board-remuneration-fpc-company": {
+      property: "board_remuneration_fpc_company",
+      label: "Board remuneration: FPC company",
+      inputType: "select",
+      multiChoice: false,
+      optionListKey: "board-remuneration"
+    },
+    "org-board-engagement-fpc-company": {
+      property: "board_engagement_fpc_company",
+      label: "Board engagement: FPC company",
+      inputType: "select",
+      multiChoice: false,
+      optionListKey: "board-engagement"
+    },
+    "org-biodiversity-focus": {
+      property: "biodiversity_focus",
+      label: "Biodiversity focus",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "biodiversity"
+    },
+    "org-global-planning-frameworks": {
+      property: "global_planning_frameworks",
+      label: "Global planning frameworks",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "planning-frameworks"
+    },
+    "org-past-gov-collaboration": {
+      property: "past_gov_collaboration",
+      label: "Past Government Collaboration",
+      inputType: "long-text"
+    },
+    "org-engagement-landless": {
+      property: "engagement_landless",
+      label: "Engagement: Landless",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "engagement-landless"
+    },
+    "org-environmental-impact": {
+      property: "environmental_impact",
+      label: "Environmental Impact",
+      inputType: "long-text"
+    },
+    "org-socioeconomic-impact": {
+      property: "socioeconomic_impact",
+      label: "Socioeconomic Impact",
+      inputType: "long-text"
+    },
+    "org-growith-stage": {
+      property: "growith_stage",
+      label: "Stage of Growth",
+      inputType: "select",
+      multiChoice: false,
+      optionListKey: "growith-stage"
+    },
+    "org-consortium": {
+      property: "consortium",
+      label: "Organizations involved in consortium and description",
+      inputType: "long-text"
+    },
+    "org-female-youth-leadership-example": {
+      property: "female_youth_leadership_example",
+      label: "Female or youth contribution to project leadership or decision making example",
+      inputType: "long-text"
+    },
+    "org-level-0-past-restoration": {
+      property: "level_0_past_restoration",
+      label: "countries where organisation has previously restored land",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "gadm-level-0"
+    },
+    "org-level-1-past-restoration": {
+      property: "level_1_past_restoration",
+      label: "GADM level 1 administrative areas where organisation has previously restored land",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "gadm-level-1"
+    },
+    "org-level-2-past-restoration": {
+      property: "level_2_past_restoration",
+      label: "GADM level 2 administrative areas where organisation has previously restored land",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "gadm-level-2"
+    },
+    "org-trees-naturally-regenerated-total": {
+      property: "trees_naturally_regenerated_total",
+      label: "Total trees naturally regenerated by organisation since founding",
+      inputType: "number"
+    },
+    "org-trees-naturally-regenerated-3year": {
+      property: "trees_naturally_regenerated_3year",
+      label: "Total trees naturally regenerated by organisation in last 36 months",
+      inputType: "number"
+    },
+    "org-carbon-credits": {
+      property: "carbon_credits",
+      label: "Has organisation ever issued carbon credits since founding",
+      inputType: "conditional",
+      multiChoice: false
+    },
+    "org-external-technical-assistance": {
+      property: "external_technical_assistance",
+      label: "Description of Non-Financial Technical Assistance Organisation has Received",
+      inputType: "long-text"
+    },
+    "org-barriers-to-funding": {
+      property: "barriers_to_funding",
+      label: "Barriers organisation faces to accessing funding, scaling operations, or delivering impact",
+      inputType: "long-text"
+    },
+    "org-capacity-building-support-needed": {
+      property: "capacity_building_support_needed",
+      label: "Where Support Needed for Project Capacity-Building",
+      inputType: "long-text"
+    },
+    "org-associations-cooperatives": {
+      property: "associations_cooperatives",
+      label: "Is the organization an association or cooperative?",
+      inputType: "boolean"
+    },
+    "org-territories-of-operation": {
+      property: "territories_of_operation",
+      label: "Territories in which the organization operates",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "territories-of-operation-collection"
+    },
+    "org-decisionmaking-structure-description": {
+      property: "descisionmaking_structure_description",
+      label: "Organization's decision-making structure",
+      inputType: "long-text"
+    },
+    "org-decisionmaking-structure-individuals-involved": {
+      property: "decisionmaking_structure_individuals_involved",
+      label: "Individuals involved in decision-making structure",
+      inputType: "long-text"
+    },
+    "org-average-worker-income": {
+      property: "average_worker_income",
+      label: "Average income per worker over the past year",
+      inputType: "number"
+    },
+    "org-anr-practices-past": {
+      property: "anr_practices_past",
+      label: "ANR practices that the organization has used",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "anr-practices-past-collection"
+    },
+    "org-anr-monitoring-approaches": {
+      property: "anr_monitoring_approaches",
+      label: "Approaches the organization has used to monitor ANR progress",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "anr-monitoring-approaches-collection"
+    },
+    "org-anr-monitoring-approaches-description": {
+      property: "anr_monitoring_approaches_description",
+      label: "Description of the approaches used to monitor ANR progress",
+      inputType: "text"
+    },
+    "org-anr-communication-funders": {
+      property: "anr_communication_funders",
+      label: "How the organization communicated ANR impact to funders",
+      inputType: "text"
+    },
+    "org-bioeconomy-products": {
+      property: "bioeconomy_products",
+      label: "Bioeconomy products cultivated by organization",
+      inputType: "text"
+    },
+    "org-bioeconomy-traditional-knowledge": {
+      property: "bioeconomy_traditional_knowledge",
+      label: "Traditional Knowledge within the bioeconomy production process",
+      inputType: "long-text"
+    },
+    "org-bioeconomy-product-processing": {
+      property: "bioeconomy_product_processing",
+      label: "How bioeconomy products are processed before selling",
+      inputType: "long-text"
+    },
+    "org-bioeconomy-buyers": {
+      property: "bioeconomy_buyers",
+      label: "Buyers of the bioeconomy products",
+      inputType: "text"
+    }
+  },
+
+  fileCollections: {
+    "org-fcol-cover": { property: "cover", label: "Cover image", inputType: "file", multiChoice: false },
+    "org-fcol-lgl-reg": {
+      property: "legal_registration",
+      label: "Legal registration",
+      inputType: "file",
+      multiChoice: true
+    },
+    "org-fcol-logo": { property: "logo", label: "Logo image", inputType: "file", multiChoice: false },
+    "org-fcol-ref": { property: "reference", label: "Reference documents", inputType: "file", multiChoice: true },
+    "org-fcol-op-bgt-1year": {
+      property: "op_budget_1year",
+      label: "Budget -1 year documents",
+      inputType: "file",
+      multiChoice: true
+    },
+    "org-fcol-op-bgt-2year": {
+      property: "op_budget_2year",
+      label: "Budget -2 year documents",
+      inputType: "file",
+      multiChoice: true
+    },
+    "org-fcol-op-bgt-3year": {
+      property: "op_budget_3year",
+      label: "Budget -3 year documents",
+      inputType: "file",
+      multiChoice: true
+    },
+    "org-fcol-op-this-year": {
+      property: "op_budget_this_year",
+      label: "Organization Budget for this year",
+      inputType: "file",
+      multiChoice: true
+    },
+    "org-fcol-op-next-year": {
+      property: "op_budget_next_year",
+      label: "Organization Budget for next year",
+      inputType: "file",
+      multiChoice: true
+    },
+    "org-fcol-hst-rest": {
+      property: "historic_restoration",
+      label: "Historic restoration",
+      inputType: "file",
+      multiChoice: true
+    },
+    "org-fcol-additional": {
+      property: "additional",
+      label: "Additional documents",
+      inputType: "file",
+      multiChoice: true
+    },
+    "org-fcol-bank-statments": {
+      property: "bank_statements",
+      label: "Bank statements",
+      inputType: "file",
+      multiChoice: true
+    },
+    "org-fcol-prev-annual-rpts": {
+      property: "previous_annual_reports",
+      label: "Previous annual reports",
+      inputType: "file",
+      multiChoice: true
+    },
+    "org-avg-tree-surv-rate-proof": {
+      property: "avg_tree_survival_rate_proof",
+      label: "Average tree survival rate proof",
+      inputType: "file",
+      multiChoice: true
+    },
+    "org-equ-ownership": {
+      property: "equity_ownership",
+      label: "Equity Ownership",
+      inputType: "file",
+      multiChoice: false
+    },
+    "org-loan-status": { property: "loan_status", label: "Loan Status", inputType: "file", multiChoice: true },
+    "org-past-rest-photos": {
+      property: "restoration_photos",
+      label: "Past Restoration Photos",
+      inputType: "file",
+      multiChoice: true
+    },
+    "org-startup-recognition-cert": {
+      property: "startup_recognition_cert",
+      label: "Certificate of Startup Recognition",
+      inputType: "file",
+      multiChoice: true
+    },
+    "org-consortium-proof": {
+      property: "consortium_proof",
+      label: "Proof of registration for other consortium applicants",
+      inputType: "file",
+      multiChoice: true
+    },
+    "org-consortium-partnership-agreements": {
+      property: "consortium_partnership_agreements",
+      label: "Signed partnership documents",
+      inputType: "file",
+      multiChoice: true
+    },
+    "org-organogram": {
+      property: "organogram",
+      label: "Organisation structure/diagram",
+      inputType: "file",
+      multiChoice: true
+    },
+    "org-ownership-documents": {
+      property: "ownership_documents",
+      label: "Ownership documentation upload",
+      inputType: "file",
+      multiChoice: true
+    },
+    "org-carbon-credits-proofs": {
+      property: "carbon_credits_proof",
+      label: "Proof of carbon credit issuing in past",
+      inputType: "file",
+      multiChoice: true
+    }
+  },
+
+  relations: {
+    "org-funding-types": {
+      property: "fundingTypes",
+      label: "Funding Type",
+      resource: "App\\Http\\Resources\\V2\\FundingTypeResource",
+      inputType: "fundingType"
+    },
+    "org-tree-species": {
+      property: "treeSpeciesHistorical",
+      label: "Tree Species",
+      resource: "App\\Http\\Resources\\V2\\TreeSpecies\\TreeSpeciesResource",
+      inputType: "treeSpecies",
+      collection: "historical-tree-species"
+    },
+    "org-leadership-team": {
+      property: "leadershipTeam",
+      label: "Leadership Team",
+      resource: "App\\Http\\Resources\\V2\\LeadershipsResource",
+      inputType: "leaderships",
+      collection: "leadership-team"
+    },
+    "org-core-team-leaders": {
+      property: "coreTeamLeaders",
+      label: "Core Team Leaders",
+      resource: "App\\Http\\Resources\\V2\\LeadershipsResource",
+      inputType: "leaderships",
+      collection: "core-team-leaders"
+    },
+    "org-tree-species-restored": {
+      property: "treeSpeciesHistorical",
+      label: "Tree species restored in landscape",
+      resource: "App\\Http\\Resources\\V2\\TreeSpecies\\TreeSpeciesResource",
+      inputType: "treeSpecies",
+      collection: "historical-tree-species"
+    },
+    "org-ownership-stake": {
+      property: "ownershipStake",
+      label: "Ownership Stake",
+      resource: "App\\Http\\Resources\\V2\\OwnershipStakeResource",
+      inputType: "ownershipStake"
+    },
+    "org-beneficiaries-all": {
+      property: "allBeneficiaries",
+      label: "Community Members",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "allBeneficiaries",
+      collection: "all"
+    },
+    "org-employees-full-time": {
+      property: "employeesFullTime",
+      label: "Full Time Employees",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "employees",
+      collection: "full-time"
+    },
+    "org-employees-full-time-clt": {
+      property: "employeesFullTimeClt",
+      label: "Full Time CLT Employees",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "employees",
+      collection: "full-time-clt"
+    },
+    "org-employees-part-time": {
+      property: "employeesPartTime",
+      label: "Part Time Employees",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "employees",
+      collection: "part-time"
+    },
+    "org-employees-part-time-clt": {
+      property: "employeesPartTimeClt",
+      label: "Part Time CLT Employees",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "employees",
+      collection: "part-time-clt"
+    },
+    "org-employees-temp": {
+      property: "employeesTemp",
+      label: "Temp Employees",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "employees",
+      collection: "temp"
+    },
+    "org-associates": {
+      property: "associates",
+      label: "Associates",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "associates",
+      collection: "all"
+    },
+    "org-financial-indicators-financial-collection": {
+      property: "financialCollection",
+      label: "Financial collection",
+      resource: "App\\Http\\Resources\\V2\\FinancialIndicatorsResource",
+      inputType: "financialIndicators"
+    }
+  }
+};

--- a/libs/common/src/lib/linkedFields/configuration/project-pitch.configuration.ts
+++ b/libs/common/src/lib/linkedFields/configuration/project-pitch.configuration.ts
@@ -7,7 +7,7 @@ export const ProjectPitchConfiguration: LinkedFieldConfiguration = {
   fields: {
     "pro-pit-name": { property: "project_name", label: "Name", inputType: "text" },
     "pro-pit-objectives": { property: "project_objectives", label: "Objectives", inputType: "long-text" },
-    "pro-pit-district": { property: "project_county_district", label: "County District", inputType: "text" },
+    "pro-pit-district": { property: "project_county_district", label: "County district", inputType: "text" },
     "pro-pit-country": {
       property: "project_country",
       label: "Country",

--- a/libs/common/src/lib/linkedFields/configuration/project-pitch.configuration.ts
+++ b/libs/common/src/lib/linkedFields/configuration/project-pitch.configuration.ts
@@ -1,0 +1,615 @@
+import { LinkedFieldConfiguration } from "../types";
+import { ProjectPitch } from "@terramatch-microservices/database/entities";
+
+export const ProjectPitchConfiguration: LinkedFieldConfiguration = {
+  label: "Project Pitch",
+  laravelModelType: ProjectPitch.LARAVEL_TYPE,
+  fields: {
+    "pro-pit-name": { property: "project_name", label: "Name", inputType: "text" },
+    "pro-pit-objectives": { property: "project_objectives", label: "Objectives", inputType: "long-text" },
+    "pro-pit-district": { property: "project_county_district", label: "County District", inputType: "text" },
+    "pro-pit-country": {
+      property: "project_country",
+      label: "Country",
+      inputType: "select",
+      multiChoice: false,
+      optionListKey: "gadm-level-0"
+    },
+    "pro-pit-rst-inv-types": {
+      property: "restoration_intervention_types",
+      label: "Restoration intervention types",
+      inputType: "select-image",
+      multiChoice: true,
+      optionListKey: "restoration-systems"
+    },
+    "pro-pit-detailed-rst-inv-types": {
+      property: "detailed_intervention_types",
+      label: "Detailed intervention types",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "interventions"
+    },
+    "pro-pit-tot-ha": { property: "total_hectares", label: "Total hectares", inputType: "number" },
+    "pro-pit-tot-trees": { property: "total_trees", label: "Total trees", inputType: "number" },
+    "pro-pit-bgt": { property: "project_budget", label: "Project budget", inputType: "number" },
+    "pro-pit-cap-bld-needs": {
+      property: "capacity_building_needs",
+      label: "Capacity building needs",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "building-needs"
+    },
+    "pro-pit-how-discovered": {
+      property: "how_discovered",
+      label: "How discovered WRI",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "media-channels"
+    },
+    "pro-pit-land-tenure-proj-area": {
+      property: "land_tenure_proj_area",
+      label: "Land tenure project area",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "land-tenure-proj-area-collection"
+    },
+    "pro-pit-expected-active-rest-start-date": {
+      property: "expected_active_restoration_start_date",
+      label: "Expected active restoration start date",
+      inputType: "date"
+    },
+    "pro-pit-expected-active-rest-end-date": {
+      property: "expected_active_restoration_end_date",
+      label: "Expected active restoration end date",
+      inputType: "date"
+    },
+    "pro-pit-desc-of-proj-timeline": {
+      property: "description_of_project_timeline",
+      label: "Description of project timeline",
+      inputType: "long-text"
+    },
+    "pro-pit-proj-partner-info": {
+      property: "proj_partner_info",
+      label: "Project partner info",
+      inputType: "long-text"
+    },
+    "pro-pit-landholder-comm-engage": {
+      property: "landholder_comm_engage",
+      label: "Landholder & Community Engagement Strategy",
+      inputType: "long-text"
+    },
+    "pro-pit-proj-success-risks": {
+      property: "proj_success_risks",
+      label: "Project risks to success",
+      inputType: "long-text"
+    },
+    "pro-pit-monitor-eval-plan": {
+      property: "monitor_eval_plan",
+      label: "Monitoring and evaluation plan",
+      inputType: "long-text"
+    },
+    "pro-pit-proj-boundary": { property: "proj_boundary", label: "Project Boundary", inputType: "mapInput" },
+    "pro-pit-sustainable-dev-goals": {
+      property: "sustainable_dev_goals",
+      label: "Sustainable Development Goals",
+      inputType: "select-image",
+      multiChoice: true
+    },
+    "pro-pit-proj-area-desc": {
+      property: "proj_area_description",
+      label: "Description of Project Area",
+      inputType: "long-text"
+    },
+    "pro-pit-curr-land-degradation": {
+      property: "curr_land_degradation",
+      label: "Main causes of degradation",
+      inputType: "long-text"
+    },
+    "pro-pit-proposed-num-sites": {
+      property: "proposed_num_sites",
+      label: "Proposed Number of Sites",
+      inputType: "number"
+    },
+    "pro-pit-environmental-goals": {
+      property: "environmental_goals",
+      label: "Environmental goals",
+      inputType: "long-text"
+    },
+    "pro-pit-proposed-num-nurseries": {
+      property: "proposed_num_nurseries",
+      label: "Proposed Number of Nurseries",
+      inputType: "number"
+    },
+    "pro-pit-proj-impact-socieconom": {
+      property: "proj_impact_socieconom",
+      label: "Potential project impact: socioeconomic",
+      inputType: "long-text"
+    },
+    "pro-pit-proj-impact-foodsec": {
+      property: "proj_impact_foodsec",
+      label: "Potential project impact: food security",
+      inputType: "long-text"
+    },
+    "pro-pit-proj-impact-watersec": {
+      property: "proj_impact_watersec",
+      label: "Potential project impact: water security",
+      inputType: "long-text"
+    },
+    "pro-pit-proj-impact-jobtypes": {
+      property: "proj_impact_jobtypes",
+      label: "Potential project impact: types of jobs created",
+      inputType: "long-text"
+    },
+    "pro-pit-num-jobs-created": { property: "num_jobs_created", label: "Number of jobs created", inputType: "number" },
+    "pro-pit-beneficiaries": {
+      property: "proj_beneficiaries",
+      label: "Total Expected project beneficiaries",
+      inputType: "number"
+    },
+    "pro-pit-pct-beneficiaries-small": {
+      property: "pct_beneficiaries_small",
+      label: "% Beneficiaries smallholder",
+      inputType: "number-percentage"
+    },
+    "pro-pit-pct-beneficiaries-large": {
+      property: "pct_beneficiaries_large",
+      label: "% Beneficiaries large",
+      inputType: "number-percentage"
+    },
+    "pro-pit-pct-beneficiaries-women": {
+      property: "pct_beneficiaries_women",
+      label: "% Beneficiaries women",
+      inputType: "number-percentage"
+    },
+    "pro-pit-pct-beneficiaries-men": {
+      property: "pct_beneficiaries_men",
+      label: "% Beneficiaries men",
+      inputType: "number-percentage"
+    },
+    "pro-pit-pct-beneficiaries-35below": {
+      property: "pct_beneficiaries_youth",
+      label: "% Beneficiaries youth",
+      inputType: "number-percentage"
+    },
+    "pro-pit-pct-beneficiaries-sch-classes": {
+      property: "pct_beneficiaries_scheduled_classes",
+      label: "% Beneficiaries Scheduled Classes",
+      inputType: "number-percentage"
+    },
+    "pro-pit-pct-beneficiaries-sch-tribes": {
+      property: "pct_beneficiaries_scheduled_tribes",
+      label: "% Beneficiaries Scheduled Tribes",
+      inputType: "number-percentage"
+    },
+    "pro-pit-pct-beneficiaries-marginalised": {
+      property: "pct_beneficiaries_marginalised",
+      label: "% Beneficiaries Marginalised Communities",
+      inputType: "number-percentage"
+    },
+    "pro-pit-main-degradation_causes": {
+      property: "main_degradation_causes",
+      label: "Main degradation causes",
+      inputType: "long-text"
+    },
+    "pro-pit-seedlings-source": { property: "seedlings_source", label: "Seedlings source", inputType: "long-text" },
+    "pro-pit-pct-employees-men": {
+      property: "pct_employees_men",
+      label: "% of total employees that would be men",
+      inputType: "number-percentage"
+    },
+    "pro-pit-pct-employees-women": {
+      property: "pct_employees_women",
+      label: "% of total employees that would be women",
+      inputType: "number-percentage"
+    },
+    "pro-pit-pct-employees-18to35": {
+      property: "pct_employees_18to35",
+      label: "% of total employees that would be between the ages of 18 and 35",
+      inputType: "number-percentage"
+    },
+    "pro-pit-pct-employees-older35": {
+      property: "pct_employees_older35",
+      label: "% of total employees that would be older than 35 years of age",
+      inputType: "number-percentage"
+    },
+    "pro-pit-pct-employees-marginalised": {
+      property: "pct_employees_marginalised",
+      label: "% of total employees that would be part of a marginalised community",
+      inputType: "number-percentage"
+    },
+    "pro-pit-states": {
+      property: "states",
+      label: "States",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "gadm-level-1"
+    },
+    "pro-pit-hec-yr1": {
+      property: "hectares_first_yr",
+      label: "Hectares to be restored in the first year",
+      inputType: "number"
+    },
+    "pro-pit-trees-yr1": {
+      property: "total_trees_first_yr",
+      label: "Trees planted in the first year",
+      inputType: "number"
+    },
+    "pro-pit-pct-beneficiaries-backward-class": {
+      property: "pct_beneficiaries_backward_class",
+      label: "% Beneficiaries backward class",
+      inputType: "number-percentage"
+    },
+    "pro-pit-land-systems": {
+      property: "land_systems",
+      label: "Land systems",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "restoration-systems"
+    },
+    "pro-pit-tree-rest-prac": {
+      property: "tree_restoration_practices",
+      label: "Tree Restoration Practices",
+      inputType: "select-image",
+      multiChoice: true,
+      optionListKey: "restoration-practices"
+    },
+    "pro-pit-main-cause-deg": {
+      property: "main_causes_of_degradation",
+      label: "Main causes of degradation",
+      inputType: "long-text"
+    },
+    "pro-theory-of-change": { property: "theory_of_change", label: "Theory of change", inputType: "long-text" },
+    "pro-proposed-gov-partners": {
+      property: "proposed_gov_partners",
+      label: "Proposed government partners",
+      inputType: "long-text"
+    },
+    "pro-pct-sch-tribe": {
+      property: "pct_sch_tribe",
+      label: "% of total employees that would be Scheduled Caste/Other Backward Class/Scheduled Tribe",
+      inputType: "number-percentage"
+    },
+    "pro-sustainability-plan": {
+      property: "sustainability_plan",
+      label: "Project sustainability plan",
+      inputType: "long-text"
+    },
+    "pro-replication-plan": { property: "replication_plan", label: "Project replication plan", inputType: "long-text" },
+    "pro-replication-challenges": {
+      property: "replication_challenges",
+      label: "Project replication challenges",
+      inputType: "long-text"
+    },
+    "pro-solution-market-size": {
+      property: "solution_market_size",
+      label: "Solution market size",
+      inputType: "long-text"
+    },
+    "pro-affordability-of-solution": {
+      property: "affordability_of_solution",
+      label: "Affordability of solution/products",
+      inputType: "long-text"
+    },
+    "pro-growth-trends-business": {
+      property: "growth_trends_business",
+      label: "Growth trends of business",
+      inputType: "long-text"
+    },
+    "pro-limitations-on-scope": {
+      property: "limitations_on_scope",
+      label: "Limitations on scope of operations",
+      inputType: "long-text"
+    },
+    "pro-business-model-replication_plan": {
+      property: "business_model_replication_plan",
+      label: "Business model replication plan",
+      inputType: "long-text"
+    },
+    "pro-biodiversity-impact": {
+      property: "biodiversity_impact",
+      label: "Biodiversity Impact (project)",
+      inputType: "long-text"
+    },
+    "pro-water-source": { property: "water_source", label: "Water Source (project)", inputType: "long-text" },
+    "pro-climate-resilience": {
+      property: "climate_resilience",
+      label: "Climate resilience (project)",
+      inputType: "long-text"
+    },
+    "pro-soil-health": { property: "soil_health", label: "Soil Health (project)", inputType: "long-text" },
+    "pro-pit-land-use-types": {
+      property: "land_use_types",
+      label: "Land use types",
+      inputType: "select-image",
+      multiChoice: true,
+      optionListKey: "restoration-systems"
+    },
+    "pro-pit-restoration_strategy": {
+      property: "restoration_strategy",
+      label: "Restoration strategy",
+      inputType: "select-image",
+      multiChoice: true,
+      optionListKey: "restoration-practices"
+    },
+    "pro-pit-baseline-biodiversity": {
+      property: "baseline_biodiversity",
+      label: "Baseline Biodiversity Conditions",
+      inputType: "long-text"
+    },
+    "pro-pit-goal-trees-restored-planting": {
+      property: "goal_trees_restored_planting",
+      label: "Trees Restored Goal - Planting",
+      inputType: "number"
+    },
+    "pro-pit-goal-trees-restored-anr": {
+      property: "goal_trees_restored_anr",
+      label: "Trees Restored Goal - ANR",
+      inputType: "number"
+    },
+    "pro-pit-goal-trees-restored-direct-seeding": {
+      property: "goal_trees_restored_direct_seeding",
+      label: "Trees Restored Goal - Direct Seeding",
+      inputType: "number"
+    },
+    "pro-pit-direct-seeding-survival-rate": {
+      property: "direct_seeding_survival_rate",
+      label: "Direct Seeding Survival Rate",
+      inputType: "number-percentage"
+    },
+    "pro-pit-level-0-proposed": {
+      property: "level_0_proposed",
+      label: "countries where project will be restoring land",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "gadm-level-0"
+    },
+    "pro-pit-level-1-proposed": {
+      property: "level_1_proposed",
+      label: "GADM level 1 administrative areas where project will be restoring land",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "gadm-level-1"
+    },
+    "pro-pit-level-2-proposed": {
+      property: "level_2_proposed",
+      label: "GADM level 2 administrative areas where project will be restoring land",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "gadm-level-2"
+    },
+    "pro-pit-lat-proposed": {
+      property: "lat_proposed",
+      label: "Proposed center point of a restoration site - latitude",
+      inputType: "number"
+    },
+    "pro-pit-long-proposed": {
+      property: "long_proposed",
+      label: "Proposed center point of a restoration site - longitude",
+      inputType: "number"
+    },
+    "pro-pit-stakeholder-engagement": {
+      property: "stakeholder_engagement",
+      label: "Local stakeholders affected by project",
+      inputType: "long-text"
+    },
+    "pro-pit-landowner-agreement": {
+      property: "landowner_agreement",
+      label: "Prior agreement with landowner to use their land for restoration",
+      inputType: "select",
+      multiChoice: false,
+      optionListKey: "landowner-collection"
+    },
+    "pro-pit-landowner-agreement-description": {
+      property: "landowner_agreement_description",
+      label: "Explanation of landowner agreement",
+      inputType: "long-text"
+    },
+    "pro-pit-land-tenure-risks": {
+      property: "land_tenure_risks",
+      label: "Risks or challenges in securing tenure arrangements with landowners",
+      inputType: "long-text"
+    },
+    "pro-pit-non-tree-interventions-description": {
+      property: "non_tree_interventions_description",
+      label: "Additional non-tree intervention description",
+      inputType: "long-text"
+    },
+    "pro-pit-complement-existing-restoration": {
+      property: "complement_existing_restoration",
+      label: "Project complements existing restoration",
+      inputType: "long-text"
+    },
+    "pro-pit-restoration-strategy-distribution": {
+      property: "restoration_strategy_distribution",
+      label: "Distribution of restoration strategies",
+      inputType: "strategy-area",
+      multiChoice: false,
+      optionListKey: "strategy-distribution-collection"
+    },
+    "pro-pit-land-use-type-distribution": {
+      property: "land_use_type_distribution",
+      label: "Distribution of land use systems",
+      inputType: "strategy-area",
+      multiChoice: false,
+      optionListKey: "land-use-distribution-collection"
+    },
+    "pro-pit-land-tenure-distribution": {
+      property: "land_tenure_distribution",
+      label: "Distribution of land tenure agreement",
+      inputType: "strategy-area",
+      multiChoice: false,
+      optionListKey: "tenure-distribution-collection"
+    },
+    "pro-pit-total-tree-second-yr": {
+      property: "total_tree_second_yr",
+      label: "Trees Planted in Second Year",
+      inputType: "number"
+    },
+    "pro-pit-proj-survival-rate": {
+      property: "proj_survival_rate",
+      label: "Projected Project Survival Rate",
+      inputType: "number-percentage"
+    },
+    "pro-pit-anr-approach": { property: "anr_approach", label: "Project Approach to ANR", inputType: "text" },
+    "pro-pit-anr-rights": { property: "anr_rights", label: "How to Secure Rights to Conduct ANR", inputType: "text" },
+    "pro-pit-project-site-model": {
+      property: "project_site_model",
+      label: "Project site distribution model",
+      inputType: "select",
+      multiChoice: false,
+      optionListKey: "project-site-model-collection"
+    },
+    "pro-pit-indigenous-impact": {
+      property: "indigenous_impact",
+      label: "Project Impacts or Benefits for Indigenous People",
+      inputType: "text"
+    },
+    "pro-pit-barriers-project-activity": {
+      property: "barriers_project_activity",
+      label: "Barriers to Project Activities",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "barriers-project-collection"
+    },
+    "pro-pit-barriers-project-activity-description": {
+      property: "barriers_project_activity_description",
+      label: "Barriers to Project Activities Descriptions",
+      inputType: "text"
+    },
+    "pro-pit-other-engage-women-youth": {
+      property: "other_engage_women_youth",
+      label: "Other Ways Project will Engage and Benefit Women/Youth",
+      inputType: "text"
+    },
+    "pro-pit-forest-fragments-distance": {
+      property: "forest_fragments_distance",
+      label: "Approximate distance in meters between project area and the center of the nearest forest fragment",
+      inputType: "number"
+    },
+    "pro-pit-anr-practices-proposed": {
+      property: "anr_practices_proposed",
+      label: "ANR practices that the organization will use during the project",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "anr-practices-proposed-collection"
+    },
+    "pro-pit-information-authorization": {
+      property: "information_authorization",
+      label: "If the organization authorizes WRI to use their data for research",
+      inputType: "boolean"
+    },
+    "pro-pit-full-time-jobs-count": {
+      property: "full_time_jobs_aggregate",
+      label: "Aggregate full time jobs",
+      inputType: "number"
+    },
+    "pro-pit-full-time-clt-jobs-count": {
+      property: "full_time_clt_jobs_aggregate",
+      label: "Aggregate full time CLT jobs",
+      inputType: "number"
+    },
+    "pro-pit-part-time-jobs-count": {
+      property: "part_time_jobs_aggregate",
+      label: "Aggregate part time jobs",
+      inputType: "number"
+    },
+    "pro-pit-part-time-clt-jobs-count": {
+      property: "part_time_clt_jobs_aggregate",
+      label: "Aggregate part time CLT jobs",
+      inputType: "number"
+    },
+    "pro-pit-volunteers-count": {
+      property: "volunteers_aggregate",
+      label: "Aggregate volunteers",
+      inputType: "number"
+    },
+    "pro-pit-beneficiaries-count": {
+      property: "all_beneficiaries_aggregate",
+      label: "Aggregate beneficiaries",
+      inputType: "number"
+    },
+    "pro-pit-indirect-beneficiaries-count": {
+      property: "indirect_beneficiaries_aggregate",
+      label: "Aggregate indirect beneficiaries",
+      inputType: "number"
+    },
+    "pro-pit-associates-count": {
+      property: "all_associates_aggregate",
+      label: "Aggregate associates",
+      inputType: "number"
+    }
+  },
+  fileCollections: {
+    "pro-pit-fcol-cover": { property: "cover", label: "Cover Image", inputType: "file", multiChoice: false },
+    "pro-pit-fcol-add": { property: "additional", label: "Additional documents", inputType: "file", multiChoice: true },
+    "pro-pit-fcol-rest-photos": {
+      property: "restoration_photos",
+      label: "Past Restoration Photos",
+      inputType: "file",
+      multiChoice: true
+    },
+    "pro-pit-fcol-detail-proj-bdgt": {
+      property: "detailed_project_budget",
+      label: "Detailed project budget",
+      inputType: "file",
+      multiChoice: false
+    },
+    "pro-pit-proof-of-land-tenure-mou": {
+      property: "proof_of_land_tenure_mou",
+      label: "Proof of land tenure MOU",
+      inputType: "file",
+      multiChoice: true
+    }
+  },
+  relations: {
+    "pro-pit-tree-species": {
+      property: "treeSpecies",
+      label: "Tree Species",
+      resource: "App\\Http\\Resources\\V2\\TreeSpecies\\TreeSpeciesResource",
+      inputType: "treeSpecies",
+      collection: "tree-planted"
+    },
+    "pro-pit-all-jobs": {
+      property: "jobsAll",
+      label: "All Jobs",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "jobs",
+      collection: "all"
+    },
+    "pro-pit-full-time-jobs": {
+      property: "jobsFullTime",
+      label: "Full-time Jobs",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "jobs",
+      collection: "full-time"
+    },
+    "pro-pit-part-time-jobs": {
+      property: "jobsPartTime",
+      label: "Part-time Jobs",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "jobs",
+      collection: "part-time"
+    },
+    "pro-pit-volunteers": {
+      property: "volunteers",
+      label: "Volunteers",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "volunteers",
+      collection: "volunteer"
+    },
+    "pro-pit-all-beneficiaries": {
+      property: "allBeneficiaries",
+      label: "All Beneficiaries",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "allBeneficiaries",
+      collection: "all"
+    },
+    "pro-pit-indirect-beneficiaries": {
+      property: "indirectBeneficiaries",
+      label: "Indirect Beneficiaries",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "indirectBeneficiaries",
+      collection: "indirect"
+    }
+  }
+};

--- a/libs/common/src/lib/linkedFields/configuration/project-pitch.configuration.ts
+++ b/libs/common/src/lib/linkedFields/configuration/project-pitch.configuration.ts
@@ -1,6 +1,7 @@
 import { LinkedFieldConfiguration } from "../types";
 import { ProjectPitch } from "@terramatch-microservices/database/entities";
 
+// Note: All field / fileCollection / relation keys _must_ be unique across all LinkedFieldConfigurations.
 export const ProjectPitchConfiguration: LinkedFieldConfiguration = {
   label: "Project Pitch",
   laravelModelType: ProjectPitch.LARAVEL_TYPE,

--- a/libs/common/src/lib/linkedFields/configuration/project-report.configuration.ts
+++ b/libs/common/src/lib/linkedFields/configuration/project-report.configuration.ts
@@ -1,0 +1,690 @@
+import { LinkedFieldConfiguration } from "../types";
+import { ProjectReport } from "@terramatch-microservices/database/entities";
+
+export const ProjectReportConfiguration: LinkedFieldConfiguration = {
+  label: "Project Report",
+  laravelModelType: ProjectReport.LARAVEL_TYPE,
+  fields: {
+    "pro-rep-title": { property: "title", label: "Title", inputType: "text" },
+    "pro-rep-ind-1": { property: "ethnic_indigenous_1", label: "Indigenous 1", inputType: "number" },
+    "pro-rep-ind-2": { property: "ethnic_indigenous_2", label: "Indigenous 2", inputType: "number" },
+    "pro-rep-ind-3": { property: "ethnic_indigenous_3", label: "Indigenous 3", inputType: "number" },
+    "pro-rep-ind-4": { property: "ethnic_indigenous_4", label: "Indigenous 4", inputType: "number" },
+    "pro-rep-ind-5": { property: "ethnic_indigenous_5", label: "Indigenous 5", inputType: "number" },
+    "pro-rep-other-1": { property: "ethnic_other_1", label: "Other 1", inputType: "number" },
+    "pro-rep-other-2": { property: "ethnic_other_2", label: "Other 2", inputType: "number" },
+    "pro-rep-other-3": { property: "ethnic_other_3", label: "Other 3", inputType: "number" },
+    "pro-rep-other-4": { property: "ethnic_other_4", label: "Other 4", inputType: "number" },
+    "pro-rep-other-5": { property: "ethnic_other_5", label: "Other 5", inputType: "number" },
+    "pro-rep-workdays-paid": { property: "workdays_paid", label: "Workdays Paid", inputType: "number" },
+    "pro-rep-workdays-volunteer": { property: "workdays_volunteer", label: "Workdays Volunteer", inputType: "number" },
+    "pro-rep-tech-nar": { property: "technical_narrative", label: "Technical narrative", inputType: "long-text" },
+    "pro-rep-pub-nar": { property: "public_narrative", label: "Public narrative", inputType: "long-text" },
+    "pro-rep-landscape-com-con": {
+      property: "landscape_community_contribution",
+      label: "Landscape Progress",
+      inputType: "long-text"
+    },
+    "pro-rep-top-three-successes": {
+      property: "top_three_successes",
+      label: "Top Three Successes",
+      inputType: "long-text"
+    },
+    "pro-rep-chal-faced": { property: "challenges_faced", label: "Challenges Faced", inputType: "long-text" },
+    "pro-rep-lessons": { property: "lessons_learned", label: "Lessons Learned", inputType: "long-text" },
+    "pro-rep-maint-mon-act": {
+      property: "maintenance_and_monitoring_activities",
+      label: "Maintenance and Monitoring Activities",
+      inputType: "long-text"
+    },
+    "pro-rep-sig-change": { property: "significant_change", label: "Significant Change", inputType: "long-text" },
+    "pro-rep-pct-surv": {
+      property: "pct_survival_to_date",
+      label: "Percentage Survival to Date",
+      inputType: "number-percentage"
+    },
+    "pro-rep-surv-calc": { property: "survival_calculation", label: "Survival Calculation", inputType: "long-text" },
+    "pro-rep-surv-comp": { property: "survival_comparison", label: "Survival Comparison", inputType: "long-text" },
+    "pro-rep-ft-women": { property: "ft_women", label: "FT Women", inputType: "number" },
+    "pro-rep-ft-men": { property: "ft_men", label: "FT Men", inputType: "number" },
+    "pro-rep-ft-youth": { property: "ft_youth", label: "FT Youth", inputType: "number" },
+    "pro-rep-ft-smallholder": { property: "ft_smallholder_farmers", label: "FT Smallholder", inputType: "number" },
+    "pro-rep-ft-total": { property: "ft_total", label: "FT Total", inputType: "number" },
+    "pro-rep-pt-women": { property: "pt_women", label: "PT Women", inputType: "number" },
+    "pro-rep-pt-men": { property: "pt_men", label: "PT Men", inputType: "number" },
+    "pro-rep-pt-youth": { property: "pt_youth", label: "PT Youth", inputType: "number" },
+    "pro-rep-pt-non-youth": { property: "pt_non_youth", label: "PT Non-Youth", inputType: "number" },
+    "pro-rep-pt-smallholder": { property: "pt_smallholder_farmers", label: "PT Smallholder", inputType: "number" },
+    "pro-rep-pt-total": { property: "pt_total", label: "PT Total", inputType: "number" },
+    "pro-rep-seasonal-women": { property: "seasonal_women", label: "Seasonal Women", inputType: "number" },
+    "pro-rep-seasonal-men": { property: "seasonal_men", label: "Seasonal Men", inputType: "number" },
+    "pro-rep-seasonal-youth": { property: "seasonal_youth", label: "Seasonal Youth", inputType: "number" },
+    "pro-rep-seasonal-smallholder": {
+      property: "seasonal_smallholder_farmers",
+      label: "Seasonal Smallholder",
+      inputType: "number"
+    },
+    "pro-rep-seasonal-total": { property: "seasonal_total", label: "Seasonal Total", inputType: "number" },
+    "pro-rep-volunteer-women": { property: "volunteer_women", label: "Volunteer Women", inputType: "number" },
+    "pro-rep-volunteer-men": { property: "volunteer_men", label: "Volunteer Men", inputType: "number" },
+    "pro-rep-volunteer-youth": { property: "volunteer_youth", label: "Volunteer Youth", inputType: "number" },
+    "pro-rep-volunteer-smallholder": {
+      property: "volunteer_smallholder_farmers",
+      label: "Volunteer Smallholder",
+      inputType: "number"
+    },
+    "pro-rep-volunteer-total": { property: "volunteer_total", label: "Volunteer Total", inputType: "number" },
+    "pro-rep-shared-drive": { property: "shared_drive_link", label: "Shared Drive Link", inputType: "url" },
+    "pro-rep-planted-trees": { property: "planted_trees", label: "Planted Trees", inputType: "number" },
+    "pro-rep-new-jobs-desc": {
+      property: "new_jobs_description",
+      label: "New Jobs Description",
+      inputType: "long-text"
+    },
+    "pro-rep-volunteer-desc": {
+      property: "volunteers_work_description",
+      label: "Volunteers Work Description",
+      inputType: "long-text"
+    },
+    "pro-rep-ft-non-youth": { property: "ft_jobs_non_youth", label: "FT Jobs Non-Youth", inputType: "number" },
+    "pro-rep-volunteer-non-youth": {
+      property: "volunteer_non_youth",
+      label: "Volunteer Non-Youth",
+      inputType: "number"
+    },
+    "pro-rep-beneficiaries": { property: "beneficiaries", label: "Beneficiaries", inputType: "number" },
+    "pro-rep-beneficiaries-desc": {
+      property: "beneficiaries_description",
+      label: "Beneficiaries Description",
+      inputType: "long-text"
+    },
+    "pro-rep-beneficiaries-women": {
+      property: "beneficiaries_women",
+      label: "Beneficiaries Women",
+      inputType: "number"
+    },
+    "pro-rep-beneficiaries-men": { property: "beneficiaries_men", label: "Beneficiaries Men", inputType: "number" },
+    "pro-rep-beneficiaries-non-youth": {
+      property: "beneficiaries_non_youth",
+      label: "Beneficiaries Non-Youth",
+      inputType: "number"
+    },
+    "pro-rep-beneficiaries-youth": {
+      property: "beneficiaries_youth",
+      label: "Beneficiaries Youth",
+      inputType: "number"
+    },
+    "pro-rep-beneficiaries-smallholder": {
+      property: "beneficiaries_smallholder",
+      label: "Beneficiaries Smallholder",
+      inputType: "number"
+    },
+    "pro-rep-beneficiaries-large-scl": {
+      property: "beneficiaries_large_scale",
+      label: "Beneficiaries Large Scale",
+      inputType: "number"
+    },
+    "pro-rep-beneficiaries-income-inc": {
+      property: "beneficiaries_income_increase",
+      label: "Beneficiaries Income Increase",
+      inputType: "number"
+    },
+    "pro-rep-beneificaries-income-desc": {
+      property: "beneficiaries_income_increase_description",
+      label: "Beneficiaries Income Increase Description",
+      inputType: "long-text"
+    },
+    "pro-rep-beneficiaries-skill-inc": {
+      property: "beneficiaries_skills_knowledge_increase",
+      label: "Beneficiaries Skills Knowledge Increased",
+      inputType: "number"
+    },
+    "pro-rep-beneficiaries-skill-inc-desc": {
+      property: "beneficiaries_skills_knowledge_increase_description",
+      label: "Beneficiaries Skills Knowledge Description",
+      inputType: "long-text"
+    },
+    "pro-rep-people_knowledge-skills-increased": {
+      property: "people_knowledge_skills_increased",
+      label: "People Knowledge Skills Increased",
+      inputType: "number"
+    },
+    "pro-rep-community-progress": {
+      property: "community_progress",
+      label: "Community Engagement Progress",
+      inputType: "long-text"
+    },
+    "pro-rep-equitable-opportunities": {
+      property: "equitable_opportunities",
+      label: "Equitable Opportunities for Women + Youth",
+      inputType: "long-text"
+    },
+    "pro-rep-local-engagement": {
+      property: "local_engagement",
+      label: "Community Engagement Approach",
+      inputType: "select",
+      multiChoice: false,
+      optionListKey: "local-engagement"
+    },
+    "pro-rep-site-addition": { property: "site_addition", label: "Site Addition", inputType: "boolean" },
+    "pro-rep-resilience_progress": {
+      property: "resilience_progress",
+      label: "Climate Resilience Progress",
+      inputType: "long-text"
+    },
+    "pro-rep-local_governance": { property: "local_governance", label: "Governance Progress", inputType: "long-text" },
+    "pro-rep-adaptive_management": {
+      property: "adaptive_management",
+      label: "Adaptative Management",
+      inputType: "long-text"
+    },
+    "pro-rep-scalability_replicability": {
+      property: "scalability_replicability",
+      label: "Scalability Progress",
+      inputType: "long-text"
+    },
+    "pro-rep-convergence_jobs_description": {
+      property: "convergence_jobs_description",
+      label: "Description of Convergence Jobs",
+      inputType: "long-text"
+    },
+    "pro-rep-convergence_schemes": {
+      property: "convergence_schemes",
+      label: "Convergence Schemes",
+      inputType: "long-text"
+    },
+    "pro-rep-convergence_amount": { property: "convergence_amount", label: "Convergence Raised", inputType: "number" },
+    "pro-rep-community_partners_assets_description": {
+      property: "community_partners_assets_description",
+      label: "Community Assests",
+      inputType: "long-text"
+    },
+    "pro-rep-volunteer_scstobc": {
+      property: "volunteer_scstobc",
+      label: "Volunteers Marginalized",
+      inputType: "number"
+    },
+    "pro-rep-beneficiaries_scstobc_farmers": {
+      property: "beneficiaries_scstobc_farmers",
+      label: "Community Partners Marginalized Farmers",
+      inputType: "number"
+    },
+    "pro-rep-beneficiaries-scstobc": {
+      property: "beneficiaries_scstobc",
+      label: "Community Partners Marginalized",
+      inputType: "number"
+    },
+    // TODO (TM-912) Deprecated, to be removed.
+    "pro-rep-paid-other-activity-description": {
+      property: "paid_other_activity_description",
+      label: "Paid Other Activities Description",
+      inputType: "long-text"
+    },
+    "pro-rep-other-workdays-description": {
+      property: "other_workdays_description",
+      label: "Other Activities Description",
+      inputType: "long-text"
+    },
+    "pro-rep-local-engagement-description": {
+      property: "local_engagement_description",
+      label: "Response to Local Priorities",
+      inputType: "long-text"
+    },
+    "pro-rep-indirect-beneficiaries": {
+      property: "indirect_beneficiaries",
+      label: "Number of Indirect Beneficiaries",
+      inputType: "number"
+    },
+    "pro-rep-indirect-beneficiaries-description": {
+      property: "indirect_beneficiaries_description",
+      label: "Indirect Beneficiaries Description",
+      inputType: "long-text"
+    },
+    "pro-rep-other-restoration-partners-description": {
+      property: "other_restoration_partners_description",
+      label: "Other Restoration Partners Description",
+      inputType: "long-text"
+    },
+    "pro-rep-total-unique-restoration-partners": {
+      property: "total_unique_restoration_partners",
+      label: "Total Unique Restoration Partners",
+      inputType: "number"
+    },
+    "pro-rep-business-milestones": {
+      property: "business_milestones",
+      label: "Business Milestones",
+      inputType: "long-text"
+    },
+    "pro-rep-ft-other": { property: "ft_other", label: "Full Time Other Gender", inputType: "number" },
+    "pro-rep-pt-other": { property: "pt_other", label: "Part Time Other Gender", inputType: "number" },
+    "pro-rep-volunteer_other": { property: "volunteer_other", label: "Volunteer Other Gender", inputType: "number" },
+    "pro-rep-beneficiaries-other": {
+      property: "beneficiaries_other",
+      label: "Other Gender Beneficiary",
+      inputType: "number"
+    },
+    "pro-rep-beneficiaries-training-women": {
+      property: "beneficiaries_training_women",
+      label: "Women Trained",
+      inputType: "number"
+    },
+    "pro-rep-beneficiaries-training-men": {
+      property: "beneficiaries_training_men",
+      label: "Men Trained",
+      inputType: "number"
+    },
+    "pro-rep-beneficiaries-training-other": {
+      property: "beneficiaries_training_other",
+      label: "Other Gender Trained",
+      inputType: "number"
+    },
+    "pro-rep-beneficiaries-training-youth": {
+      property: "beneficiaries_training_youth",
+      label: "Youth Trained",
+      inputType: "number"
+    },
+    "pro-rep-beneficiaries-training-non-youth": {
+      property: "beneficiaries_training_non_youth",
+      label: "Non Youth Trained",
+      inputType: "number"
+    }
+  },
+  fileCollections: {
+    "pro-rep-col-media": { property: "media", label: "Media", inputType: "file", multiChoice: true },
+    "pro-rep-col-socioeconomic-benefits": {
+      property: "socioeconomic_benefits",
+      label: "Socioeconomic benefits",
+      inputType: "file",
+      multiChoice: true
+    },
+    "pro-rep-col-file": { property: "file", label: "File", inputType: "file", multiChoice: true },
+    "pro-rep-col-other-additional-documents": {
+      property: "other_additional_documents",
+      label: "Other additional documents",
+      inputType: "file",
+      multiChoice: true
+    },
+    "pro-rep-col-photos": { property: "photos", label: "Photos", inputType: "file", multiChoice: true },
+    "pro-rep-col-baseline-report-upload": {
+      property: "baseline_report_upload",
+      label: "Baseline Report Upload",
+      inputType: "file",
+      multiChoice: true
+    },
+    "pro-rep-col-local-governance-order-letter-upload": {
+      property: "local_governance_order_letter_upload",
+      label: "Local Governance Order or Letter Upload",
+      inputType: "file",
+      multiChoice: true
+    },
+    "pro-rep-col-events-meetings-photos": {
+      property: "events_meetings_photos",
+      label: "Events or Meetings Photos",
+      inputType: "file",
+      multiChoice: true
+    },
+    "pro-rep-col-local-governance-proof-of-partnership-upload": {
+      property: "local_governance_proof_of_partnership_upload",
+      label: "Local Governance Proof of Partnership Upload",
+      inputType: "file",
+      multiChoice: true
+    },
+    "pro-rep-col-top-three-successes-upload": {
+      property: "top_three_successes_upload",
+      label: "Top Three Successes Upload",
+      inputType: "file",
+      multiChoice: true
+    },
+    "pro-rep-col-direct-jobs-upload": {
+      property: "direct_jobs_upload",
+      label: "Direct Jobs Upload",
+      inputType: "file",
+      multiChoice: true
+    },
+    "pro-rep-col-convergence-jobs-upload": {
+      property: "convergence_jobs_upload",
+      label: "Convergence Jobs Upload",
+      inputType: "file",
+      multiChoice: true
+    },
+    "pro-rep-col-convergence-schemes-upload": {
+      property: "convergence_schemes_upload",
+      label: "Convergence Schemes Upload",
+      inputType: "file",
+      multiChoice: true
+    },
+    "pro-rep-col-livelihood-activities-upload": {
+      property: "livelihood_activities_upload",
+      label: "Livelihood Report Upload",
+      inputType: "file",
+      multiChoice: true
+    },
+    "pro-rep-col-direct-livelihood-impacts-upload": {
+      property: "direct_livelihood_impacts_upload",
+      label: "Direct Livelihood Impacts Upload",
+      inputType: "file",
+      multiChoice: true
+    },
+    "pro-rep-col-certified-database-upload": {
+      property: "certified_database_upload",
+      label: "Certified Database Upload",
+      inputType: "file",
+      multiChoice: true
+    },
+    "pro-rep-col-physical-assets-photos": {
+      property: "physical_assets_photos",
+      label: "Physical Assets Photos",
+      inputType: "file",
+      multiChoice: true
+    },
+    "pro-rep-col-indirect-community-partners-upload": {
+      property: "indirect_community_partners_upload",
+      label: "Indirect Community Partners Upload",
+      inputType: "file",
+      multiChoice: true
+    },
+    "pro-rep-col-training-capacity-building-upload": {
+      property: "training_capacity_building_upload",
+      label: "Training or Capacity Building Upload",
+      inputType: "file",
+      multiChoice: true
+    },
+    "pro-rep-col-training-capacity-building-photos": {
+      property: "training_capacity_building_photos",
+      label: "Training or Capacity Building Photos",
+      inputType: "file",
+      multiChoice: true
+    },
+    "pro-rep-col-financial-report-upload": {
+      property: "financial_report_upload",
+      label: "Financial Report Upload",
+      inputType: "file",
+      multiChoice: true
+    },
+    "pro-rep-col-tree-planting-upload": {
+      property: "tree_planting_upload",
+      label: "Tree Planting Upload",
+      inputType: "file",
+      multiChoice: true
+    },
+    "pro-rep-col-soil-water-conservation-upload": {
+      property: "soil_water_conservation_upload",
+      label: "Soil or Water Conservation Upload",
+      inputType: "file",
+      multiChoice: true
+    },
+    "pro-rep-col-soil-water-conservation-photos": {
+      property: "soil_water_conservation_photos",
+      label: "Soil or Water Conservation Photos",
+      inputType: "file",
+      multiChoice: true
+    }
+  },
+  relations: {
+    "pro-rep-rel-tree-species": {
+      property: "treeSpecies",
+      label: "Tree Species (Nursery Seedling)",
+      resource: "App\\Http\\Resources\\V2\\TreeSpecies\\TreeSpeciesResource",
+      inputType: "treeSpecies",
+      collection: "nursery-seedling"
+    },
+    "pro-rep-rel-paid-nursery-operations": {
+      property: "workdaysPaidNurseryOperations",
+      label: "Paid Nursery Operations",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "workdays",
+      collection: "paid-nursery-operations"
+    },
+    "pro-rep-rel-paid-project-management": {
+      property: "workdaysPaidProjectManagement",
+      label: "Paid Project Management",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "workdays",
+      collection: "paid-project-management"
+    },
+    "pro-rep-rel-paid-other-activities": {
+      property: "workdaysPaidOtherActivities",
+      label: "Paid Other Activities",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "workdays",
+      collection: "paid-other-activities"
+    },
+    "pro-rep-rel-volunteer-nursery-operations": {
+      property: "workdaysVolunteerNurseryOperations",
+      label: "Volunteer Nursery Operations",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "workdays",
+      collection: "volunteer-nursery-operations"
+    },
+    "pro-rep-rel-volunteer-project-management": {
+      property: "workdaysVolunteerProjectManagement",
+      label: "Volunteer Project Management",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "workdays",
+      collection: "volunteer-project-management"
+    },
+    "pro-rep-rel-volunteer-other-activities": {
+      property: "workdaysVolunteerOtherActivities",
+      label: "Volunteer Other Activities",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "workdays",
+      collection: "volunteer-other-activities"
+    },
+    "pro-rep-direct-workdays": {
+      property: "workdaysDirect",
+      label: "Direct Workday",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "workdays",
+      collection: "direct"
+    },
+    "pro-rep-convergence-workdays": {
+      property: "workdaysConvergence",
+      label: "Convergence Workday",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "workdays",
+      collection: "convergence"
+    },
+    "pro-rep-direct-income-partners": {
+      property: "restorationPartnersDirectIncome",
+      label: "Direct Income Restoration Partners",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "restorationPartners",
+      collection: "direct-income"
+    },
+    "pro-rep-indirect-income-partners": {
+      property: "restorationPartnersIndirectIncome",
+      label: "Indirect Income Restoration Partners",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "restorationPartners",
+      collection: "indirect-income"
+    },
+    "pro-rep-direct-benefits-partners": {
+      property: "restorationPartnersDirectBenefits",
+      label: "Direct In-kind Benefits Restoration Partners",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "restorationPartners",
+      collection: "direct-benefits"
+    },
+    "pro-rep-indirect-benefits-partners": {
+      property: "restorationPartnersIndirectBenefits",
+      label: "Indirect In-kind Benefits Restoration Partners",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "restorationPartners",
+      collection: "indirect-benefits"
+    },
+    "pro-rep-direct-conservation-payments-partners": {
+      property: "restorationPartnersDirectConservationPayments",
+      label: "Direct Conservation Agreement Payment Restoration Partners",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "restorationPartners",
+      collection: "direct-conservation-payments"
+    },
+    "pro-rep-indirect-conservation-payments-partners": {
+      property: "restorationPartnersIndirectConservationPayments",
+      label: "Indirect Conservation Agreement Payment Restoration Partners",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "restorationPartners",
+      collection: "indirect-conservation-payments"
+    },
+    "pro-rep-direct-market-access-partners": {
+      property: "restorationPartnersDirectMarketAccess",
+      label: "Direct Increased Market Access Restoration Partners",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "restorationPartners",
+      collection: "direct-market-access"
+    },
+    "pro-rep-indirect-market-access-partners": {
+      property: "restorationPartnersIndirectMarketAccess",
+      label: "Indirect Increased Market Access Restoration Partners",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "restorationPartners",
+      collection: "indirect-market-access"
+    },
+    "pro-rep-direct-capacity-partners": {
+      property: "restorationPartnersDirectCapacity",
+      label: "Direct Increased Capacity Restoration Partners",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "restorationPartners",
+      collection: "direct-capacity"
+    },
+    "pro-rep-indirect-capacity-partners": {
+      property: "restorationPartnersIndirectCapacity",
+      label: "Indirect Capacity Restoration Partners",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "restorationPartners",
+      collection: "indirect-capacity"
+    },
+    "pro-rep-direct-training-partners": {
+      property: "restorationPartnersDirectTraining",
+      label: "Direct Training Restoration Partners",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "restorationPartners",
+      collection: "direct-training"
+    },
+    "pro-rep-indirect-training-partners": {
+      property: "restorationPartnersIndirectTraining",
+      label: "Indirect Training Restoration Partners",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "restorationPartners",
+      collection: "indirect-training"
+    },
+    "pro-rep-direct-land-title-partners": {
+      property: "restorationPartnersDirectLandTitle",
+      label: "Direct Newly Secured Land Title Restoration Partners",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "restorationPartners",
+      collection: "direct-land-title"
+    },
+    "pro-rep-indirect-land-title-partners": {
+      property: "restorationPartnersIndirectLandTitle",
+      label: "Indirect Newly Secured Land Title Restoration Partners",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "restorationPartners",
+      collection: "indirect-land-title"
+    },
+    "pro-rep-direct-livelihoods-partners": {
+      property: "restorationPartnersDirectLivelihoods",
+      label: "Direct Traditional Livelihoods or Customer Rights Restoration Partners",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "restorationPartners",
+      collection: "direct-livelihoods"
+    },
+    "pro-rep-indirect-livelihoods-partners": {
+      property: "restorationPartnersIndirectLivelihoods",
+      label: "Indirect Traditional Livelihoods or Customer Rights Restoration Partners",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "restorationPartners",
+      collection: "indirect-livelihoods"
+    },
+    "pro-rep-direct-productivity-partners": {
+      property: "restorationPartnersDirectProductivity",
+      label: "Direct Increased Productivity Restoration Partners",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "restorationPartners",
+      collection: "direct-productivity"
+    },
+    "pro-rep-indirect-productivity-partners": {
+      property: "restorationPartnersIndirectProductivity",
+      label: "Indirect Increased Productivity Restoration Partners",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "restorationPartners",
+      collection: "indirect-productivity"
+    },
+    "pro-rep-direct-other-partners": {
+      property: "restorationPartnersDirectOther",
+      label: "Direct Other Restoration Partners",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "restorationPartners",
+      collection: "direct-other"
+    },
+    "pro-rep-indirect-other-partners": {
+      property: "restorationPartnersIndirectOther",
+      label: "Indirect Other Restoration Partners",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "restorationPartners",
+      collection: "indirect-other"
+    },
+    "pro-rep-full-time-jobs": {
+      property: "jobsFullTime",
+      label: "Full-time Jobs",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "jobs",
+      collection: "full-time"
+    },
+    "pro-rep-full-time-clt-jobs": {
+      property: "jobsFullTimeClt",
+      label: "Full-time CLT Jobs",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "jobs",
+      collection: "full-time-clt"
+    },
+    "pro-rep-part-time-jobs": {
+      property: "jobsPartTime",
+      label: "Part-time Jobs",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "jobs",
+      collection: "part-time"
+    },
+    "pro-rep-part-time-clt-jobs": {
+      property: "jobsPartTimeClt",
+      label: "Part-time CLT Jobs",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "jobs",
+      collection: "part-time-clt"
+    },
+    "pro-rep-volunteers": {
+      property: "volunteers",
+      label: "Volunteers",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "volunteers",
+      collection: "volunteer"
+    },
+    "pro-rep-beneficiaries-all": {
+      property: "allBeneficiaries",
+      label: "All Beneficiaries",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "allBeneficiaries",
+      collection: "all"
+    },
+    "pro-rep-beneficiaries-training": {
+      property: "trainingBeneficiaries",
+      label: "Training Beneficiaries",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "trainingBeneficiaries",
+      collection: "training"
+    },
+    "pro-rep-associates": {
+      property: "associates",
+      label: "Associates",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "associates",
+      collection: "all"
+    },
+    "pro-rep-financial-indicators-financial-collection": {
+      property: "financialCollection",
+      label: "Financial collection",
+      resource: "App\\Http\\Resources\\V2\\FinancialIndicatorsResource",
+      inputType: "financialIndicators"
+    }
+  }
+};

--- a/libs/common/src/lib/linkedFields/configuration/project-report.configuration.ts
+++ b/libs/common/src/lib/linkedFields/configuration/project-report.configuration.ts
@@ -129,7 +129,7 @@ export const ProjectReportConfiguration: LinkedFieldConfiguration = {
       label: "Beneficiaries Income Increase",
       inputType: "number"
     },
-    "pro-rep-beneificaries-income-desc": {
+    "pro-rep-beneficiaries-income-desc": {
       property: "beneficiaries_income_increase_description",
       label: "Beneficiaries Income Increase Description",
       inputType: "long-text"
@@ -209,7 +209,7 @@ export const ProjectReportConfiguration: LinkedFieldConfiguration = {
       label: "Community Partners Marginalized Farmers",
       inputType: "number"
     },
-    "pro-rep-beneficiaries-scstobc": {
+    "pro-rep-beneficiaries_scstobc": {
       property: "beneficiaries_scstobc",
       label: "Community Partners Marginalized",
       inputType: "number"

--- a/libs/common/src/lib/linkedFields/configuration/project-report.configuration.ts
+++ b/libs/common/src/lib/linkedFields/configuration/project-report.configuration.ts
@@ -1,6 +1,7 @@
 import { LinkedFieldConfiguration } from "../types";
 import { ProjectReport } from "@terramatch-microservices/database/entities";
 
+// Note: All field / fileCollection / relation keys _must_ be unique across all LinkedFieldConfigurations.
 export const ProjectReportConfiguration: LinkedFieldConfiguration = {
   label: "Project Report",
   laravelModelType: ProjectReport.LARAVEL_TYPE,

--- a/libs/common/src/lib/linkedFields/configuration/project.configuration.ts
+++ b/libs/common/src/lib/linkedFields/configuration/project.configuration.ts
@@ -92,7 +92,7 @@ export const ProjectConfiguration: LinkedFieldConfiguration = {
     "pro-county-district": { property: "project_county_district", label: "Project District", inputType: "text" },
     "pro-desc-of-proj-timeline": {
       property: "description_of_project_timeline",
-      label: "Key stages of this project's implementation",
+      label: "Key stages of this project’s implementation",
       inputType: "long-text"
     },
     "pro-siting-strategy-description": {
@@ -308,7 +308,7 @@ export const ProjectConfiguration: LinkedFieldConfiguration = {
     },
     "pro-col-programme-submission": {
       property: "programme_submission",
-      label: "Programme Submission",
+      label: "programme_submission",
       inputType: "file",
       multiChoice: true
     },
@@ -320,7 +320,7 @@ export const ProjectConfiguration: LinkedFieldConfiguration = {
     },
     "pro-col-proof-of-land-tenure-mou": {
       property: "proof_of_land_tenure_mou",
-      label: "Documentation on project area's land tenure",
+      label: "Documentation on project area’s land tenure",
       inputType: "file",
       multiChoice: true
     }

--- a/libs/common/src/lib/linkedFields/configuration/project.configuration.ts
+++ b/libs/common/src/lib/linkedFields/configuration/project.configuration.ts
@@ -1,0 +1,379 @@
+import { LinkedFieldConfiguration } from "../types";
+import { Project } from "@terramatch-microservices/database/entities";
+
+export const ProjectConfiguration: LinkedFieldConfiguration = {
+  label: "Project",
+  laravelModelType: Project.LARAVEL_TYPE,
+  fields: {
+    "pro-name": { property: "name", label: "Name", inputType: "text" },
+    "pro-land-use-types": {
+      property: "land_use_types",
+      label: "Land use types",
+      inputType: "select-image",
+      multiChoice: true,
+      optionListKey: "restoration-systems"
+    },
+    "pro-restoration_strategy": {
+      property: "restoration_strategy",
+      label: "Restoration strategy",
+      inputType: "select-image",
+      multiChoice: true,
+      optionListKey: "restoration-practices"
+    },
+    "pro-land-tenure-proj-area": {
+      property: "land_tenure_project_area",
+      label: "Land tenure",
+      inputType: "select-image",
+      multiChoice: true,
+      optionListKey: "project-land-tenures"
+    },
+    "pro-country": {
+      property: "country",
+      label: "Country",
+      inputType: "select",
+      multiChoice: false,
+      optionListKey: "gadm-level-0"
+    },
+    "pro-continent": {
+      property: "continent",
+      label: "Continent",
+      inputType: "select",
+      multiChoice: false,
+      optionListKey: "continents"
+    },
+    "pro-plant_start_dte": { property: "planting_start_date", label: "planting start date", inputType: "date" },
+    "pro-plant_end_dte": { property: "planting_end_date", label: "Planting end date", inputType: "date" },
+    "pro-description": { property: "description", label: "Description", inputType: "long-text" },
+    "pro-history": { property: "history", label: "History", inputType: "long-text" },
+    "pro-objectives": { property: "objectives", label: "Objectives", inputType: "long-text" },
+    "pro-environmental-goals": {
+      property: "environmental_goals",
+      label: "Environmental goals",
+      inputType: "long-text"
+    },
+    "pro-socioeconomic-goals": {
+      property: "socioeconomic_goals",
+      label: "Socioeconomic goals",
+      inputType: "long-text"
+    },
+    "pro-sdgs-impacted": {
+      property: "sdgs_impacted",
+      label: "SDGS impacted",
+      inputType: "select-image",
+      multiChoice: true,
+      optionListKey: "sdgs-impacted-type"
+    },
+    "pro-long-term-growth": { property: "long_term_growth", label: "Long term growth", inputType: "long-text" },
+    "pro-community-incentives": {
+      property: "community_incentives",
+      label: "Community incentives",
+      inputType: "long-text"
+    },
+    "pro-budget": { property: "budget", label: "budget", inputType: "number" },
+    "pro-jobs-created-goal": { property: "jobs_created_goal", label: "Jobs created goal", inputType: "number" },
+    "pro-total-hectares-restored-goal": {
+      property: "total_hectares_restored_goal",
+      label: "Total hectares restored goal",
+      inputType: "number"
+    },
+    "pro-trees-grown-goal": { property: "trees_grown_goal", label: "Trees grown goal", inputType: "number" },
+    "pro-survival-rate": { property: "survival_rate", label: "Survival rate", inputType: "number" },
+    "pro-year-five-crown-cover": {
+      property: "year_five_crown_cover",
+      label: "Year five crown cover",
+      inputType: "number"
+    },
+    "pro-monitored-tree-cover": {
+      property: "monitored_tree_cover",
+      label: "monitored tree cover",
+      inputType: "number"
+    },
+    "pro-organization-name": { property: "organization_name", label: "Organisation Name", inputType: "text" },
+    "pro-county-district": { property: "project_county_district", label: "Project District", inputType: "text" },
+    "pro-desc-of-proj-timeline": {
+      property: "description_of_project_timeline",
+      label: "Key stages of this project's implementation",
+      inputType: "long-text"
+    },
+    "pro-siting-strategy-description": {
+      property: "siting_strategy_description",
+      label: "Siting Strategy Description",
+      inputType: "long-text"
+    },
+    "pro-siting-strategy": {
+      property: "siting_strategy",
+      label: "Siting Strategy",
+      inputType: "select",
+      multiChoice: false,
+      optionListKey: "siting-strategy"
+    },
+    "pro-landholder-comm-engage": {
+      property: "landholder_comm_engage",
+      label: "Landholder & Community Engagement Strategy",
+      inputType: "long-text"
+    },
+    "pro-proj-partner-info": {
+      property: "proj_partner_info",
+      label: "Proposed project partner information",
+      inputType: "long-text"
+    },
+    "pro-proj-success-risks": {
+      property: "proj_success_risks",
+      label: "Risk + Mitigate strategy",
+      inputType: "long-text"
+    },
+    "pro-monitor-eval-plan": {
+      property: "monitor_eval_plan",
+      label: "Report, Monitor, Verification Strategy",
+      inputType: "long-text"
+    },
+    "pro-seedlings-source": {
+      property: "seedlings_source",
+      label: "Sources of tree seedlings for the project",
+      inputType: "long-text"
+    },
+    "pro-pct-employees-men": {
+      property: "pct_employees_men",
+      label: "% of total employees that would be men",
+      inputType: "number-percentage"
+    },
+    "pro-pct-employees-women": {
+      property: "pct_employees_women",
+      label: "% of total employees that would be women",
+      inputType: "number-percentage"
+    },
+    "pro-pct-employees-18to35": {
+      property: "pct_employees_18to35",
+      label: "% of total employees that would be between the ages of 18 and 35",
+      inputType: "number-percentage"
+    },
+    "pro-pct-employees-older35": {
+      property: "pct_employees_older35",
+      label: "% of total employees that would be older than 35 years of age",
+      inputType: "number-percentage"
+    },
+    "pro-pct-employees-marginalised": {
+      property: "pct_employees_marginalised",
+      label: "% of total employees that would be part of a marginalised community",
+      inputType: "number-percentage"
+    },
+    "pro-beneficiaries": { property: "proj_beneficiaries", label: "Project beneficiaries Total", inputType: "number" },
+    "pro-pct-beneficiaries-women": {
+      property: "pct_beneficiaries_women",
+      label: "% of female beneficiaries",
+      inputType: "number-percentage"
+    },
+    "pro-pct-beneficiaries-men": {
+      property: "pct_beneficiaries_men",
+      label: "% Beneficiaries men",
+      inputType: "number-percentage"
+    },
+    "pro-pct-beneficiaries-small": {
+      property: "pct_beneficiaries_small",
+      label: "% of smallholder farmers beneficiaries",
+      inputType: "number-percentage"
+    },
+    "pro-pct-beneficiaries-large": {
+      property: "pct_beneficiaries_large",
+      label: "% of large-scale farmers beneficiaries",
+      inputType: "number-percentage"
+    },
+    "pro-pct-beneficiaries-35below": {
+      property: "pct_beneficiaries_youth",
+      label: "% of beneficiaries younger than 36",
+      inputType: "number-percentage"
+    },
+    "pro-pct-beneficiaries-marginalised": {
+      property: "pct_beneficiaries_marginalised",
+      label: "% Beneficiaries Marginalised Communities",
+      inputType: "number-percentage"
+    },
+    "pro-detailed-rst-inv-types": {
+      property: "detailed_intervention_types",
+      label: "Detailed intervention types",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "interventions"
+    },
+    "pro-proj-impact-foodsec": {
+      property: "proj_impact_foodsec",
+      label: "Potential project impact: food security",
+      inputType: "long-text"
+    },
+    // This is breaking convention for linked field keys because project pitch was already using pro-proposed-gov-partners.
+    "project-proposed-gov-partners": {
+      property: "proposed_gov_partners",
+      label: "Proposed government partners",
+      inputType: "long-text"
+    },
+    "pro-proposed-num-nurseries": {
+      property: "proposed_num_nurseries",
+      label: "Proposed Number of Nurseries",
+      inputType: "number"
+    },
+    "pro-proj-boundary": { property: "proj_boundary", label: "Project Boundary", inputType: "mapInput" },
+    "pro-states": {
+      property: "states",
+      label: "States",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "gadm-level-1"
+    },
+    "pro-impact-biodiv": {
+      property: "proj_impact_biodiv",
+      label: "Biodiversity Impact (project)",
+      inputType: "long-text"
+    },
+    // This is breaking convention for linked field keys because project pitch was already using pro-water-source.
+    "project-water-source": { property: "water_source", label: "Water Source", inputType: "long-text" },
+    "pro-baseline-biodiversity": {
+      property: "baseline_biodiversity",
+      label: "Baseline Biodiversity Conditions",
+      inputType: "long-text"
+    },
+    "pro-goal-trees-restored-planting": {
+      property: "goal_trees_restored_planting",
+      label: "Trees Restored Goal - Planting",
+      inputType: "number"
+    },
+    "pro-goal-trees-restored-anr": {
+      property: "goal_trees_restored_anr",
+      label: "Trees Restored Goal - ANR",
+      inputType: "number"
+    },
+    "pro-goal-trees-restored-direct-seeding": {
+      property: "goal_trees_restored_direct_seeding",
+      label: "Trees Restored Goal - Direct Seeding",
+      inputType: "number"
+    },
+    "pro-direct-seeding-survival-rate": {
+      property: "direct_seeding_survival_rate",
+      label: "Direct Seeding Survival Rate",
+      inputType: "number-percentage"
+    },
+    "pro-full-time-jobs-count": {
+      property: "full_time_jobs_aggregate",
+      label: "Aggregate full time jobs",
+      inputType: "number"
+    },
+    "pro-full-clt-time-jobs-count": {
+      property: "full_time_clt_jobs_aggregate",
+      label: "Aggregate full time CLT jobs",
+      inputType: "number"
+    },
+    "pro-part-time-jobs-count": {
+      property: "part_time_jobs_aggregate",
+      label: "Aggregate part time jobs",
+      inputType: "number"
+    },
+    "pro-part-clt-time-jobs-count": {
+      property: "part_time_clt_jobs_aggregate",
+      label: "Aggregate part time CLT jobs",
+      inputType: "number"
+    },
+    "pro-volunteers-count": { property: "volunteers_aggregate", label: "Aggregate volunteers", inputType: "number" },
+    "pro-beneficiaries-count": {
+      property: "all_beneficiaries_aggregate",
+      label: "Aggregate beneficiaries",
+      inputType: "number"
+    },
+    "pro-indirect-beneficiaries-count": {
+      property: "indirect_beneficiaries_aggregate",
+      label: "Aggregate indirect beneficiaries",
+      inputType: "number"
+    },
+    "pro-associates-count": { property: "all_associates_aggregate", label: "Aggregate associates", inputType: "number" }
+  },
+  fileCollections: {
+    "pro-col-media": { property: "media", label: "Media", inputType: "file", multiChoice: true },
+    "pro-col-socioeconomic-benefits": {
+      property: "socioeconomic_benefits",
+      label: "Socioeconomic benefits",
+      inputType: "file",
+      multiChoice: true
+    },
+    "pro-col-file": { property: "file", label: "File", inputType: "file", multiChoice: true },
+    "pro-col-other-additional-documents": {
+      property: "other_additional_documents",
+      label: "Other additional documents",
+      inputType: "file",
+      multiChoice: true
+    },
+    "pro-col-photos": { property: "photos", label: "Photos", inputType: "file", multiChoice: true },
+    "pro-col-document-files": {
+      property: "document_files",
+      label: "Document Files",
+      inputType: "file",
+      multiChoice: true
+    },
+    "pro-col-programme-submission": {
+      property: "programme_submission",
+      label: "Programme Submission",
+      inputType: "file",
+      multiChoice: true
+    },
+    "pro-col-detailed-project-budget": {
+      property: "detailed_project_budget",
+      label: "Detailed project budget",
+      inputType: "file",
+      multiChoice: false
+    },
+    "pro-col-proof-of-land-tenure-mou": {
+      property: "proof_of_land_tenure_mou",
+      label: "Documentation on project area's land tenure",
+      inputType: "file",
+      multiChoice: true
+    }
+  },
+  relations: {
+    "pro-pit-rel-tree-species": {
+      property: "treeSpecies",
+      label: "Tree Species",
+      resource: "App\\Http\\Resources\\V2\\TreeSpecies\\TreeSpeciesResource",
+      inputType: "treeSpecies",
+      collection: "tree-planted"
+    },
+    "pro-all-jobs": {
+      property: "jobsAll",
+      label: "All Jobs",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "jobs",
+      collection: "all"
+    },
+    "pro-full-time-jobs": {
+      property: "jobsFullTime",
+      label: "Full-time Jobs",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "jobs",
+      collection: "full-time"
+    },
+    "pro-part-time-jobs": {
+      property: "jobsPartTime",
+      label: "Part-time Jobs",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "jobs",
+      collection: "part-time"
+    },
+    "pro-volunteers": {
+      property: "volunteers",
+      label: "Volunteers",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "volunteers",
+      collection: "volunteer"
+    },
+    "pro-all-beneficiaries": {
+      property: "allBeneficiaries",
+      label: "All Beneficiaries",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "allBeneficiaries",
+      collection: "all"
+    },
+    "pro-indirect-beneficiaries": {
+      property: "indirectBeneficiaries",
+      label: "Indirect Beneficiaries",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "indirectBeneficiaries",
+      collection: "indirect"
+    }
+  }
+};

--- a/libs/common/src/lib/linkedFields/configuration/project.configuration.ts
+++ b/libs/common/src/lib/linkedFields/configuration/project.configuration.ts
@@ -1,6 +1,7 @@
 import { LinkedFieldConfiguration } from "../types";
 import { Project } from "@terramatch-microservices/database/entities";
 
+// Note: All field / fileCollection / relation keys _must_ be unique across all LinkedFieldConfigurations.
 export const ProjectConfiguration: LinkedFieldConfiguration = {
   label: "Project",
   laravelModelType: Project.LARAVEL_TYPE,

--- a/libs/common/src/lib/linkedFields/configuration/site-report.configuration.ts
+++ b/libs/common/src/lib/linkedFields/configuration/site-report.configuration.ts
@@ -1,6 +1,7 @@
 import { LinkedFieldConfiguration } from "../types";
 import { SiteReport } from "@terramatch-microservices/database/entities";
 
+// Note: All field / fileCollection / relation keys _must_ be unique across all LinkedFieldConfigurations.
 export const SiteReportConfiguration: LinkedFieldConfiguration = {
   label: "Site Report",
   laravelModelType: SiteReport.LARAVEL_TYPE,

--- a/libs/common/src/lib/linkedFields/configuration/site-report.configuration.ts
+++ b/libs/common/src/lib/linkedFields/configuration/site-report.configuration.ts
@@ -1,0 +1,271 @@
+import { LinkedFieldConfiguration } from "../types";
+import { SiteReport } from "@terramatch-microservices/database/entities";
+
+export const SiteReportConfiguration: LinkedFieldConfiguration = {
+  label: "Site Report",
+  laravelModelType: SiteReport.LARAVEL_TYPE,
+  fields: {
+    "site-rep-title": { property: "title", label: "Title", inputType: "text" },
+    "site-rep-shared-drive-link": { property: "shared_drive_link", label: "Shared drive link", inputType: "url" },
+    "site-rep-technical-narrative": {
+      property: "technical_narrative",
+      label: "Technical narrative",
+      inputType: "long-text"
+    },
+    "site-rep-public-narrative": { property: "public_narrative", label: "Public narrative", inputType: "long-text" },
+    "site-rep-disturbance-details": {
+      property: "disturbance_details",
+      label: "Additional Disturbance Details",
+      inputType: "long-text"
+    },
+    "site-rep-workdays-paid": { property: "workdays_paid", label: "Workdays paid", inputType: "number" },
+    "site-rep-seeds-planted": { property: "seeds_planted", label: "Seeds planted", inputType: "number" },
+    "site-rep-workdays-volunteer": { property: "workdays_volunteer", label: "Workdays volunteer", inputType: "number" },
+    "site-rep-polygon-status": { property: "polygon_status", label: "Polygon status", inputType: "long-text" },
+    "site-rep-invasive_species_removed": {
+      property: "invasive_species_removed",
+      label: "Invasive Species Removed",
+      inputType: "long-text"
+    },
+    "site-rep-invasive_species_management": {
+      property: "invasive_species_management",
+      label: "Invasive Species Management Plan",
+      inputType: "long-text"
+    },
+    "site-rep-soil_water_restoration_description": {
+      property: "soil_water_restoration_description",
+      label: "Soil + Water Restoration Methods",
+      inputType: "long-text"
+    },
+    "site-rep-water_structures": {
+      property: "water_structures",
+      label: "Water Structures Created",
+      inputType: "long-text"
+    },
+    "site-rep-site_community_partners_description": {
+      property: "site_community_partners_description",
+      label: "Community Partners (Site)",
+      inputType: "long-text"
+    },
+    "site-rep-site_community_partners_income_increase_description": {
+      property: "site_community_partners_income_increase_description",
+      label: "Community Partners Income Increase (Site)",
+      inputType: "long-text"
+    },
+    // TODO (TM-912) Deprecated, to be removed.
+    "site-rep-paid-other-activity-description": {
+      property: "paid_other_activity_description",
+      label: "Paid Other Activities Description",
+      inputType: "long-text"
+    },
+    "site-rep-other-workdays-description": {
+      property: "other_workdays_description",
+      label: "Other Activities Description",
+      inputType: "long-text"
+    },
+    "site-rep-num-trees-regenerating": {
+      property: "num_trees_regenerating",
+      label: "Estimate Number of Trees Restored via ANR",
+      inputType: "number"
+    },
+    "site-rep-regeneration-description": {
+      property: "regeneration_description",
+      label: "Description of ANR Activities",
+      inputType: "long-text"
+    },
+    "site-rep-pct-survival-to-date": {
+      property: "pct_survival_to_date",
+      label: "Survival Rate",
+      inputType: "number-percentage"
+    },
+    "site-rep-survival-calculation": {
+      property: "survival_calculation",
+      label: "Description of Survival Rate Calculation",
+      inputType: "long-text"
+    },
+    "site-rep-survival-description": {
+      property: "survival_description",
+      label: "Explanation of Survival Rate",
+      inputType: "long-text"
+    },
+    "site-rep-maintenance-activities": {
+      property: "maintenance_activities",
+      label: "Maintenance Activities",
+      inputType: "long-text"
+    }
+  },
+  fileCollections: {
+    "site-rep-col-media": { property: "media", label: "Media", inputType: "file", multiChoice: true },
+    "site-rep-col-socioeconomic-benefits": {
+      property: "socioeconomic_benefits",
+      label: "Socioeconomic benefits",
+      inputType: "file",
+      multiChoice: true
+    },
+    "site-rep-col-file": { property: "file", label: "File", inputType: "file", multiChoice: true },
+    "site-rep-col-other-additional-documents": {
+      property: "other_additional_documents",
+      label: "Other additional documents",
+      inputType: "file",
+      multiChoice: true
+    },
+    "site-rep-col-photos": { property: "photos", label: "Photos", inputType: "file", multiChoice: true },
+    "site-rep-col-document-files": {
+      property: "document_files",
+      label: "Photos",
+      inputType: "file",
+      multiChoice: true
+    },
+    "site-rep-col-tree-species": {
+      property: "tree_species",
+      label: "programme_submission",
+      inputType: "file",
+      multiChoice: true
+    },
+    "site-rep-col-site-submission": {
+      property: "site_submission",
+      label: "Site submission",
+      inputType: "file",
+      multiChoice: true
+    },
+    "site-rep-col-tree-planting-upload": {
+      property: "tree_planting_upload",
+      label: "Tree Planting Upload",
+      inputType: "file",
+      multiChoice: true
+    },
+    "site-rep-col-anr-photos": { property: "anr_photos", label: "ANR Photos", inputType: "file", multiChoice: true },
+    "site-rep-col-soil-water-conservation-upload": {
+      property: "soil_water_conservation_upload",
+      label: "Soil or Water Conservation Upload",
+      inputType: "file",
+      multiChoice: true
+    },
+    "site-rep-col-soil-water-conservation-photos": {
+      property: "soil_water_conservation_photos",
+      label: "Soil or Water Conservation Photos",
+      inputType: "file",
+      multiChoice: true
+    }
+  },
+  relations: {
+    "site-rep-rel-replanting-tree-species": {
+      property: "replantingTreeSpecies",
+      label: "Replanting Species + Count",
+      resource: "App\\Http\\Resources\\V2\\TreeSpecies\\TreeSpeciesResource",
+      inputType: "treeSpecies",
+      collection: "replanting"
+    },
+    "site-rep-rel-tree-species": {
+      property: "treeSpecies",
+      label: "Tree Species",
+      resource: "App\\Http\\Resources\\V2\\TreeSpecies\\TreeSpeciesResource",
+      inputType: "treeSpecies",
+      collection: "tree-planted"
+    },
+    "site-rep-rel-non-tree-species": {
+      property: "nonTreeSpecies",
+      label: "Non Tree Species",
+      resource: "App\\Http\\Resources\\V2\\TreeSpecies\\TreeSpeciesResource",
+      inputType: "treeSpecies",
+      collection: "non-tree"
+    },
+    "site-rep-rel-disturbances": {
+      property: "disturbances",
+      label: "Disturbances",
+      resource: "App\\Http\\Resources\\V2\\Disturbances\\DisturbanceResource",
+      inputType: "disturbances",
+      collection: "disturbance"
+    },
+    "site-rep-rel-seedings": {
+      property: "seedings",
+      label: "Seedings",
+      resource: "App\\Http\\Resources\\V2\\Seedings\\SeedingResource",
+      inputType: "seedings"
+    },
+    "site-rep-rel-paid-site-establishment": {
+      property: "workdaysPaidSiteEstablishment",
+      label: "Paid Site Establishment",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "workdays",
+      collection: "paid-site-establishment"
+    },
+    "site-rep-rel-paid-planting": {
+      property: "workdaysPaidPlanting",
+      label: "Paid Planting",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "workdays",
+      collection: "paid-planting"
+    },
+    "site-rep-rel-paid-site-maintenance": {
+      property: "workdaysPaidSiteMaintenance",
+      label: "Paid Site Maintenance",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "workdays",
+      collection: "paid-site-maintenance"
+    },
+    "site-rep-rel-paid-site-monitoring": {
+      property: "workdaysPaidSiteMonitoring",
+      label: "Paid Site Monitoring",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "workdays",
+      collection: "paid-site-monitoring"
+    },
+    "site-rep-rel-paid-other-activities": {
+      property: "workdaysPaidOtherActivities",
+      label: "Paid Other Activities",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "workdays",
+      collection: "paid-other-activities"
+    },
+    "site-rep-rel-volunteer-site-establishment": {
+      property: "workdaysVolunteerSiteEstablishment",
+      label: "Volunteer Site Establishment",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "workdays",
+      collection: "volunteer-site-establishment"
+    },
+    "site-rep-rel-volunteer-planting": {
+      property: "workdaysVolunteerPlanting",
+      label: "Volunteer Planting",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "workdays",
+      collection: "volunteer-planting"
+    },
+    "site-rep-rel-volunteer-site-maintenance": {
+      property: "workdaysVolunteerSiteMaintenance",
+      label: "volunteer Site Maintenance",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "workdays",
+      collection: "volunteer-site-maintenance"
+    },
+    "site-rep-rel-volunteer-site-monitoring": {
+      property: "workdaysVolunteerSiteMonitoring",
+      label: "Volunteer Site Monitoring",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "workdays",
+      collection: "volunteer-site-monitoring"
+    },
+    "site-rep-rel-volunteer-other-activities": {
+      property: "workdaysVolunteerOtherActivities",
+      label: "Volunteer Other Activities",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "workdays",
+      collection: "volunteer-other-activities"
+    },
+    "site-rep-direct-workdays": {
+      property: "workdaysDirect",
+      label: "Direct Workday",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "workdays",
+      collection: "direct"
+    },
+    "site-rep-convergence-workdays": {
+      property: "workdaysConvergence",
+      label: "Convergence Workday",
+      resource: "App\\Http\\Resources\\V2\\Demographics\\DemographicResource",
+      inputType: "workdays",
+      collection: "convergence"
+    }
+  }
+};

--- a/libs/common/src/lib/linkedFields/configuration/site.configuration.ts
+++ b/libs/common/src/lib/linkedFields/configuration/site.configuration.ts
@@ -1,6 +1,7 @@
 import { LinkedFieldConfiguration } from "../types";
 import { Site } from "@terramatch-microservices/database/entities";
 
+// Note: All field / fileCollection / relation keys _must_ be unique across all LinkedFieldConfigurations.
 export const SiteConfiguration: LinkedFieldConfiguration = {
   label: "Site",
   laravelModelType: Site.LARAVEL_TYPE,

--- a/libs/common/src/lib/linkedFields/configuration/site.configuration.ts
+++ b/libs/common/src/lib/linkedFields/configuration/site.configuration.ts
@@ -1,0 +1,177 @@
+import { LinkedFieldConfiguration } from "../types";
+import { Site } from "@terramatch-microservices/database/entities";
+
+export const SiteConfiguration: LinkedFieldConfiguration = {
+  label: "Site",
+  laravelModelType: Site.LARAVEL_TYPE,
+  fields: {
+    "site-name": { property: "name", label: "Name", inputType: "text" },
+    "site-control-site": { property: "control_site", label: "Control site", inputType: "boolean" },
+    "site-boundary-geojson": { property: "boundary_geojson", label: "Boundary geojson", inputType: "mapInput" },
+    "site-land-use-types": {
+      property: "land_use_types",
+      label: "Land use types",
+      inputType: "select-image",
+      multiChoice: true,
+      optionListKey: "restoration-systems"
+    },
+    "site-restoration-strategy": {
+      property: "restoration_strategy",
+      label: "Restoration strategy",
+      inputType: "select-image",
+      multiChoice: true,
+      optionListKey: "restoration-practices"
+    },
+    "site-description": { property: "description", label: "Description", inputType: "long-text" },
+    "site-history": { property: "history", label: "History", inputType: "long-text" },
+    "site-land-tenures": {
+      property: "land_tenures",
+      label: "Land tenures",
+      inputType: "select-image",
+      multiChoice: true,
+      optionListKey: "land-tenures"
+    },
+    "site-landscape-community-contribution": {
+      property: "landscape_community_contribution",
+      label: "Landscape community contribution",
+      inputType: "long-text"
+    },
+    "site-planting-pattern": { property: "planting_pattern", label: "Planting pattern", inputType: "long-text" },
+    "site-soil-condition": {
+      property: "soil_condition",
+      label: "Soil condition",
+      inputType: "select",
+      multiChoice: false,
+      optionListKey: "soil-condition"
+    },
+    "site-survival-rate-planted": {
+      property: "survival_rate_planted",
+      label: "Survival rate planted",
+      inputType: "number"
+    },
+    "site-direct-seeding-survival-rate": {
+      property: "direct_seeding_survival_rate",
+      label: "Direct seeding survival rate",
+      inputType: "number"
+    },
+    "site-a-nat-regeneration-trees-per-hectare": {
+      property: "a_nat_regeneration_trees_per_hectare",
+      label: "A natural regeneration trees per hectare",
+      inputType: "number"
+    },
+    "site-a-nat-regeneration": { property: "a_nat_regeneration", label: "A natural regeneration", inputType: "number" },
+    "site-hectares_to_restore-goal": {
+      property: "hectares_to_restore_goal",
+      label: "Hectares to restore_goal",
+      inputType: "number"
+    },
+    "site-aim-year-five-crown-cover": {
+      property: "aim_year_five_crown_cover",
+      label: "Aim year five crown cover",
+      inputType: "number"
+    },
+    "site-aim-number-of-mature-trees": {
+      property: "aim_number_of_mature_trees",
+      label: "Aim number of mature trees",
+      inputType: "number"
+    },
+    "site-start-date": { property: "start_date", label: "Start date", inputType: "date" },
+    "site-end-date": { property: "end_date", label: "End date", inputType: "date" },
+    "site-description-siting-strategy": {
+      property: "description_siting_strategy",
+      label: "Description siting strategy",
+      inputType: "text"
+    },
+    "site-col-siting-strategy": {
+      property: "siting_strategy",
+      label: "Siting Strategy",
+      inputType: "select",
+      multiChoice: false,
+      optionListKey: "siting-strategy-collection"
+    },
+    "site-detailed-rst-inv-types": {
+      property: "detailed_intervention_types",
+      label: "Detailed intervention types",
+      inputType: "select",
+      multiChoice: true,
+      optionListKey: "interventions"
+    }
+  },
+  fileCollections: {
+    "site-col-media": { property: "media", label: "Media", inputType: "file", multiChoice: true },
+    "site-col-socioeconomic-benefits": {
+      property: "socioeconomic_benefits",
+      label: "Socioeconomic benefits",
+      inputType: "file",
+      multiChoice: true
+    },
+    "site-col-file": { property: "file", label: "File", inputType: "file", multiChoice: true },
+    "site-col-other-additional-documents": {
+      property: "other_additional_documents",
+      label: "Other additional documents",
+      inputType: "file",
+      multiChoice: true
+    },
+    "site-col-photos": { property: "photos", label: "Photos", inputType: "file", multiChoice: true },
+    "site-col-document-files": {
+      property: "document_files",
+      label: "Document files",
+      inputType: "file",
+      multiChoice: true
+    },
+    "site-col-tree-species": {
+      property: "tree_species",
+      label: "programme_submission",
+      inputType: "file",
+      multiChoice: true
+    },
+    "site-col-strat-for-heterogeneity": {
+      property: "stratification_for_heterogeneity",
+      label: "Stratification for heterogeneity",
+      inputType: "file",
+      multiChoice: false
+    }
+  },
+  relations: {
+    "site-rel-tree-species": {
+      property: "treeSpecies",
+      label: "Tree Species",
+      resource: "App\\Http\\Resources\\V2\\TreeSpecies\\TreeSpeciesResource",
+      inputType: "treeSpecies",
+      collection: "tree-planted"
+    },
+    "site-rel-non-tree-species": {
+      property: "nonTreeSpecies",
+      label: "Non Tree Species",
+      resource: "App\\Http\\Resources\\V2\\TreeSpecies\\TreeSpeciesResource",
+      inputType: "treeSpecies",
+      collection: "non-tree"
+    },
+    "site-rel-disturbances": {
+      property: "disturbances",
+      label: "Disturbances",
+      resource: "App\\Http\\Resources\\V2\\Disturbances\\DisturbanceResource",
+      inputType: "disturbances",
+      collection: "disturbance"
+    },
+    "site-rel-invasive": {
+      property: "invasives",
+      label: "Invasives",
+      resource: "App\\Http\\Resources\\V2\\Invasives\\InvasiveResource",
+      inputType: "invasive",
+      collection: "invasive"
+    },
+    "site-rel-seedings": {
+      property: "seedings",
+      label: "Seedings",
+      resource: "App\\Http\\Resources\\V2\\Seedings\\SeedingResource",
+      inputType: "seedings"
+    },
+    "site-rel-stratas": {
+      property: "stratas",
+      label: "Stratas",
+      resource: "App\\Http\\Resources\\V2\\Stratas\\StrataResource",
+      inputType: "stratas"
+    }
+  }
+};

--- a/libs/common/src/lib/linkedFields/types.ts
+++ b/libs/common/src/lib/linkedFields/types.ts
@@ -1,0 +1,72 @@
+import { Dictionary } from "lodash";
+
+export type LinkedFieldConfiguration = {
+  label: string;
+  laravelModelType: string;
+  fields: Dictionary<LinkedField>;
+  fileCollections: Dictionary<LinkedFile>;
+  relations: Dictionary<linkedRelation>;
+};
+
+export const FIELD_INPUT_TYPES = [
+  "boolean",
+  "conditional",
+  "date",
+  "long-text",
+  "mapInput",
+  "number",
+  "number-percentage",
+  "radio",
+  "select",
+  "select-image",
+  "strategy-area",
+  "text",
+  "url"
+] as const;
+export type FieldInputType = (typeof FIELD_INPUT_TYPES)[number];
+
+export type LinkedField = {
+  property: string;
+  label: string;
+  inputType: FieldInputType;
+  multiChoice?: boolean;
+  optionListKey?: string;
+};
+
+export const FILE_INPUT_TYPES = ["file"] as const;
+export type FileInputType = (typeof FILE_INPUT_TYPES)[number];
+
+export type LinkedFile = Omit<LinkedField, "optionListKey" | "inputType"> & {
+  inputType: FileInputType;
+};
+
+export const RELATION_INPUT_TYPES = [
+  "allBeneficiaries",
+  "associates",
+  "disturbances",
+  "employees",
+  "financialIndicators",
+  "fundingType",
+  "indirectBeneficiaries",
+  "invasive",
+  "jobs",
+  "leaderships",
+  "ownershipStake",
+  "restorationPartners",
+  "seedings",
+  "stratas",
+  "trainingBeneficiaries",
+  "treeSpecies",
+  "volunteers",
+  "workdays"
+] as const;
+export type RelationInputType = (typeof RELATION_INPUT_TYPES)[number];
+
+export type linkedRelation = Omit<LinkedField, "optionListKey" | "inputType"> & {
+  inputType: RelationInputType;
+  resource: string;
+  collection?: string;
+};
+
+export const INPUT_TYPES = [...FIELD_INPUT_TYPES, ...FILE_INPUT_TYPES, ...RELATION_INPUT_TYPES] as const;
+export type InputType = (typeof INPUT_TYPES)[number];

--- a/libs/common/src/lib/linkedFields/types.ts
+++ b/libs/common/src/lib/linkedFields/types.ts
@@ -5,7 +5,7 @@ export type LinkedFieldConfiguration = {
   laravelModelType: string;
   fields: Dictionary<LinkedField>;
   fileCollections: Dictionary<LinkedFile>;
-  relations: Dictionary<linkedRelation>;
+  relations: Dictionary<LinkedRelation>;
 };
 
 export const FIELD_INPUT_TYPES = [
@@ -62,7 +62,7 @@ export const RELATION_INPUT_TYPES = [
 ] as const;
 export type RelationInputType = (typeof RELATION_INPUT_TYPES)[number];
 
-export type linkedRelation = Omit<LinkedField, "optionListKey" | "inputType"> & {
+export type LinkedRelation = Omit<LinkedField, "optionListKey" | "inputType" | "multichoice"> & {
   inputType: RelationInputType;
   resource: string;
   collection?: string;
@@ -70,3 +70,10 @@ export type linkedRelation = Omit<LinkedField, "optionListKey" | "inputType"> & 
 
 export const INPUT_TYPES = [...FIELD_INPUT_TYPES, ...FILE_INPUT_TYPES, ...RELATION_INPUT_TYPES] as const;
 export type InputType = (typeof INPUT_TYPES)[number];
+
+export const isField = (field: LinkedField | LinkedFile | LinkedRelation): field is LinkedField =>
+  FIELD_INPUT_TYPES.includes(field.inputType as FieldInputType);
+export const isFile = (field: LinkedField | LinkedFile | LinkedRelation): field is LinkedFile =>
+  FILE_INPUT_TYPES.includes(field.inputType as FileInputType);
+export const isRelation = (field: LinkedField | LinkedFile | LinkedRelation): field is LinkedRelation =>
+  RELATION_INPUT_TYPES.includes(field.inputType as RelationInputType);

--- a/libs/common/src/lib/util/document-builder-interceptor.ts
+++ b/libs/common/src/lib/util/document-builder-interceptor.ts
@@ -1,0 +1,15 @@
+import { CallHandler, ExecutionContext, NestInterceptor } from "@nestjs/common";
+import { DocumentBuilder, ResourceBuilder } from "./json-api-builder";
+import { map } from "rxjs";
+
+export class DocumentBuilderInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler) {
+    return next.handle().pipe(
+      map(data => {
+        if (data instanceof DocumentBuilder) return data.serialize();
+        if (data instanceof ResourceBuilder) return data.document.serialize();
+        return data;
+      })
+    );
+  }
+}

--- a/libs/common/src/lib/util/json-api-builder.ts
+++ b/libs/common/src/lib/util/json-api-builder.ts
@@ -127,7 +127,7 @@ export type SerializeOptions = {
 export type IndexData = {
   resource: string;
   requestPath: string;
-  ids: string[];
+  ids?: string[];
   total?: number;
   cursor?: string;
   pageNumber?: number;
@@ -162,8 +162,13 @@ export class DocumentBuilder {
     return builder;
   }
 
-  addIndexData(indexData: IndexData): DocumentBuilder {
-    this.indexData.push(indexData);
+  addIndex(indexData: Omit<IndexData, "resource"> & { resource?: string }): DocumentBuilder {
+    const resource = indexData.resource ?? this.resourceType;
+    const ids = resource === this.resourceType ? undefined : indexData.ids;
+    if (resource !== this.resourceType && ids == null) {
+      throw new ApiBuilderException(`Sideloaded indices must have an ids array`);
+    }
+    this.indexData.push({ ...indexData, resource, ids });
     return this;
   }
 

--- a/libs/common/src/lib/util/testing.ts
+++ b/libs/common/src/lib/util/testing.ts
@@ -1,0 +1,9 @@
+import { DocumentBuilder, JsonApiDocument, ResourceBuilder } from "./json-api-builder";
+
+// A utility for unit tests that can take any likely response from a standard v3 controller and
+// product a JsonApiDocument from it.
+export const serialize = (data: JsonApiDocument | DocumentBuilder | ResourceBuilder) => {
+  if (data instanceof DocumentBuilder) return data.serialize();
+  if (data instanceof ResourceBuilder) return data.document.serialize();
+  return data;
+};

--- a/libs/database/src/lib/entities/form-option-list.entity.ts
+++ b/libs/database/src/lib/entities/form-option-list.entity.ts
@@ -1,5 +1,6 @@
-import { AutoIncrement, Column, Index, Model, PrimaryKey, Table, Unique } from "sequelize-typescript";
+import { AutoIncrement, Column, HasMany, Index, Model, PrimaryKey, Table, Unique } from "sequelize-typescript";
 import { BIGINT, STRING, UUID, UUIDV4 } from "sequelize";
+import { FormOptionListOption } from "./form-option-list-option.entity";
 
 @Table({ tableName: "form_option_lists", underscored: true, paranoid: true })
 export class FormOptionList extends Model<FormOptionList> {
@@ -15,4 +16,7 @@ export class FormOptionList extends Model<FormOptionList> {
   @Unique
   @Column(STRING)
   key: string;
+
+  @HasMany(() => FormOptionListOption, { foreignKey: "formOptionListId", constraints: false })
+  listOptions: FormOptionListOption[] | null;
 }

--- a/libs/database/src/lib/factories/form-option-list.factory.ts
+++ b/libs/database/src/lib/factories/form-option-list.factory.ts
@@ -1,0 +1,7 @@
+import { FactoryGirl } from "factory-girl-ts";
+import { faker } from "@faker-js/faker";
+import { FormOptionList } from "../entities";
+
+export const FormOptionListFactory = FactoryGirl.define(FormOptionList, async () => ({
+  key: faker.lorem.slug()
+}));

--- a/libs/database/src/lib/factories/index.ts
+++ b/libs/database/src/lib/factories/index.ts
@@ -5,6 +5,7 @@ export * from "./demographic-entry.factory";
 export * from "./financial-indicator.factory";
 export * from "./financial-report.factory";
 export * from "./funding-type.factory";
+export * from "./form-option-list.factory";
 export * from "./form-option-list-option.factory";
 export * from "./form-submission.factory";
 export * from "./form.factory";


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-2412

We'll hold off merging this one until after the release in order to avoid dealing with the regression testing needed for this feature.

This has three big changes in addition to some new API endpoints:
* The linked-fields.php configuration has been fully ported over to v3 now. Any further changes that are made to the PHP configuration **must** also be made in v3.
* Index endpoints no longer need to include the IDs in the index meta as long as they're the main resource of the endpoint. Sideloaded resources do still need to include the IDs in their index meta data, but for the main resource, the IDs aren't sent because they are already represented in the `data` array and we can compact the payload sent to the client by avoiding sending them. The client pulls them out of `data`, and the server in most cases can avoid collating and adding them to the index meta.
* I've made it so that controllers may now return a `ResourceBuilder` or `DocumentBuilder` from `buildJsonApi` directly, and the interceptor defined in each `main.ts` will serialize the resulting document.
  * While making this change, I saw that there were a few controller tests that were mocking `builJsonApi`. Please don't do that. This library is super lightweight - it's a bit like mocking `lodash` functions. It's not necessary, and it avoids testing the real output of the controller function.

Also note: I started by porting over the linked field configuration fairly manually; copying the PHP code and running some modifications on it to create the JS code. This felt fairly safe, but it did result in some errors and was _very_ time consuming, so I switched to generating JSON from the existing config in `php artisan tinker`, and using that to create the configs in the JS codebase. With that process, I'm quite confident that the configurations match what's in the PHP codebase correctly. This implementation also gives us some nice type safety given the new TS types that are enforcing the structure in the config, and the new [unit test](https://github.com/wri/terramatch-microservices/pull/287/files#diff-ad603f7b052a543e6ffb39fed29bca9249a341bf5a0288c0489aabf0effc6f91) ensures that nobody accidentally re-uses a linked field key, which is required to be globally unique for this system to work correctly.