### PR TITLE
Add project fields and indicator outputs to geoparquet dump

### DIFF
--- a/bin/dbBackup/parque_dump.py
+++ b/bin/dbBackup/parque_dump.py
@@ -25,26 +25,45 @@ import uuid
 # DuckDB export
 # ---------------------------------------------------------------------------
 
-TERRAMATCH_QUERY = """\
+POLYGONS_QUERY = """\
 SELECT vp.uuid as project_id, vp.name as project_name, vp.country,
-       vp.framework_key, vp.short_name, vp.cohort,
+       vp.framework_key, vp.short_name, CAST(vp.cohort AS CHAR) AS cohort,
+       vp.polygon_data_submission, vp.ready_for_baseline,
        vs.name as site_name, vs.uuid as site_id,
        sp.poly_name, sp.uuid as poly_uuid, sp.plantstart, sp.practice,
        sp.target_sys, sp.distr, sp.calc_area,
        sp.status, sp.version_name, sp.is_active,
        sp.source, sp.deleted_at,
-       tc.project_phase,
-       tc.year_of_analysis,
-       tc.percent_cover,
        HEX(ST_AsBinary(pg.geom)) as geom
 FROM v2_sites vs
 INNER JOIN v2_projects vp ON vp.id = vs.project_id
 INNER JOIN site_polygon sp ON sp.site_id = vs.uuid
 INNER JOIN polygon_geometry pg ON pg.uuid = sp.poly_id
-LEFT JOIN indicator_output_tree_cover tc ON tc.site_polygon_id = sp.id
 WHERE sp.status = 'approved' AND sp.is_active = 1
       AND sp.deleted_at IS NULL AND sp.plantstart IS NOT NULL
 ORDER BY vp.short_name, vs.name, sp.poly_name\
+"""
+
+TREE_COVER_QUERY = """\
+SELECT sp.uuid AS poly_uuid, tc.year_of_analysis, tc.percent_cover, tc.project_phase
+FROM indicator_output_tree_cover tc
+INNER JOIN site_polygon sp ON sp.id = tc.site_polygon_id
+WHERE tc.deleted_at IS NULL\
+"""
+
+TREE_COUNT_QUERY = """\
+SELECT sp.uuid AS poly_uuid, tcnt.year_of_analysis, tcnt.tree_count
+FROM indicator_output_tree_count tcnt
+INNER JOIN site_polygon sp ON sp.id = tcnt.site_polygon_id
+WHERE tcnt.deleted_at IS NULL\
+"""
+
+HECTARES_QUERY = """\
+SELECT sp.uuid AS poly_uuid, h.year_of_analysis, h.indicator_slug, CAST(h.value AS CHAR) AS value
+FROM indicator_output_hectares h
+INNER JOIN site_polygon sp ON sp.id = h.site_polygon_id
+WHERE h.deleted_at IS NULL
+  AND h.indicator_slug IN ('restorationByStrategy', 'restorationByLandUse', 'restorationByEcoRegion')\
 """
 
 def _export_geoparquet(
@@ -66,26 +85,81 @@ def _export_geoparquet(
         AS mariadb (TYPE MYSQL, READ_ONLY)
     """)
 
-    # Escape single quotes for use inside DuckDB's mysql_query() string literal
-    escaped_query = TERRAMATCH_QUERY.replace("'", "''")
+    def esc(q: str) -> str:
+        return q.replace("'", "''")
 
-    print("Running query and writing GeoParquet...")
+    print("Running queries and writing GeoParquet...")
     con.execute(f"""
         COPY (
-            WITH raw AS (
+            WITH polygons AS (
                 SELECT * REPLACE (ST_GeomFromHexWKB(geom) AS geom)
-                FROM mysql_query('mariadb', '{escaped_query}')
+                FROM mysql_query('mariadb', '{esc(POLYGONS_QUERY)}')
+            ),
+            tree_cover_raw AS (
+                SELECT * FROM mysql_query('mariadb', '{esc(TREE_COVER_QUERY)}')
+            ),
+            tree_cover AS (
+                SELECT poly_uuid,
+                       MAX(project_phase) AS project_phase,
+                       MAP(
+                           LIST(year_of_analysis ORDER BY year_of_analysis)
+                               FILTER (WHERE year_of_analysis IS NOT NULL),
+                           LIST(percent_cover ORDER BY year_of_analysis)
+                               FILTER (WHERE year_of_analysis IS NOT NULL)
+                       ) AS ttc
+                FROM tree_cover_raw
+                GROUP BY poly_uuid
+            ),
+            tree_count_raw AS (
+                SELECT * FROM mysql_query('mariadb', '{esc(TREE_COUNT_QUERY)}')
+            ),
+            tree_count AS (
+                SELECT poly_uuid,
+                       MAP(
+                           LIST(year_of_analysis ORDER BY year_of_analysis)
+                               FILTER (WHERE year_of_analysis IS NOT NULL),
+                           LIST(tree_count ORDER BY year_of_analysis)
+                               FILTER (WHERE year_of_analysis IS NOT NULL)
+                       ) AS tree_count_by_year
+                FROM tree_count_raw
+                GROUP BY poly_uuid
+            ),
+            hectares_raw AS (
+                SELECT * FROM mysql_query('mariadb', '{esc(HECTARES_QUERY)}')
+            ),
+            hectares_per_slug AS (
+                SELECT poly_uuid, indicator_slug,
+                       MAP(
+                           LIST(year_of_analysis ORDER BY year_of_analysis)
+                               FILTER (WHERE year_of_analysis IS NOT NULL),
+                           LIST(value ORDER BY year_of_analysis)
+                               FILTER (WHERE year_of_analysis IS NOT NULL)
+                       ) AS m
+                FROM hectares_raw
+                GROUP BY poly_uuid, indicator_slug
+            ),
+            hectares AS (
+                SELECT poly_uuid,
+                       ANY_VALUE(m) FILTER (WHERE indicator_slug = 'restorationByStrategy')
+                           AS restoration_by_strategy,
+                       ANY_VALUE(m) FILTER (WHERE indicator_slug = 'restorationByLandUse')
+                           AS restoration_by_land_use,
+                       ANY_VALUE(m) FILTER (WHERE indicator_slug = 'restorationByEcoRegion')
+                           AS restoration_by_eco_region
+                FROM hectares_per_slug
+                GROUP BY poly_uuid
             )
-            SELECT * EXCLUDE (year_of_analysis, percent_cover, project_phase),
-                   MAX(project_phase) AS project_phase,
-                   MAP(
-                       LIST(year_of_analysis ORDER BY year_of_analysis)
-                           FILTER (WHERE year_of_analysis IS NOT NULL),
-                       LIST(percent_cover ORDER BY year_of_analysis)
-                           FILTER (WHERE year_of_analysis IS NOT NULL)
-                   ) AS ttc
-            FROM raw
-            GROUP BY ALL
+            SELECT p.*,
+                   tc.project_phase,
+                   tc.ttc,
+                   tcnt.tree_count_by_year,
+                   h.restoration_by_strategy,
+                   h.restoration_by_land_use,
+                   h.restoration_by_eco_region
+            FROM polygons p
+            LEFT JOIN tree_cover tc ON tc.poly_uuid = p.poly_uuid
+            LEFT JOIN tree_count tcnt ON tcnt.poly_uuid = p.poly_uuid
+            LEFT JOIN hectares h ON h.poly_uuid = p.poly_uuid
         ) TO '{output}' (FORMAT PARQUET)
     """)
 


### PR DESCRIPTION
Include polygon_data_submission and ready_for_baseline from v2_projects, and join in tree_count and three restoration-hectares indicators (restorationByStrategy, restorationByLandUse, restorationByEcoRegion) as year-keyed maps alongside the existing tree-cover ttc map.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Nightly geoparquet doesn't include all indicators or the new fields to indicate when all polygons are submitted and a project is ready for baseline

Issue Number: N/A


## What is the new behavior?
Updated query so that the nightly geoparquet _does_ include all indicators and the new fields to indicate when all polygons are submitted and a project is ready for baseline

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
