### PR TITLE
[TM-3488] Improve asynchronous user context

### DIFF
--- a/apps/dashboard-service/src/dashboard/dashboard-entities.controller.ts
+++ b/apps/dashboard-service/src/dashboard/dashboard-entities.controller.ts
@@ -4,7 +4,7 @@ import { ExceptionResponse, JsonApiResponse } from "@terramatch-microservices/co
 import { buildJsonApi, getStableRequestQuery } from "@terramatch-microservices/common/util/json-api-builder";
 import { DashboardEntitiesService } from "./dashboard-entities.service";
 import { DashboardQueryDto } from "./dto/dashboard-query.dto";
-import { OptionalBearerAuth } from "@terramatch-microservices/common/guards";
+import { AuthOptional } from "@terramatch-microservices/common/guards";
 import { CacheService } from "./dto/cache.service";
 import { DashboardProjectsFullDto, DashboardProjectsLightDto } from "./dto/dashboard-projects.dto";
 import { DashboardImpactStoryFullDto, DashboardImpactStoryLightDto } from "./dto/dashboard-impact-story.dto";
@@ -34,7 +34,7 @@ export class DashboardEntitiesController {
   ) {}
 
   @Get(":entity")
-  @OptionalBearerAuth
+  @AuthOptional
   @ApiParam({
     name: "entity",
     enum: DASHBOARD_ENTITIES,
@@ -184,7 +184,7 @@ export class DashboardEntitiesController {
   }
 
   @Get(":entity/:uuid")
-  @OptionalBearerAuth
+  @AuthOptional
   @ApiParam({
     name: "entity",
     enum: DASHBOARD_ENTITIES,

--- a/apps/dashboard-service/src/dashboard/dashboard-projects.controller.ts
+++ b/apps/dashboard-service/src/dashboard/dashboard-projects.controller.ts
@@ -1,10 +1,10 @@
-import { Get, Query, Controller } from "@nestjs/common";
+import { Controller, Get, Query } from "@nestjs/common";
 import { ApiOperation } from "@nestjs/swagger";
 import { DashboardQueryDto } from "./dto/dashboard-query.dto";
 import { JsonApiResponse } from "@terramatch-microservices/common/decorators";
 import { CacheService } from "./dto/cache.service";
 import { buildJsonApi } from "@terramatch-microservices/common/util/json-api-builder";
-import { NoBearerAuth } from "@terramatch-microservices/common/guards";
+import { AuthOptional } from "@terramatch-microservices/common/guards";
 import { DashboardProjectsLightDto } from "./dto/dashboard-projects.dto";
 import { DashboardProjectsService } from "./dashboard-projects.service";
 
@@ -16,7 +16,7 @@ export class DashboardProjectsController {
   ) {}
 
   @Get()
-  @NoBearerAuth
+  @AuthOptional
   @JsonApiResponse(DashboardProjectsLightDto)
   @ApiOperation({ operationId: "getDashboardProjects", summary: "Get dashboard projects" })
   async getDashboardProjects(@Query() query: DashboardQueryDto) {

--- a/apps/dashboard-service/src/dashboard/hectares-restoration.controller.ts
+++ b/apps/dashboard-service/src/dashboard/hectares-restoration.controller.ts
@@ -1,10 +1,10 @@
-import { Get, Query, Controller } from "@nestjs/common";
+import { Controller, Get, Query } from "@nestjs/common";
 import { ApiOperation } from "@nestjs/swagger";
 import { DashboardQueryDto } from "./dto/dashboard-query.dto";
 import { JsonApiResponse } from "@terramatch-microservices/common/decorators";
 import { CacheService } from "./dto/cache.service";
 import { buildJsonApi, getStableRequestQuery } from "@terramatch-microservices/common/util/json-api-builder";
-import { NoBearerAuth } from "@terramatch-microservices/common/guards";
+import { AuthOptional } from "@terramatch-microservices/common/guards";
 import { HectareRestorationDto } from "./dto/hectare-restoration.dto";
 import { HectaresRestorationService } from "./hectares-restoration.service";
 
@@ -16,7 +16,7 @@ export class HectaresRestorationController {
   ) {}
 
   @Get()
-  @NoBearerAuth
+  @AuthOptional
   @JsonApiResponse([HectareRestorationDto])
   @ApiOperation({ operationId: "getHectaresRestoration", summary: "Get hectares restoration" })
   async getHectaresRestoration(@Query() query: DashboardQueryDto) {

--- a/apps/dashboard-service/src/dashboard/total-jobs-created.controller.ts
+++ b/apps/dashboard-service/src/dashboard/total-jobs-created.controller.ts
@@ -1,10 +1,10 @@
-import { Get, Query, Controller } from "@nestjs/common";
+import { Controller, Get, Query } from "@nestjs/common";
 import { ApiOperation } from "@nestjs/swagger";
 import { JsonApiResponse } from "@terramatch-microservices/common/decorators";
 import { CacheService } from "./dto/cache.service";
 import { buildJsonApi, getStableRequestQuery } from "@terramatch-microservices/common/util/json-api-builder";
 import { DelayedJobDto } from "@terramatch-microservices/common/dto/delayed-job.dto";
-import { NoBearerAuth } from "@terramatch-microservices/common/guards";
+import { AuthOptional } from "@terramatch-microservices/common/guards";
 import { TotalJobsCreatedDto } from "./dto/total-jobs-created.dto";
 import { TotalJobsCreatedService } from "./total-jobs-created.service";
 import { DashboardQueryDto } from "./dto/dashboard-query.dto";
@@ -17,7 +17,7 @@ export class TotalJobsCreatedController {
   ) {}
 
   @Get()
-  @NoBearerAuth
+  @AuthOptional
   @JsonApiResponse([TotalJobsCreatedDto, DelayedJobDto])
   @ApiOperation({ operationId: "getTotalJobsCreated", summary: "Get total jobs created" })
   async getTotalJobsCreated(@Query() query: DashboardQueryDto) {

--- a/apps/dashboard-service/src/dashboard/total-section-header.controller.ts
+++ b/apps/dashboard-service/src/dashboard/total-section-header.controller.ts
@@ -4,21 +4,21 @@ import { DashboardQueryDto } from "./dto/dashboard-query.dto";
 import { JsonApiResponse } from "@terramatch-microservices/common/decorators";
 import { CacheService } from "./dto/cache.service";
 import {
-  buildJsonApi,
   buildDelayedJobResponse,
+  buildJsonApi,
   getStableRequestQuery
 } from "@terramatch-microservices/common/util/json-api-builder";
 import { TotalSectionHeaderDto } from "./dto/total-section-header.dto";
 import { DelayedJob } from "@terramatch-microservices/database/entities";
 import { DelayedJobDto } from "@terramatch-microservices/common/dto/delayed-job.dto";
-import { NoBearerAuth } from "@terramatch-microservices/common/guards";
+import { AuthOptional } from "@terramatch-microservices/common/guards";
 
 @Controller("dashboard/v3/totalSectionHeaders")
 export class TotalSectionHeaderController {
   constructor(private readonly cacheService: CacheService) {}
 
   @Get()
-  @NoBearerAuth
+  @AuthOptional
   @JsonApiResponse([TotalSectionHeaderDto, DelayedJobDto])
   @ApiOperation({ operationId: "getTotalSectionHeaders", summary: "Get total section header" })
   async getTotalSectionHeader(@Query() query: DashboardQueryDto) {

--- a/apps/dashboard-service/src/dashboard/tree-restoration-goal.controller.ts
+++ b/apps/dashboard-service/src/dashboard/tree-restoration-goal.controller.ts
@@ -1,4 +1,4 @@
-import { Get, Query, Controller } from "@nestjs/common";
+import { Controller, Get, Query } from "@nestjs/common";
 import { ApiOperation } from "@nestjs/swagger";
 import { DashboardQueryDto } from "./dto/dashboard-query.dto";
 import { JsonApiResponse } from "@terramatch-microservices/common/decorators";
@@ -6,7 +6,7 @@ import { TreeRestorationGoalDto } from "./dto/tree-restoration-goal.dto";
 import { TreeRestorationGoalService } from "./dto/tree-restoration-goal.service";
 import { CacheService } from "./dto/cache.service";
 import { buildJsonApi, getStableRequestQuery } from "@terramatch-microservices/common/util/json-api-builder";
-import { NoBearerAuth } from "@terramatch-microservices/common/guards";
+import { AuthOptional } from "@terramatch-microservices/common/guards";
 
 @Controller("dashboard/v3/treeRestorationGoal")
 export class TreeRestorationGoalController {
@@ -16,7 +16,7 @@ export class TreeRestorationGoalController {
   ) {}
 
   @Get()
-  @NoBearerAuth
+  @AuthOptional
   @JsonApiResponse(TreeRestorationGoalDto)
   @ApiOperation({ operationId: "getTreeRestorationGoal", summary: "Get tree restoration goal statistics" })
   async getTreeRestorationGoal(@Query() query: DashboardQueryDto) {

--- a/apps/entity-service/src/applications/applications.controller.spec.ts
+++ b/apps/entity-service/src/applications/applications.controller.spec.ts
@@ -17,7 +17,7 @@ import {
   StageFactory,
   UserFactory
 } from "@terramatch-microservices/database/factories";
-import { mockRequestContext, mockRequestForUser, serialize } from "@terramatch-microservices/common/util/testing";
+import { mockUserContext, mockContextForUser, serialize } from "@terramatch-microservices/common/util/testing";
 import { Resource } from "@terramatch-microservices/common/util";
 import { sortBy } from "lodash";
 import FakeTimers from "@sinonjs/fake-timers";
@@ -55,7 +55,7 @@ describe("ApplicationsController", () => {
   describe("indexApplications", () => {
     it("returns all applications to admins", async () => {
       const apps = await ApplicationFactory.createMany(3);
-      mockRequestContext({ userId: 123, permissions: ["framework-ppc"] });
+      mockUserContext({ userId: 123, permissions: ["framework-ppc"] });
       const result = serialize(await controller.index({}));
       const dtos = (result.data as Resource[]).map(({ attributes }) => attributes);
       expect(dtos.length).toBe(3);
@@ -71,7 +71,7 @@ describe("ApplicationsController", () => {
       const user = await UserFactory.create({ organisationId: orgs[0].id });
       await OrganisationUserFactory.create({ organisationId: orgs[1].id, userId: user.id, status: "approved" });
       await OrganisationUserFactory.create({ organisationId: orgs[2].id, userId: user.id, status: "pending" });
-      mockRequestForUser(user, "manage-own");
+      mockContextForUser(user, "manage-own");
       const apps = await Promise.all(orgs.map(({ uuid }) => ApplicationFactory.create({ organisationUuid: uuid })));
       const userApps = apps.slice(0, 2); // the third is not a confirmed org association
       await ApplicationFactory.create();
@@ -86,7 +86,7 @@ describe("ApplicationsController", () => {
     });
 
     it("filters by submission status", async () => {
-      mockRequestContext({ userId: 123, permissions: ["framework-ppc"] });
+      mockUserContext({ userId: 123, permissions: ["framework-ppc"] });
       const apps = await ApplicationFactory.createMany(2);
       const excluded = await ApplicationFactory.create();
       // included - only submission on this app
@@ -108,7 +108,7 @@ describe("ApplicationsController", () => {
     });
 
     it("filters on application fields", async () => {
-      mockRequestContext({ userId: 123, permissions: ["framework-ppc"] });
+      mockUserContext({ userId: 123, permissions: ["framework-ppc"] });
       const apps = await ApplicationFactory.createMany(2);
       let result = serialize(await controller.index({ organisationUuid: apps[0].organisationUuid as string }));
       let dtos = (result.data as Resource[]).map(({ attributes }) => attributes);
@@ -122,7 +122,7 @@ describe("ApplicationsController", () => {
     });
 
     it("throws with an invalid sort", async () => {
-      mockRequestContext({ userId: 123, permissions: ["framework-ppc"] });
+      mockUserContext({ userId: 123, permissions: ["framework-ppc"] });
       await expect(controller.index({ sort: { field: "foo" } })).rejects.toThrow("Invalid sort field: foo");
     });
 
@@ -140,7 +140,7 @@ describe("ApplicationsController", () => {
         clock.setSystemTime(now.minus({ days: 6 }).toJSDate());
         await app1.update({ updatedBy: 123 });
 
-        mockRequestContext({ userId: 123, permissions: ["framework-ppc"] });
+        mockUserContext({ userId: 123, permissions: ["framework-ppc"] });
 
         let result = serialize(await controller.index({ sort: { field: "createdAt" } }));
         let uuids = (result.data as Resource[]).map(({ id }) => id);
@@ -175,7 +175,7 @@ describe("ApplicationsController", () => {
       const org3 = await OrganisationFactory.create({ name: "Crops" });
       await ApplicationFactory.create({ organisationUuid: org3.uuid });
 
-      mockRequestContext({ userId: 123, permissions: ["framework-ppc"] });
+      mockUserContext({ userId: 123, permissions: ["framework-ppc"] });
 
       let result = serialize(await controller.index({ search: "Test" }));
       let uuids = (result.data as Resource[]).map(({ id }) => id);
@@ -206,7 +206,7 @@ describe("ApplicationsController", () => {
         userId: user.uuid
       });
       const project = await ProjectFactory.create({ applicationId: app.id });
-      mockRequestForUser(user, "framework-ppc");
+      mockContextForUser(user, "framework-ppc");
 
       const result = serialize(await controller.get({ uuid: app.uuid }, {}));
       const dto = (result.data as Resource).attributes;
@@ -232,7 +232,7 @@ describe("ApplicationsController", () => {
         locale: "es-MX",
         organisationId: (await app.$get("organisation", { attributes: ["id"] }))?.id
       });
-      mockRequestForUser(user, "manage-own");
+      mockContextForUser(user, "manage-own");
       const submissions = [
         await FormSubmissionFactory.create({
           applicationId: app.id,
@@ -366,7 +366,7 @@ describe("ApplicationsController", () => {
           comment: "Requires More Feedback"
         });
 
-        mockRequestContext({ userId: 123, permissions: ["framework-ppc"] });
+        mockUserContext({ userId: 123, permissions: ["framework-ppc"] });
         const result = serialize(await controller.getHistory({ uuid: app.uuid }));
         const dto = (result.data as Resource).attributes;
         // result is in reverse chronological order

--- a/apps/entity-service/src/applications/applications.controller.ts
+++ b/apps/entity-service/src/applications/applications.controller.ts
@@ -20,7 +20,6 @@ import {
 } from "@terramatch-microservices/common/util";
 import { FormDataService } from "../entities/form-data.service";
 import { SingleResourceDto } from "@terramatch-microservices/common/dto/single-resource.dto";
-import { authenticatedUserId, userLocale } from "@terramatch-microservices/common/guards/auth.guard";
 import { PaginatedQueryBuilder } from "@terramatch-microservices/common/util/paginated-query.builder";
 import { Subquery } from "@terramatch-microservices/database/util/subquery.builder";
 import { Op } from "sequelize";
@@ -33,6 +32,7 @@ import { DateTime } from "luxon";
 import { JsonApiDeletedResponse } from "@terramatch-microservices/common/decorators/json-api-response.decorator";
 import { FormsService } from "../forms/forms.service";
 import { Response } from "express";
+import { UserContext } from "@terramatch-microservices/common/contexts/user.context";
 
 const FILTER_COLUMNS = ["organisationUuid", "fundingProgrammeUuid"] as const;
 const SORT_COLUMNS = ["createdAt", "updatedAt"] as const;
@@ -59,7 +59,7 @@ export class ApplicationsController {
 
     if (this.policyService.permissions.find(p => p.startsWith("framework-")) == null) {
       // admins have access to everything, so we just filter what's available for non-admins
-      const orgUuids = await User.orgUuids(authenticatedUserId());
+      const orgUuids = await User.orgUuids(UserContext.authenticatedUserId);
       builder.where({ organisationUuid: { [Op.in]: orgUuids } });
     }
 
@@ -163,7 +163,7 @@ export class ApplicationsController {
         await this.formDataService.addFundingProgrammeDtos(
           document,
           [fundingProgramme],
-          translated === false ? undefined : userLocale()
+          translated === false ? undefined : UserContext.userLocale
         );
       }
     }

--- a/apps/entity-service/src/entities/disturbance.controller.spec.ts
+++ b/apps/entity-service/src/entities/disturbance.controller.spec.ts
@@ -8,7 +8,7 @@ import { SiteReportFactory } from "@terramatch-microservices/database/factories"
 import { DisturbancesController } from "./disturbances.controller";
 import { DisturbanceService } from "./disturbance.service";
 import { DisturbanceQueryDto } from "./dto/disturbance-query.dto";
-import { mockRequestContext, serialize, setMockedPermissions } from "@terramatch-microservices/common/util/testing";
+import { mockUserContext, serialize, setMockedPermissions } from "@terramatch-microservices/common/util/testing";
 
 describe("DisturbanceController", () => {
   let controller: DisturbancesController;
@@ -25,7 +25,7 @@ describe("DisturbanceController", () => {
 
     controller = module.get(DisturbancesController);
 
-    mockRequestContext({ userId: 123 });
+    mockUserContext({ userId: 123 });
   });
 
   afterEach(() => {

--- a/apps/entity-service/src/entities/entities.controller.spec.ts
+++ b/apps/entity-service/src/entities/entities.controller.spec.ts
@@ -16,7 +16,7 @@ import {
 import { EntityQueryDto } from "./dto/entity-query.dto";
 import { faker } from "@faker-js/faker";
 import { EntityUpdateData } from "./dto/entity-update.dto";
-import { mockRequestContext, serialize } from "@terramatch-microservices/common/util/testing";
+import { mockUserContext, serialize } from "@terramatch-microservices/common/util/testing";
 import { Response } from "express";
 import { CsvExportService } from "@terramatch-microservices/common/export/csv-export.service";
 import { Resource, ResourceBuilder } from "@terramatch-microservices/common/util";
@@ -77,7 +77,7 @@ describe("EntitiesController", () => {
 
   describe("entityIndex", () => {
     it("should call findMany", async () => {
-      mockRequestContext({ permissions: ["projects-read"] });
+      mockUserContext({ permissions: ["projects-read"] });
       const query = { page: { number: 2 }, sort: { field: "name" }, status: "approved" } as EntityQueryDto;
       await controller.entityIndex({ entity: "projects" }, query);
       expect(processor.findMany).toHaveBeenCalledWith(query);
@@ -112,7 +112,7 @@ describe("EntitiesController", () => {
     });
 
     it("should return a presigned url", async () => {
-      mockRequestContext({ userId: 123, permissions: ["framework-ppc"] });
+      mockUserContext({ userId: 123, permissions: ["framework-ppc"] });
       csvExportService().generateExportDto.mockResolvedValue(new FileDownloadDto("fake-url"));
       const result = serialize(
         (await controller.entityExportAll(

--- a/apps/entity-service/src/entities/entities.service.ts
+++ b/apps/entity-service/src/entities/entities.service.ts
@@ -69,7 +69,7 @@ import {
 import { TMLogger } from "@terramatch-microservices/common/util/tm-logger";
 import { batchFindAll } from "@terramatch-microservices/common/util/batch-find-all";
 import { FrameworkKey } from "@terramatch-microservices/database/constants";
-import { userLocale } from "@terramatch-microservices/common/guards/auth.guard";
+import { UserContext } from "@terramatch-microservices/common/contexts/user.context";
 
 // The keys of this array must match the type in the resulting DTO.
 export const ENTITY_PROCESSORS = {
@@ -214,7 +214,7 @@ export class EntitiesService {
   }
 
   get userLocale() {
-    return userLocale() ?? "en-US";
+    return UserContext.userLocale ?? "en-US";
   }
 
   async localizeText(text: string, params?: ITranslateParams) {

--- a/apps/entity-service/src/entities/entity-associations.controller.spec.ts
+++ b/apps/entity-service/src/entities/entity-associations.controller.spec.ts
@@ -8,7 +8,7 @@ import { AssociationProcessor } from "./processors/association-processor";
 import { TrackingDto } from "@terramatch-microservices/common/dto/tracking.dto";
 import { ProjectReportFactory, TrackingFactory } from "@terramatch-microservices/database/factories";
 import { NotFoundException, UnauthorizedException } from "@nestjs/common";
-import { mockRequestContext, serialize, setMockedPermissions } from "@terramatch-microservices/common/util/testing";
+import { mockUserContext, serialize, setMockedPermissions } from "@terramatch-microservices/common/util/testing";
 
 class StubProcessor extends AssociationProcessor<Tracking, TrackingDto> {
   DTO = TrackingDto;
@@ -37,7 +37,7 @@ describe("EntityAssociationsController", () => {
       return new StubProcessor(entity, uuid, ProjectReport, entitiesService);
     });
 
-    mockRequestContext({ userId: 123 });
+    mockUserContext({ userId: 123 });
   });
 
   afterEach(() => {

--- a/apps/entity-service/src/entities/form-data.controller.spec.ts
+++ b/apps/entity-service/src/entities/form-data.controller.spec.ts
@@ -8,7 +8,7 @@ import { StubProcessor } from "./entities.controller.spec";
 import { Form, Project } from "@terramatch-microservices/database/entities";
 import { FormFactory, ProjectFactory } from "@terramatch-microservices/database/factories";
 import { FormDataDto, UpdateFormDataBody } from "./dto/form-data.dto";
-import { mockRequestContext, serialize } from "@terramatch-microservices/common/util/testing";
+import { mockUserContext, serialize } from "@terramatch-microservices/common/util/testing";
 import { Resource } from "@terramatch-microservices/common/util/json-api-builder";
 import { Dictionary } from "lodash";
 import { ValidLocale } from "@terramatch-microservices/database/constants/locale";
@@ -58,7 +58,7 @@ describe("FormDataController", () => {
 
     it("throws if the form is not found", async () => {
       const project = await ProjectFactory.create();
-      mockRequestContext({ userId: 123, permissions: [`framework-${project.frameworkKey}`] });
+      mockUserContext({ userId: 123, permissions: [`framework-${project.frameworkKey}`] });
       processor.findOne.mockResolvedValue(project);
       await expect(controller.get({ entity: "projects", uuid: project.uuid })).rejects.toThrow(
         "Form for entity not found"
@@ -103,7 +103,7 @@ describe("FormDataController", () => {
 
     it("throws if the form is not found", async () => {
       const project = await ProjectFactory.create();
-      mockRequestContext({ userId: 123, permissions: [`framework-${project.frameworkKey}`] });
+      mockUserContext({ userId: 123, permissions: [`framework-${project.frameworkKey}`] });
       processor.findOne.mockResolvedValue(project);
       await expect(
         controller.update({ entity: "projects", uuid: project.uuid }, createPayload(`projects|${project.uuid}`, {}))

--- a/apps/entity-service/src/entities/form-data.controller.ts
+++ b/apps/entity-service/src/entities/form-data.controller.ts
@@ -11,7 +11,7 @@ import { EntityModel, EntityType } from "@terramatch-microservices/database/cons
 import { AuditStatus, Form } from "@terramatch-microservices/database/entities";
 import { SpecificEntityDto } from "./dto/specific-entity.dto";
 import { APPROVED, NEEDS_MORE_INFORMATION } from "@terramatch-microservices/database/constants/status";
-import { authenticatedUserId } from "@terramatch-microservices/common/guards/auth.guard";
+import { UserContext } from "@terramatch-microservices/common/contexts/user.context";
 
 @Controller("entities/v3/:entity/:uuid/formData")
 export class FormDataController {
@@ -60,7 +60,7 @@ export class FormDataController {
 
     const type =
       model.status === APPROVED || model.status === NEEDS_MORE_INFORMATION ? "change-request-updated" : "updated";
-    await AuditStatus.ensureRecentAudit(model, authenticatedUserId(), type);
+    await AuditStatus.ensureRecentAudit(model, UserContext.authenticatedUserId, type);
 
     return this.addFormData(buildJsonApi(FormDataDto), model, entity, form);
   }

--- a/apps/entity-service/src/entities/form-data.service.spec.ts
+++ b/apps/entity-service/src/entities/form-data.service.spec.ts
@@ -35,9 +35,9 @@ import {
 import { DRAFT, STARTED } from "@terramatch-microservices/database/constants/status";
 import {
   mockTranslateFieldsWithOriginal,
-  mockRequestContext,
+  mockUserContext,
   serialize,
-  mockRequestForUser
+  mockContextForUser
 } from "@terramatch-microservices/common/util/testing";
 import {
   LinkedAnswerCollector,
@@ -108,7 +108,7 @@ describe("FormDataService", () => {
     // @ts-expect-error Passing an extra param to the stubbed mock singleton collector
     collector = new LinkedAnswerCollector(mediaService, true);
 
-    mockRequestContext({ userId: 123 });
+    mockUserContext({ userId: 123 });
   });
 
   afterEach(() => {
@@ -128,7 +128,7 @@ describe("FormDataService", () => {
     it("creates an update request if the user cannot update answers", async () => {
       const site = await SiteFactory.create();
       jest.spyOn(policyService, "hasAccess").mockResolvedValue(false);
-      mockRequestContext({ userId: 123 });
+      mockUserContext({ userId: 123 });
       const form = await EntityFormFactory.site(site).create();
       await service.storeEntityAnswers(site, form, { color: "red" });
 
@@ -194,7 +194,7 @@ describe("FormDataService", () => {
     });
 
     it("does additional report processing", async () => {
-      mockRequestContext({ userId: 123, permissions: ["manage-own"] });
+      mockUserContext({ userId: 123, permissions: ["manage-own"] });
       jest.spyOn(policyService, "hasAccess").mockResolvedValue(true);
       const siteReport = await SiteReportFactory.create({ submittedAt: null, nothingToReport: true });
       const form = await EntityFormFactory.siteReport(siteReport).create();
@@ -435,7 +435,7 @@ describe("FormDataService", () => {
       const conditional = await FormQuestionFactory.section(section).create({ inputType: "conditional" });
       const stage = await StageFactory.create({});
       const user = await UserFactory.create({ locale: "es-MX" });
-      mockRequestForUser(user);
+      mockContextForUser(user);
       const submission = await FormSubmissionFactory.create({
         answers: { [conditional.uuid]: true },
         organisationUuid: org.uuid,

--- a/apps/entity-service/src/entities/form-data.service.ts
+++ b/apps/entity-service/src/entities/form-data.service.ts
@@ -32,7 +32,6 @@ import { FormDataDto } from "./dto/form-data.dto";
 import { populateDto } from "@terramatch-microservices/common/dto/json-api-attributes";
 import { PolicyService } from "@terramatch-microservices/common";
 import { DUE, STARTED } from "@terramatch-microservices/database/constants/status";
-import { authenticatedUserId, userLocale } from "@terramatch-microservices/common/guards/auth.guard";
 import { BadRequestException } from "@nestjs/common/exceptions/bad-request.exception";
 import { SubmissionDto } from "./dto/submission.dto";
 import { Op } from "sequelize";
@@ -40,6 +39,7 @@ import { isNotNull } from "@terramatch-microservices/database/types/array";
 import { DocumentBuilder } from "@terramatch-microservices/common/util";
 import { FundingProgrammeDto, StageDto } from "../fundingProgrammes/dto/funding-programme.dto";
 import { EmbeddedMediaDto } from "@terramatch-microservices/common/dto/media.dto";
+import { UserContext } from "@terramatch-microservices/common/contexts/user.context";
 
 @Injectable()
 export class FormDataService {
@@ -57,7 +57,7 @@ export class FormDataService {
       const newUpdateRequest = await UpdateRequest.create({
         updateRequestableType: laravelType(model),
         updateRequestableId: model.id,
-        createdById: authenticatedUserId(),
+        createdById: UserContext.authenticatedUserId,
         frameworkKey: model.frameworkKey,
         content: answers,
         projectId: await getProjectId(model),
@@ -133,7 +133,7 @@ export class FormDataService {
       undefined;
     if (form == null) throw new BadRequestException("Form not found for submission");
 
-    locale ??= userLocale() ?? "en-US";
+    locale ??= UserContext.userLocale ?? "en-US";
 
     formSubmission.organisation ??= (await formSubmission.$get("organisation")) ?? null;
     formSubmission.projectPitch ??= (await formSubmission.$get("projectPitch")) ?? null;
@@ -321,7 +321,7 @@ export class FormDataService {
           ? permissions.find(permission => permission.startsWith("framework-")) != null
           : permissions.includes(`framework-${answersModel.frameworkKey}`);
       if (answersModel.createdBy == null && !isAdmin) {
-        answersModel.createdBy = authenticatedUserId() ?? null;
+        answersModel.createdBy = UserContext.authenticatedUserId ?? null;
       }
 
       // An admin should be able to directly update a report without a transition unless it's in `due`, in which case

--- a/apps/entity-service/src/entities/impact-stories.controller.ts
+++ b/apps/entity-service/src/entities/impact-stories.controller.ts
@@ -12,10 +12,10 @@ import {
   UnauthorizedException
 } from "@nestjs/common";
 import {
-  buildJsonApi,
-  getStableRequestQuery,
   buildDeletedResponse,
-  getDtoType
+  buildJsonApi,
+  getDtoType,
+  getStableRequestQuery
 } from "@terramatch-microservices/common/util";
 import { ApiOperation } from "@nestjs/swagger";
 import { ExceptionResponse, JsonApiResponse } from "@terramatch-microservices/common/decorators";
@@ -26,7 +26,7 @@ import { ImpactStoryParamDto } from "./dto/impact-story-param.dto";
 import { ImpactStoryFullDto, ImpactStoryLightDto, ImpactStoryMedia } from "./dto/impact-story.dto";
 import { EntitiesService } from "./entities.service";
 import { ImpactStory } from "@terramatch-microservices/database/entities";
-import { NoBearerAuth } from "@terramatch-microservices/common/guards";
+import { AuthOptional } from "@terramatch-microservices/common/guards";
 import { PolicyService } from "@terramatch-microservices/common";
 import { CreateImpactStoryBody } from "./dto/create-impact-story.dto";
 import { UpdateImpactStoryBody } from "./dto/update-impact-story.dto";
@@ -41,7 +41,7 @@ export class ImpactStoriesController {
   ) {}
 
   @Get()
-  @NoBearerAuth
+  @AuthOptional
   @ApiOperation({
     operationId: "impactStoryIndex",
     summary: "Get impact stories."
@@ -91,7 +91,7 @@ export class ImpactStoriesController {
   }
 
   @Get(":uuid")
-  @NoBearerAuth
+  @AuthOptional
   @ApiOperation({
     operationId: "impactStoryGet",
     summary: "Get an impact story by uuid."
@@ -157,7 +157,7 @@ export class ImpactStoriesController {
     operationId: "impactStoryUpdate",
     summary: "Update an existing impact story",
     description: `Update an impact story by UUID. Requires authentication and appropriate permissions.
-    
+
     All fields except status are optional. Status is required.`
   })
   @JsonApiResponse(ImpactStoryFullDto)

--- a/apps/entity-service/src/entities/processors/entity.processor.spec.ts
+++ b/apps/entity-service/src/entities/processors/entity.processor.spec.ts
@@ -15,7 +15,7 @@ import { LocalizationService } from "@terramatch-microservices/common/localizati
 import { BadRequestException, UnauthorizedException } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { CsvExportService } from "@terramatch-microservices/common/export/csv-export.service";
-import { mockRequestContext } from "@terramatch-microservices/common/util/testing";
+import { mockUserContext } from "@terramatch-microservices/common/util/testing";
 import { EntityModel } from "@terramatch-microservices/database/constants/entities";
 import { EntityProcessor } from "./entity-processor";
 import { EntityDto } from "../dto/entity.dto";
@@ -26,7 +26,7 @@ import { ProjectUser } from "@terramatch-microservices/database/entities";
 
 export const mockEntityService = async () => {
   const userId = (await UserFactory.create()).id;
-  mockRequestContext({ userId });
+  mockUserContext({ userId });
   return Test.createTestingModule({
     providers: [
       PolicyService,
@@ -47,7 +47,7 @@ export const expectExportAllFiltersOwn = async <T extends EntityModel>(
   const exportSpy = jest.spyOn(service, "entityExport").mockResolvedValue();
   const projectIdResult = { val: {} };
   const subquerySpy = jest.spyOn(ProjectUser, "userProjectsSubquery").mockReturnValue(projectIdResult);
-  mockRequestContext({ userId: 123, permissions: ["manage-own"] });
+  mockUserContext({ userId: 123, permissions: ["manage-own"] });
   await processor.exportAll({ frameworkKey: "ppc" });
   expect(exportSpy).toHaveBeenCalled();
   expect(subquerySpy).toHaveBeenCalled();
@@ -63,7 +63,7 @@ export const expectExportAllFiltersManaged = async <T extends EntityModel>(
   const exportSpy = jest.spyOn(service, "entityExport").mockResolvedValue();
   const projectIdResult = { val: {} };
   const subquerySpy = jest.spyOn(ProjectUser, "projectsManageSubquery").mockReturnValue(projectIdResult);
-  mockRequestContext({ userId: 123, permissions: ["projects-manage"] });
+  mockUserContext({ userId: 123, permissions: ["projects-manage"] });
   await processor.exportAll({ frameworkKey: "ppc" });
   expect(exportSpy).toHaveBeenCalled();
   expect(subquerySpy).toHaveBeenCalled();

--- a/apps/entity-service/src/entities/processors/nursery.processor.spec.ts
+++ b/apps/entity-service/src/entities/processors/nursery.processor.spec.ts
@@ -21,7 +21,7 @@ import { InternalServerErrorException, NotAcceptableException, NotFoundException
 import { ScheduledJobFactory } from "@terramatch-microservices/database/factories/scheduled-job.factory";
 import { expectExportAllFiltersManaged, expectExportAllFiltersOwn, mockEntityService } from "./entity.processor.spec";
 import { CsvExportService } from "@terramatch-microservices/common/export/csv-export.service";
-import { mockRequestContext, setMockedPermissions } from "@terramatch-microservices/common/util/testing";
+import { mockUserContext, setMockedPermissions } from "@terramatch-microservices/common/util/testing";
 import { Op } from "sequelize";
 import { TestingModule } from "@nestjs/testing";
 import { Response } from "express";
@@ -397,7 +397,7 @@ describe("NurseryProcessor", () => {
         projectId: project.id,
         dueAt: DateTime.now().minus({ days: 5 }).set({ millisecond: 0 }).toJSDate()
       });
-      mockRequestContext({ userId: 123, permissions: [`framework-${project.frameworkKey}`] });
+      mockUserContext({ userId: 123, permissions: [`framework-${project.frameworkKey}`] });
       const nursery = await processor.create({ parentUuid: project.uuid });
       expect(nursery.projectId).toBe(project.id);
       expect(nursery.frameworkKey).toBe(project.frameworkKey);
@@ -411,7 +411,7 @@ describe("NurseryProcessor", () => {
         projectId: project.id,
         dueAt: DateTime.now().plus({ days: 5 }).set({ millisecond: 0 }).toJSDate()
       });
-      mockRequestContext({ userId: 123, permissions: [`framework-${project.frameworkKey}`] });
+      mockUserContext({ userId: 123, permissions: [`framework-${project.frameworkKey}`] });
       const nursery = await processor.create({ parentUuid: project.uuid });
       const report = await NurseryReport.findOne({ where: { nurseryId: nursery.id } });
       expect(report?.taskId).toBe(task.id);
@@ -432,7 +432,7 @@ describe("NurseryProcessor", () => {
           dueAt: DateTime.now().plus({ weeks: 5 }).toISO()
         }
       });
-      mockRequestContext({ userId: 123, permissions: [`framework-${project.frameworkKey}`] });
+      mockUserContext({ userId: 123, permissions: [`framework-${project.frameworkKey}`] });
       const nursery = await processor.create({ parentUuid: project.uuid });
       const report = await NurseryReport.findOne({ where: { nurseryId: nursery.id } });
       expect(report?.taskId).toBe(task.id);

--- a/apps/entity-service/src/entities/processors/project.processor.spec.ts
+++ b/apps/entity-service/src/entities/processors/project.processor.spec.ts
@@ -52,7 +52,7 @@ import { buildJsonApi } from "@terramatch-microservices/common/util";
 import { EntityProcessor } from "./entity-processor";
 import { expectExportAllFiltersManaged, expectExportAllFiltersOwn, mockEntityService } from "./entity.processor.spec";
 import { CsvExportService } from "@terramatch-microservices/common/export/csv-export.service";
-import { mockRequestForUser, setMockedPermissions } from "@terramatch-microservices/common/util/testing";
+import { mockContextForUser, setMockedPermissions } from "@terramatch-microservices/common/util/testing";
 import { Op } from "sequelize";
 import { TestingModule } from "@nestjs/testing";
 import { Response } from "express";
@@ -718,7 +718,7 @@ describe("ProjectProcessor", () => {
     it("creates a test project if the org is a test org", async () => {
       const org = await OrganisationFactory.create({ isTest: true });
       const user = await UserFactory.create({ organisationId: org.id });
-      mockRequestForUser(user);
+      mockContextForUser(user);
       const form = await EntityFormFactory.project().create();
       const project = await processor.create({ formUuid: form.uuid });
       expect(project.isTest).toBe(true);
@@ -727,7 +727,7 @@ describe("ProjectProcessor", () => {
     it("creates blank project if there is no application", async () => {
       const org = await OrganisationFactory.create();
       const user = await UserFactory.create({ organisationId: org.id });
-      mockRequestForUser(user);
+      mockContextForUser(user);
       const form = await EntityFormFactory.project().create();
       const project = await processor.create({ formUuid: form.uuid });
       expect(project.isTest).toBe(false);
@@ -738,7 +738,7 @@ describe("ProjectProcessor", () => {
     it("establishes a project user connection", async () => {
       const org = await OrganisationFactory.create();
       const user = await UserFactory.create({ organisationId: org.id });
-      mockRequestForUser(user);
+      mockContextForUser(user);
       const form = await EntityFormFactory.project().create();
       const project = await processor.create({ formUuid: form.uuid });
       const projectUser = await ProjectUser.findOne({ where: { projectId: project.id, userId: user.id } });

--- a/apps/entity-service/src/entities/project-pitches.controller.spec.ts
+++ b/apps/entity-service/src/entities/project-pitches.controller.spec.ts
@@ -6,7 +6,7 @@ import { ProjectPitchService } from "./project-pitch.service";
 import { BadRequestException, NotFoundException } from "@nestjs/common";
 import { PolicyService } from "@terramatch-microservices/common";
 import { ProjectPitchQueryDto } from "./dto/project-pitch-query.dto";
-import { mockRequestContext, serialize } from "@terramatch-microservices/common/util/testing";
+import { mockUserContext, serialize } from "@terramatch-microservices/common/util/testing";
 import { Resource } from "@terramatch-microservices/common/util/json-api-builder";
 
 describe("ProjectPitchesController", () => {
@@ -38,7 +38,7 @@ describe("ProjectPitchesController", () => {
         paginationTotal: 0,
         pageNumber: 1
       };
-      mockRequestContext({ permissions: ["framework-ppc"] });
+      mockUserContext({ permissions: ["framework-ppc"] });
 
       projectPitchService.getProjectPitches.mockResolvedValue(mockResponse);
 
@@ -56,7 +56,7 @@ describe("ProjectPitchesController", () => {
         paginationTotal: 3,
         pageNumber: 1
       };
-      mockRequestContext({ userId: 123, permissions: ["framework-ppc"] });
+      mockUserContext({ userId: 123, permissions: ["framework-ppc"] });
       projectPitchService.getProjectPitches.mockResolvedValue(mockResponse);
 
       const result = serialize(await controller.projectPitchIndex(new ProjectPitchQueryDto()));

--- a/apps/entity-service/src/entities/tasks.controller.spec.ts
+++ b/apps/entity-service/src/entities/tasks.controller.spec.ts
@@ -9,7 +9,7 @@ import { Task } from "@terramatch-microservices/database/entities";
 import { BadRequestException } from "@nestjs/common";
 import { Resource } from "@terramatch-microservices/common/util";
 import { TaskLightDto } from "./dto/task.dto";
-import { mockRequestContext, serialize, setMockedPermissions } from "@terramatch-microservices/common/util/testing";
+import { mockUserContext, serialize, setMockedPermissions } from "@terramatch-microservices/common/util/testing";
 
 describe("TasksController", () => {
   let controller: TasksController;
@@ -33,7 +33,7 @@ describe("TasksController", () => {
       return document;
     });
 
-    mockRequestContext({ userId: 123 });
+    mockUserContext({ userId: 123 });
   });
 
   afterEach(() => {

--- a/apps/entity-service/src/entities/tasks.service.spec.ts
+++ b/apps/entity-service/src/entities/tasks.service.spec.ts
@@ -32,7 +32,7 @@ import { AuditStatus } from "@terramatch-microservices/database/entities/audit-s
 import { TaskUpdateBody } from "./dto/task-update.dto";
 import { ConfigService } from "@nestjs/config";
 import { CsvExportService } from "@terramatch-microservices/common/export/csv-export.service";
-import { mockRequestContext } from "@terramatch-microservices/common/util/testing";
+import { mockUserContext } from "@terramatch-microservices/common/util/testing";
 
 describe("TasksService", () => {
   let service: TasksService;
@@ -78,7 +78,7 @@ describe("TasksService", () => {
         paginationTotal = expected.length
       }: { permissions?: string[]; sortField?: string; sortUp?: boolean; paginationTotal?: number } = {}
     ) {
-      mockRequestContext({ userId, permissions });
+      mockUserContext({ userId, permissions });
       const { tasks, total } = await service.getTasks(query);
       expect(tasks.length).toBe(expected.length);
       expect(total).toBe(paginationTotal);
@@ -229,7 +229,7 @@ describe("TasksService", () => {
     it("should add all task details", async () => {
       const project = await ProjectFactory.create();
       const task = await TaskFactory.create({ projectId: project.id });
-      mockRequestContext({ userId, permissions: [`framework-${project.frameworkKey}`] });
+      mockUserContext({ userId, permissions: [`framework-${project.frameworkKey}`] });
       const projectReport = await ProjectReportFactory.create({
         taskId: task.id,
         projectId: project.id,
@@ -310,7 +310,7 @@ describe("TasksService", () => {
 
     it("should throw if there is an incomplete report", async () => {
       const project = await ProjectFactory.create();
-      mockRequestContext({ userId, permissions: [`framework-${project.frameworkKey}`] });
+      mockUserContext({ userId, permissions: [`framework-${project.frameworkKey}`] });
       const task = await TaskFactory.create({ projectId: project.id });
       await ProjectReportFactory.create({
         taskId: task.id,
@@ -323,7 +323,7 @@ describe("TasksService", () => {
 
     it("should ensure all reports are in a complete state", async () => {
       const project = await ProjectFactory.create();
-      mockRequestContext({ userId, permissions: [`framework-${project.frameworkKey}`] });
+      mockUserContext({ userId, permissions: [`framework-${project.frameworkKey}`] });
       const task = await TaskFactory.create({ projectId: project.id });
       const projectReport = await ProjectReportFactory.create({
         taskId: task.id,
@@ -370,7 +370,7 @@ describe("TasksService", () => {
   describe("approveBulkReports", () => {
     it("should approve reports and update their status", async () => {
       const user = await UserFactory.create();
-      mockRequestContext({ userId: user.id });
+      mockUserContext({ userId: user.id });
 
       const task = await TaskFactory.create();
       const siteReport = await SiteReportFactory.create({ taskId: task.id, status: "due" });
@@ -397,7 +397,7 @@ describe("TasksService", () => {
 
     it("should handle empty arrays of UUIDs", async () => {
       const user = await UserFactory.create();
-      mockRequestContext({ userId: user.id });
+      mockUserContext({ userId: user.id });
 
       const task = await TaskFactory.create();
 
@@ -418,7 +418,7 @@ describe("TasksService", () => {
 
     it("should handle null UUIDs arrays", async () => {
       const user = await UserFactory.create();
-      mockRequestContext({ userId: user.id });
+      mockUserContext({ userId: user.id });
 
       const task = await TaskFactory.create();
 

--- a/apps/entity-service/src/forms/forms.controller.spec.ts
+++ b/apps/entity-service/src/forms/forms.controller.spec.ts
@@ -10,7 +10,7 @@ import { PolicyService } from "@terramatch-microservices/common";
 import { FormFactory, FormQuestionFactory, FormSectionFactory } from "@terramatch-microservices/database/factories";
 import { StoreFormAttributes } from "./dto/form.dto";
 import { LocalizationService } from "@terramatch-microservices/common/localization/localization.service";
-import { mockRequestContext } from "@terramatch-microservices/common/util/testing";
+import { mockUserContext } from "@terramatch-microservices/common/util/testing";
 
 describe("FormsController", () => {
   let module: TestingModule;
@@ -32,7 +32,7 @@ describe("FormsController", () => {
 
     controller = module.get(FormsController);
 
-    mockRequestContext({ userId: 123, permissions: ["custom-forms-manage", "framework-ppc"] });
+    mockUserContext({ userId: 123, permissions: ["custom-forms-manage", "framework-ppc"] });
   });
 
   afterEach(() => {

--- a/apps/entity-service/src/forms/forms.service.spec.ts
+++ b/apps/entity-service/src/forms/forms.service.spec.ts
@@ -34,7 +34,7 @@ import {
 import { buildJsonApi, Resource } from "@terramatch-microservices/common/util";
 import { FormFullDto, FormLightDto, StoreFormAttributes } from "./dto/form.dto";
 import {
-  mockRequestContext,
+  mockUserContext,
   mockTranslateFieldsWithOriginal,
   serialize
 } from "@terramatch-microservices/common/util/testing";
@@ -181,7 +181,7 @@ describe("FormsService", () => {
 
   describe("addFullDto", () => {
     const setupTestForm = async (translated: boolean) => {
-      mockRequestContext({ userId: (await UserFactory.create()).id });
+      mockUserContext({ userId: (await UserFactory.create()).id });
       mediaService.getUrl.mockReturnValue("fake-url");
       localizationService.translateIds.mockResolvedValue({
         1: "First Translation",
@@ -344,7 +344,7 @@ describe("FormsService", () => {
 
   describe("store", () => {
     beforeEach(() => {
-      mockRequestContext({ userId: 123 });
+      mockUserContext({ userId: 123 });
       localizationService.generateI18nId.mockResolvedValue(1);
     });
 

--- a/apps/entity-service/src/forms/forms.service.ts
+++ b/apps/entity-service/src/forms/forms.service.ts
@@ -56,7 +56,6 @@ import { ModelCtor } from "sequelize-typescript/dist/model/model/model";
 import { MediaDto } from "@terramatch-microservices/common/dto/media.dto";
 import { isNotNull } from "@terramatch-microservices/database/types/array";
 import { LinkedFile } from "@terramatch-microservices/database/constants/linked-fields";
-import { authenticatedUserId, userLocale } from "@terramatch-microservices/common/guards/auth.guard";
 import { Model } from "sequelize-typescript";
 import {
   CsvExportService,
@@ -68,6 +67,7 @@ import {
 import { batchFindAll } from "@terramatch-microservices/common/util/batch-find-all";
 import { FrameworkKey } from "@terramatch-microservices/database/constants";
 import { timestampFileName } from "@terramatch-microservices/common/util/filenames";
+import { UserContext } from "@terramatch-microservices/common/contexts/user.context";
 
 const SORTABLE_FIELDS: (keyof Attributes<Form>)[] = ["title", "type", "published"];
 const SIMPLE_FILTERS: (keyof FormIndexQueryDto)[] = ["type"];
@@ -599,7 +599,7 @@ export class FormsService {
   }
 
   private get userLocale() {
-    const locale = userLocale();
+    const locale = UserContext.userLocale;
     if (locale == null) {
       throw new BadRequestException("Locale is required");
     }
@@ -636,7 +636,7 @@ export class FormsService {
   private async storeForm(form: Form, attributes: StoreFormAttributes) {
     // Note: this field is a char(32) in the DB which would normally be a UUID, but the current
     // rows are all numerical IDs.
-    form.updatedBy = `${authenticatedUserId()}`;
+    form.updatedBy = `${UserContext.authenticatedUserId}`;
     form.title = attributes.title;
     form.titleId = await this.localizationService.generateI18nId(attributes.title, form.titleId);
     form.subtitle = attributes.subtitle ?? null;

--- a/apps/entity-service/src/forms/option-labels.controller.spec.ts
+++ b/apps/entity-service/src/forms/option-labels.controller.spec.ts
@@ -8,7 +8,7 @@ import {
 } from "@terramatch-microservices/database/factories";
 import { faker } from "@faker-js/faker";
 import { I18nTranslationFactory } from "@terramatch-microservices/database/factories/i18n-translation.factory";
-import { mockRequestContext, serialize } from "@terramatch-microservices/common/util/testing";
+import { mockUserContext, serialize } from "@terramatch-microservices/common/util/testing";
 import { NotFoundException } from "@nestjs/common";
 import { LocalizationService } from "@terramatch-microservices/common/localization/localization.service";
 import { createMock } from "@golevelup/ts-jest";
@@ -35,12 +35,12 @@ describe("OptionsLabelsController", () => {
 
   describe("optionLabelsIndex", () => {
     it("should throw an error if ids is empty", async () => {
-      mockRequestContext({ userId: 123 });
+      mockUserContext({ userId: 123 });
       await expect(controller.optionLabelsIndex([])).rejects.toThrow("Set of ids is required");
     });
 
     it("should throw if no locale is found", async () => {
-      mockRequestContext({ userId: -1, locale: null });
+      mockUserContext({ userId: -1, locale: null });
       await expect(controller.optionLabelsIndex(["1"])).rejects.toThrow("Locale is required");
     });
 
@@ -49,7 +49,7 @@ describe("OptionsLabelsController", () => {
       options.push(await FormOptionListOptionFactory.create({ imageUrl: faker.internet.url() }));
       await FormOptionListOptionFactory.create();
 
-      mockRequestContext({ userId: 123, locale: "en-US" });
+      mockUserContext({ userId: 123, locale: "en-US" });
       const document = serialize(await controller.optionLabelsIndex(options.map(({ slug }) => slug) as string[]));
       expect(document.data).toHaveLength(options.length);
       for (const { slug, label, imageUrl } of options) {
@@ -67,7 +67,7 @@ describe("OptionsLabelsController", () => {
       await FormOptionListOptionFactory.create();
       options.push((await FormQuestionOptionFactory.forQuestion().create()) as OptionLabelModel);
 
-      mockRequestContext({ userId: 123, locale: "en-US" });
+      mockUserContext({ userId: 123, locale: "en-US" });
       const document = serialize(await controller.optionLabelsIndex(options.map(({ slug }) => slug) as string[]));
       expect(document.data).toHaveLength(options.length);
       for (const { slug, label, imageUrl } of options) {
@@ -80,7 +80,7 @@ describe("OptionsLabelsController", () => {
     });
 
     it("should throw an error if no ids are found", async () => {
-      mockRequestContext({ userId: 123, locale: "en-US" });
+      mockUserContext({ userId: 123, locale: "en-US" });
       await expect(controller.optionLabelsIndex(["1", "2"])).rejects.toThrow("No records matching the given ids exist");
     });
 
@@ -92,7 +92,7 @@ describe("OptionsLabelsController", () => {
       const options = [listOption, questionOption];
       const translations = [translation1, translation2];
 
-      mockRequestContext({ userId: 123, locale: "es-MX" });
+      mockUserContext({ userId: 123, locale: "es-MX" });
       const document = serialize(await controller.optionLabelsIndex(options.map(({ slug }) => slug) as string[]));
       expect(document.data).toHaveLength(options.length);
       for (const { slug, labelId, imageUrl } of options) {
@@ -118,25 +118,25 @@ describe("OptionsLabelsController", () => {
     });
 
     it("should throw an error if listKey does not exist", async () => {
-      mockRequestContext({ userId: 123 });
+      mockUserContext({ userId: 123 });
       await expect(controller.findList("fake-list-key")).rejects.toThrow(NotFoundException);
     });
 
     it("should throw an error if the listKey has no associated options", async () => {
       const { key } = await FormOptionListFactory.create();
-      mockRequestContext({ userId: 123 });
+      mockUserContext({ userId: 123 });
       await expect(controller.findList(key)).rejects.toThrow(NotFoundException);
     });
 
     it("should throw if no locale is found", async () => {
-      mockRequestContext({ userId: -1, locale: null });
+      mockUserContext({ userId: -1, locale: null });
       await expect(controller.findList("fake-list-key")).rejects.toThrow("Locale is required");
     });
 
     it("should return the options associated with the listKey", async () => {
       const { key, id } = await FormOptionListFactory.create();
       const options = await FormOptionListOptionFactory.createMany(5, { formOptionListId: id });
-      mockRequestContext({ userId: 123 });
+      mockUserContext({ userId: 123 });
       const document = serialize(await controller.findList(key));
       expect(document.data).toHaveLength(options.length);
       for (const { slug, label, imageUrl } of options) {

--- a/apps/entity-service/src/forms/option-labels.controller.ts
+++ b/apps/entity-service/src/forms/option-labels.controller.ts
@@ -9,7 +9,7 @@ import { buildJsonApi, DocumentBuilder, getStableRequestQuery } from "@terramatc
 import { populateDto } from "@terramatch-microservices/common/dto/json-api-attributes";
 import { ValidLocale } from "@terramatch-microservices/database/constants/locale";
 import { LocalizationService } from "@terramatch-microservices/common/localization/localization.service";
-import { userLocale } from "@terramatch-microservices/common/guards/auth.guard";
+import { UserContext } from "@terramatch-microservices/common/contexts/user.context";
 
 export type OptionLabelModel = {
   slug: string;
@@ -31,7 +31,7 @@ export class OptionLabelsController {
   async optionLabelsIndex(@Query("ids") ids: string[]) {
     if (isEmpty(ids)) throw new BadRequestException("Set of ids is required");
 
-    const locale = userLocale();
+    const locale = UserContext.userLocale;
     if (locale == null) throw new BadRequestException("Locale is required");
 
     const listOptions = (await FormOptionListOption.findAll({
@@ -68,7 +68,7 @@ export class OptionLabelsController {
   @ExceptionResponse(NotFoundException, { description: "List for listKey not found" })
   @JsonApiResponse({ data: OptionLabelDto, hasMany: true })
   async findList(@Param("listKey") listKey: string) {
-    const locale = userLocale();
+    const locale = UserContext.userLocale;
     if (locale == null) throw new BadRequestException("Locale is required");
 
     const list = await FormOptionList.findOne({

--- a/apps/entity-service/src/forms/submissions.controller.spec.ts
+++ b/apps/entity-service/src/forms/submissions.controller.spec.ts
@@ -13,7 +13,7 @@ import {
   StageFactory,
   UserFactory
 } from "@terramatch-microservices/database/factories";
-import { mockRequestContext } from "@terramatch-microservices/common/util/testing";
+import { mockUserContext } from "@terramatch-microservices/common/util/testing";
 import { FormSubmission } from "@terramatch-microservices/database/entities";
 import { UpdateSubmissionAttributes } from "../entities/dto/submission.dto";
 
@@ -76,7 +76,7 @@ describe("SubmissionsController", () => {
 
     it("throws if the user doesn't have an org", async () => {
       const user = await UserFactory.create();
-      mockRequestContext({ userId: user.id });
+      mockUserContext({ userId: user.id });
       const programme = await FundingProgrammeFactory.create();
       const stage = await StageFactory.create({ fundingProgrammeId: programme.uuid });
       await FormFactory.create({ stageId: stage.uuid });
@@ -171,7 +171,7 @@ describe("SubmissionsController", () => {
     it("creates the submission, application and project pitch for the first stage", async () => {
       const org = await OrganisationFactory.create();
       const user = await UserFactory.create({ organisationId: org.id });
-      mockRequestContext({ userId: user.id });
+      mockUserContext({ userId: user.id });
 
       const programme = await FundingProgrammeFactory.create();
       const stage = await StageFactory.create({ fundingProgrammeId: programme.uuid });
@@ -210,7 +210,7 @@ describe("SubmissionsController", () => {
     it("creates the submission, application and project pitch for the next stage", async () => {
       const org = await OrganisationFactory.create();
       const user = await UserFactory.create({ organisationId: org.id });
-      mockRequestContext({ userId: user.id });
+      mockUserContext({ userId: user.id });
 
       const programme = await FundingProgrammeFactory.create();
       const stages = [
@@ -289,7 +289,7 @@ describe("SubmissionsController", () => {
 
     it("calls the service to update the answers", async () => {
       const user = await UserFactory.create();
-      mockRequestContext({ userId: user.id });
+      mockUserContext({ userId: user.id });
 
       const form = await FormFactory.create();
       const submission = await FormSubmissionFactory.create({ formId: form.uuid });
@@ -311,7 +311,7 @@ describe("SubmissionsController", () => {
 
     it("updates the submissions status and feedback", async () => {
       const user = await UserFactory.create();
-      mockRequestContext({ userId: user.id });
+      mockUserContext({ userId: user.id });
 
       const form = await FormFactory.create();
       const submission = await FormSubmissionFactory.create({ formId: form.uuid, status: "awaiting-approval" });

--- a/apps/entity-service/src/forms/submissions.controller.ts
+++ b/apps/entity-service/src/forms/submissions.controller.ts
@@ -25,8 +25,8 @@ import {
   ProjectPitch,
   User
 } from "@terramatch-microservices/database/entities";
-import { authenticatedUserId } from "@terramatch-microservices/common/guards/auth.guard";
 import { FormDataDto } from "../entities/dto/form-data.dto";
+import { UserContext } from "@terramatch-microservices/common/contexts/user.context";
 
 @Controller("forms/v3/submissions")
 export class SubmissionsController {
@@ -98,7 +98,7 @@ export class SubmissionsController {
     const form = await Form.findOne({ where: { stageId: stageUuid } });
     if (form == null) throw new BadRequestException("Form for stage not found");
 
-    const user = await User.findByPk(authenticatedUserId(), {
+    const user = await User.findByPk(UserContext.authenticatedUserId, {
       attributes: ["uuid", "locale"],
       include: [{ association: "organisation" }] // pull full org for DTO creation below
     });
@@ -129,12 +129,12 @@ export class SubmissionsController {
         await Application.create({
           organisationUuid: user.organisation.uuid,
           fundingProgrammeUuid: programme.uuid,
-          updatedBy: authenticatedUserId()
+          updatedBy: UserContext.authenticatedUserId
         })
       ).id;
     if (previousSubmission?.applicationId != null) {
       await Application.update(
-        { updatedBy: authenticatedUserId() },
+        { updatedBy: UserContext.authenticatedUserId },
         { where: { id: previousSubmission?.applicationId } }
       );
     }
@@ -164,7 +164,10 @@ export class SubmissionsController {
     const form = submission.formId == null ? undefined : await Form.findOne({ where: { uuid: submission.formId } });
     if (form == null) throw new NotFoundException("Form for submission not found");
 
-    const user = await User.findOne({ where: { id: authenticatedUserId() }, attributes: ["uuid", "locale"] });
+    const user = await User.findOne({
+      where: { id: UserContext.authenticatedUserId },
+      attributes: ["uuid", "locale"]
+    });
 
     const attributes = payload.data.attributes;
     if (attributes.answers != null) {
@@ -173,7 +176,10 @@ export class SubmissionsController {
 
       await submission.update({ userId: user?.uuid });
       if (submission.applicationId != null) {
-        await Application.update({ updatedBy: authenticatedUserId() }, { where: { id: submission.applicationId } });
+        await Application.update(
+          { updatedBy: UserContext.authenticatedUserId },
+          { where: { id: submission.applicationId } }
+        );
       }
     }
 
@@ -189,7 +195,7 @@ export class SubmissionsController {
 
       await submission.save();
     } else {
-      await AuditStatus.ensureRecentAudit(submission, authenticatedUserId());
+      await AuditStatus.ensureRecentAudit(submission, UserContext.authenticatedUserId);
     }
 
     return await this.formDataService.addSubmissionDto(buildJsonApi(SubmissionDto), submission, form, user?.locale);

--- a/apps/entity-service/src/fundingProgrammes/funding-programmes.controller.spec.ts
+++ b/apps/entity-service/src/fundingProgrammes/funding-programmes.controller.spec.ts
@@ -14,8 +14,8 @@ import {
   UserFactory
 } from "@terramatch-microservices/database/factories";
 import {
-  mockRequestContext,
-  mockRequestForUser,
+  mockUserContext,
+  mockContextForUser,
   serialize,
   setMockedPermissions
 } from "@terramatch-microservices/common/util/testing";
@@ -75,7 +75,7 @@ describe("FundingProgrammesController", () => {
 
     it("returns no funding programmes if the user doesn't have an org", async () => {
       const user = await UserFactory.create();
-      mockRequestForUser(user, "manage-own");
+      mockContextForUser(user, "manage-own");
       await FundingProgrammeFactory.createMany(3);
       const authSpy = jest.spyOn(policyService, "authorize").mockResolvedValue();
       await controller.index({ translated: false });
@@ -88,7 +88,7 @@ describe("FundingProgrammesController", () => {
       const org2 = await OrganisationFactory.create({ type: "gov" });
       const user = await UserFactory.create({ organisationId: org.id });
       await OrganisationUserFactory.create({ organisationId: org2.id, userId: user.id, status: "approved" });
-      mockRequestForUser(user, "manage-own");
+      mockContextForUser(user, "manage-own");
       await FundingProgramme.truncate();
       const programmes = [
         await FundingProgrammeFactory.create({
@@ -120,7 +120,7 @@ describe("FundingProgrammesController", () => {
     it("translates by default", async () => {
       await FundingProgramme.truncate();
       const user = await UserFactory.create({ locale: "es-MX" });
-      mockRequestForUser(user, "framework-ppc");
+      mockContextForUser(user, "framework-ppc");
       await controller.index({});
       expect(formDataService.addFundingProgrammeDtos).toHaveBeenCalledWith(
         expect.anything(),
@@ -151,7 +151,7 @@ describe("FundingProgrammesController", () => {
     it("translates by default", async () => {
       const programme = await FundingProgrammeFactory.create();
       const user = await UserFactory.create({ locale: "es-MX" });
-      mockRequestForUser(user);
+      mockContextForUser(user);
       await controller.get({ uuid: programme.uuid }, {});
       await programme.reload();
       expect(formDataService.addFundingProgrammeDtos).toHaveBeenCalledWith(
@@ -328,7 +328,7 @@ describe("FundingProgrammesController", () => {
   describe("exportAll", () => {
     it("throws if the export is not found", async () => {
       await SavedExport.truncate();
-      mockRequestContext({ userId: 123, permissions: ["framework-ppc"] });
+      mockUserContext({ userId: 123, permissions: ["framework-ppc"] });
       await expect(controller.exportAll({ uuid: "uuid" })).rejects.toThrow(NotFoundException);
     });
 
@@ -338,7 +338,7 @@ describe("FundingProgrammesController", () => {
       exports[0].setDataValue("createdAt", DateTime.fromJSDate(exports[0].createdAt).minus({ days: 1 }).toJSDate());
       await exports[0].save();
 
-      mockRequestContext({ userId: 123, permissions: ["framework-ppc"] });
+      mockUserContext({ userId: 123, permissions: ["framework-ppc"] });
       csvExportService.generateExportDto.mockResolvedValue(new FileDownloadDto("test"));
       await controller.exportAll({ uuid: fp.uuid });
       expect(csvExportService.generateExportDto).toHaveBeenCalledWith(exports[1].name);

--- a/apps/entity-service/src/fundingProgrammes/funding-programmes.controller.ts
+++ b/apps/entity-service/src/fundingProgrammes/funding-programmes.controller.ts
@@ -35,7 +35,6 @@ import {
   getStableRequestQuery
 } from "@terramatch-microservices/common/util";
 import { FundingProgrammeQueryDto } from "./dto/funding-programme-query.dto";
-import { authenticatedUserId, userLocale } from "@terramatch-microservices/common/guards/auth.guard";
 import { FormDataService } from "../entities/form-data.service";
 import { difference, uniq } from "lodash";
 import { isNotNull } from "@terramatch-microservices/database/types/array";
@@ -46,6 +45,7 @@ import { BadRequestException } from "@nestjs/common/exceptions/bad-request.excep
 import { LocalizationService } from "@terramatch-microservices/common/localization/localization.service";
 import { CsvExportService } from "@terramatch-microservices/common/export/csv-export.service";
 import { FileDownloadDto } from "@terramatch-microservices/common/dto/file-download.dto";
+import { UserContext } from "@terramatch-microservices/common/contexts/user.context";
 
 @Controller("fundingProgrammes/v3/fundingProgrammes")
 export class FundingProgrammesController {
@@ -69,7 +69,7 @@ export class FundingProgrammesController {
     let fundingProgrammes: FundingProgramme[];
     if (this.policyService.permissions.find(p => p.startsWith("framework-")) == null) {
       // non-admins only have access to FPs that match their org types
-      const orgUuids = await User.orgUuids(authenticatedUserId());
+      const orgUuids = await User.orgUuids(UserContext.authenticatedUserId);
       const types =
         orgUuids.length === 0
           ? []
@@ -93,7 +93,7 @@ export class FundingProgrammesController {
       fundingProgrammes = await FundingProgramme.findAll();
     }
 
-    const locale = query.translated === false ? undefined : userLocale();
+    const locale = query.translated === false ? undefined : UserContext.userLocale;
     await this.policyService.authorize("read", fundingProgrammes);
     const document = buildJsonApi(FundingProgrammeDto, { forceDataArray: true }).addIndex({
       requestPath: `/fundingProgrammes/v3/fundingProgrammes${getStableRequestQuery(query)}`
@@ -113,7 +113,7 @@ export class FundingProgrammesController {
     const fundingProgramme = await FundingProgramme.findOne({ where: { uuid } });
     if (fundingProgramme == null) throw new NotFoundException("Funding programme not found");
 
-    const locale = translated === false ? undefined : userLocale();
+    const locale = translated === false ? undefined : UserContext.userLocale;
     await this.policyService.authorize("read", fundingProgramme);
 
     return await this.formDataService.addFundingProgrammeDtos(

--- a/apps/entity-service/src/jobs/entity-service-exports.processor.ts
+++ b/apps/entity-service/src/jobs/entity-service-exports.processor.ts
@@ -11,11 +11,11 @@ import { TMLogger } from "@terramatch-microservices/common/util/tm-logger";
 import { EntitiesService } from "../entities/entities.service";
 import { DelayedJobDto } from "@terramatch-microservices/common/dto";
 import { buildJsonApi } from "@terramatch-microservices/common/util";
-import { authenticatedUserId } from "@terramatch-microservices/common/guards/auth.guard";
 import { FileService } from "@terramatch-microservices/common/file/file.service";
 import { ConfigService } from "@nestjs/config";
 import { streamZip } from "@terramatch-microservices/common/util/zip-stream";
 import { FileDownloadDto } from "@terramatch-microservices/common/dto/file-download.dto";
+import { UserContext } from "@terramatch-microservices/common/contexts/user.context";
 
 export type EntityServiceExportJobData = {
   delayedJobId: number;
@@ -38,7 +38,7 @@ export class EntityServiceExportsProcessor extends DelayedJobWorker<EntityServic
   static async queueProjectExport(queue: Queue, projectUuid: string, projectName: string) {
     const delayedJob = await DelayedJob.create({
       name: "Project Zip Export",
-      createdBy: authenticatedUserId()
+      createdBy: UserContext.authenticatedUserId
     });
     const data: EntityServiceExportJobData = { delayedJobId: delayedJob.id, projectUuid, projectName };
     await queue.add(PROJECT_EXPORT, data);

--- a/apps/entity-service/src/reportingFrameworks/reporting-frameworks.controller.spec.ts
+++ b/apps/entity-service/src/reportingFrameworks/reporting-frameworks.controller.spec.ts
@@ -5,7 +5,7 @@ import { ReportingFrameworksService } from "./reporting-frameworks.service";
 import { PolicyService } from "@terramatch-microservices/common";
 import { BadRequestException, NotFoundException, UnauthorizedException } from "@nestjs/common";
 import { FrameworkFactory, ProjectFactory } from "@terramatch-microservices/database/factories";
-import { mockRequestContext } from "@terramatch-microservices/common/util/testing";
+import { mockUserContext } from "@terramatch-microservices/common/util/testing";
 import { DocumentBuilder } from "@terramatch-microservices/common/util";
 import { Project, Framework, FrameworkUser } from "@terramatch-microservices/database/entities";
 
@@ -35,7 +35,7 @@ describe("ReportingFrameworksController", () => {
 
     controller = module.get<ReportingFrameworksController>(ReportingFrameworksController);
 
-    mockRequestContext({ userId: 1 });
+    mockUserContext({ userId: 1 });
     createdFrameworkIds.length = 0;
   });
 

--- a/apps/job-service/src/jobs/delayed-jobs.controller.spec.ts
+++ b/apps/job-service/src/jobs/delayed-jobs.controller.spec.ts
@@ -7,7 +7,7 @@ import { v4 as uuidv4 } from "uuid";
 import { NotFoundException } from "@nestjs/common";
 import { plainToClass } from "class-transformer";
 import { validate } from "class-validator";
-import { mockRequestContext, serialize } from "@terramatch-microservices/common/util/testing";
+import { mockUserContext, serialize } from "@terramatch-microservices/common/util/testing";
 import { DelayedJobFactory } from "@terramatch-microservices/database/factories";
 import { Resource } from "@terramatch-microservices/common/util/json-api-builder";
 
@@ -34,7 +34,7 @@ describe("DelayedJobsController", () => {
   describe("getRunningJobs", () => {
     it("should return a job with null entity_name if metadata is null", async () => {
       const authenticatedUserId = 130999;
-      mockRequestContext({ userId: authenticatedUserId });
+      mockUserContext({ userId: authenticatedUserId });
       const job = await DelayedJobFactory.succeeded.create({ createdBy: authenticatedUserId });
       const result = serialize(await controller.getRunningJobs());
 
@@ -47,7 +47,7 @@ describe("DelayedJobsController", () => {
 
     it("should return a job with entity_name if metadata exists", async () => {
       const authenticatedUserId = 130999;
-      mockRequestContext({ userId: authenticatedUserId });
+      mockUserContext({ userId: authenticatedUserId });
       const job = await DelayedJobFactory.succeeded.create({
         createdBy: authenticatedUserId,
         metadata: { entity_name: "TestEntity" }
@@ -65,7 +65,7 @@ describe("DelayedJobsController", () => {
 
     it("should return a job with null entity_name if metadata does not have entity_name", async () => {
       const authenticatedUserId = 130999;
-      mockRequestContext({ userId: authenticatedUserId });
+      mockUserContext({ userId: authenticatedUserId });
       const job = await DelayedJobFactory.succeeded.create({ createdBy: authenticatedUserId, metadata: {} });
       const result = serialize(await controller.getRunningJobs());
       const data = Array.isArray(result.data) ? result.data : [result.data];
@@ -100,7 +100,7 @@ describe("DelayedJobsController", () => {
   describe("bulkUdpateJobs", () => {
     it("should successfully update jobs with null metadata", async () => {
       const authenticatedUserId = 130999;
-      mockRequestContext({ userId: authenticatedUserId });
+      mockUserContext({ userId: authenticatedUserId });
       const job1 = await DelayedJobFactory.succeeded.create({ createdBy: authenticatedUserId });
       const job2 = await DelayedJobFactory.succeeded.create({
         createdBy: authenticatedUserId,
@@ -134,7 +134,7 @@ describe("DelayedJobsController", () => {
 
     it("should successfully bulk update jobs to acknowledged with entity_name", async () => {
       const authenticatedUserId = 130999;
-      mockRequestContext({ userId: authenticatedUserId });
+      mockUserContext({ userId: authenticatedUserId });
       const job1 = await DelayedJobFactory.succeeded.create({
         createdBy: authenticatedUserId,
         metadata: { entity_name: "TestEntity1" } // Adding entity_name
@@ -182,14 +182,14 @@ describe("DelayedJobsController", () => {
           }
         ]
       };
-      mockRequestContext({ userId: 130999 });
+      mockUserContext({ userId: 130999 });
 
       await expect(controller.bulkUpdateJobs(payload)).rejects.toThrow(NotFoundException);
     });
 
     it('should update jobs with status "pending"', async () => {
       const authenticatedUserId = 130999;
-      mockRequestContext({ userId: authenticatedUserId });
+      mockUserContext({ userId: authenticatedUserId });
       const pendingJob = await DelayedJob.create({
         uuid: uuidv4(),
         createdBy: authenticatedUserId,

--- a/apps/job-service/src/jobs/delayed-jobs.controller.ts
+++ b/apps/job-service/src/jobs/delayed-jobs.controller.ts
@@ -16,7 +16,7 @@ import { DelayedJob } from "@terramatch-microservices/database/entities";
 import { DelayedJobBulkUpdateBodyDto } from "./dto/delayed-job-update.dto";
 import { DelayedJobDto } from "@terramatch-microservices/common/dto/delayed-job.dto";
 import { isNotNull } from "@terramatch-microservices/database/types/array";
-import { authenticatedUserId } from "@terramatch-microservices/common/guards/auth.guard";
+import { UserContext } from "@terramatch-microservices/common/contexts/user.context";
 
 @Controller("jobs/v3/delayedJobs")
 export class DelayedJobsController {
@@ -31,7 +31,7 @@ export class DelayedJobsController {
     const runningJobs = await DelayedJob.findAll({
       where: {
         isAcknowledged: false,
-        createdBy: authenticatedUserId()
+        createdBy: UserContext.authenticatedUserId
       },
       order: [["createdAt", "DESC"]]
     });
@@ -79,7 +79,7 @@ export class DelayedJobsController {
     const jobs = await DelayedJob.findAll({
       where: {
         uuid: { [Op.in]: jobUpdates.map(({ id }) => id) },
-        createdBy: authenticatedUserId()
+        createdBy: UserContext.authenticatedUserId
       },
       order: [["createdAt", "DESC"]]
     });

--- a/apps/research-service/src/bounding-boxes/bounding-box.controller.ts
+++ b/apps/research-service/src/bounding-boxes/bounding-box.controller.ts
@@ -4,7 +4,7 @@ import { BoundingBoxService } from "./bounding-box.service";
 import { BoundingBoxQueryDto } from "./dto/bounding-box-query.dto";
 import { BoundingBoxDto } from "./dto/bounding-box.dto";
 import { ExceptionResponse, JsonApiResponse } from "@terramatch-microservices/common/decorators";
-import { NoBearerAuth } from "@terramatch-microservices/common/guards";
+import { AuthOptional } from "@terramatch-microservices/common/guards";
 import { buildJsonApi, getStableRequestQuery } from "@terramatch-microservices/common/util";
 import { isEmpty } from "lodash";
 import { LandscapeGeometry, Project, ProjectPitch, Site } from "@terramatch-microservices/database/entities";
@@ -13,7 +13,7 @@ type ParameterType = "polygonUuid" | "siteUuid" | "projectUuid" | "projectPitchU
 
 @Controller("boundingBoxes/v3")
 @ApiTags("Bounding Boxes")
-@NoBearerAuth
+@AuthOptional
 export class BoundingBoxController {
   constructor(private readonly boundingBoxService: BoundingBoxService) {}
 

--- a/apps/research-service/src/indicators/indicators.controller.spec.ts
+++ b/apps/research-service/src/indicators/indicators.controller.spec.ts
@@ -5,7 +5,7 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { IndicatorsService } from "./indicators.service";
 import { getQueueToken } from "@nestjs/bullmq";
 import { IndicatorsBodyDto } from "./dto/indicators-body.dto";
-import { mockRequestContext, serialize } from "@terramatch-microservices/common/util/testing";
+import { mockUserContext, serialize } from "@terramatch-microservices/common/util/testing";
 import { DelayedJob } from "@terramatch-microservices/database/entities";
 import { IndicatorSlug } from "@terramatch-microservices/database/constants";
 
@@ -62,7 +62,7 @@ describe("IndicatorsController", () => {
   });
 
   describe("startIndicatorCalculation", () => {
-    mockRequestContext({ userId: 1 });
+    mockUserContext({ userId: 1 });
 
     it("should create a indicators job", async () => {
       const request: IndicatorsBodyDto = {

--- a/apps/research-service/src/indicators/indicators.controller.ts
+++ b/apps/research-service/src/indicators/indicators.controller.ts
@@ -14,7 +14,7 @@ import { SitePolygonLightDto } from "../site-polygons/dto/site-polygon.dto";
 import { IndicatorsService } from "./indicators.service";
 import { ExceptionResponse } from "@terramatch-microservices/common/decorators";
 import { IndicatorExportQueryDto } from "./dto/indicator-export-query.dto";
-import { authenticatedUserId } from "@terramatch-microservices/common/guards/auth.guard";
+import { UserContext } from "@terramatch-microservices/common/contexts/user.context";
 
 @Controller("research/v3/indicators")
 @ApiExtraModels(IndicatorTreeCoverLossDto, IndicatorHectaresDto)
@@ -42,7 +42,7 @@ export class IndicatorsController {
       name: "Indicator Calculation",
       processedContent: 0,
       progressMessage: "Starting indicator calculation...",
-      createdBy: authenticatedUserId(),
+      createdBy: UserContext.authenticatedUserId,
       metadata: {
         entity_name: `${polygonUuids.length} polygons`
       }

--- a/apps/research-service/src/polygon-clipping/polygon-clipping.controller.spec.ts
+++ b/apps/research-service/src/polygon-clipping/polygon-clipping.controller.spec.ts
@@ -8,7 +8,7 @@ import { SitePolygon, DelayedJob, Site, User, Project } from "@terramatch-micros
 import { PolygonListClippingRequestBody } from "./dto/clip-polygon-request.dto";
 import { getQueueToken } from "@nestjs/bullmq";
 import { Queue, Job } from "bullmq";
-import { mockRequestContext } from "@terramatch-microservices/common/util/testing";
+import { mockUserContext } from "@terramatch-microservices/common/util/testing";
 
 describe("PolygonClippingController", () => {
   let controller: PolygonClippingController;
@@ -80,7 +80,7 @@ describe("PolygonClippingController", () => {
 
     it("should throw UnauthorizedException when user is not authorized", async () => {
       policyService.authorize.mockRejectedValue(new UnauthorizedException());
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
 
       await expect(controller.createClippedVersions({ siteUuid })).rejects.toThrow(UnauthorizedException);
       expect(policyService.authorize).toHaveBeenCalledWith("update", SitePolygon);
@@ -88,14 +88,14 @@ describe("PolygonClippingController", () => {
 
     it("should throw BadRequestException when neither siteUuid nor projectUuid is provided", async () => {
       policyService.authorize.mockResolvedValue(undefined);
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
 
       await expect(controller.createClippedVersions({})).rejects.toThrow(BadRequestException);
     });
 
     it("should throw BadRequestException when both siteUuid and projectUuid are provided", async () => {
       policyService.authorize.mockResolvedValue(undefined);
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
 
       await expect(controller.createClippedVersions({ siteUuid, projectUuid })).rejects.toThrow(BadRequestException);
     });
@@ -106,7 +106,7 @@ describe("PolygonClippingController", () => {
         site: { id: 1, uuid: siteUuid, name: "Test Site" } as Site,
         polygonIds: []
       });
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
 
       await expect(controller.createClippedVersions({ siteUuid })).rejects.toThrow(NotFoundException);
       expect(clippingService.getFixablePolygonsForSite).toHaveBeenCalledWith(siteUuid);
@@ -115,7 +115,7 @@ describe("PolygonClippingController", () => {
     it("should throw NotFoundException when site is not found", async () => {
       policyService.authorize.mockResolvedValue(undefined);
       clippingService.getFixablePolygonsForSite.mockRejectedValue(new NotFoundException(`Site not found: ${siteUuid}`));
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
 
       await expect(controller.createClippedVersions({ siteUuid })).rejects.toThrow(NotFoundException);
       expect(clippingService.getFixablePolygonsForSite).toHaveBeenCalledWith(siteUuid);
@@ -130,7 +130,7 @@ describe("PolygonClippingController", () => {
         polygonIds: polygonUuids
       });
       mockQueue.add.mockResolvedValue({ id: "job-1" } as Job);
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
 
       const result = await controller.createClippedVersions({ siteUuid });
 
@@ -154,7 +154,7 @@ describe("PolygonClippingController", () => {
         project: { id: 1, uuid: projectUuid, name: "Test Project" } as Project,
         polygonIds: []
       });
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
 
       await expect(controller.createClippedVersions({ projectUuid })).rejects.toThrow(NotFoundException);
       expect(clippingService.getFixablePolygonsForProject).toHaveBeenCalledWith(projectUuid);
@@ -165,7 +165,7 @@ describe("PolygonClippingController", () => {
       clippingService.getFixablePolygonsForProject.mockRejectedValue(
         new NotFoundException(`Project not found: ${projectUuid}`)
       );
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
 
       await expect(controller.createClippedVersions({ projectUuid })).rejects.toThrow(NotFoundException);
       expect(clippingService.getFixablePolygonsForProject).toHaveBeenCalledWith(projectUuid);
@@ -180,7 +180,7 @@ describe("PolygonClippingController", () => {
         polygonIds: polygonUuids
       });
       mockQueue.add.mockResolvedValue({ id: "job-1" } as Job);
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
 
       const result = await controller.createClippedVersions({ projectUuid });
 
@@ -200,20 +200,20 @@ describe("PolygonClippingController", () => {
 
     it("should throw BadRequestException when siteUuid is empty string", async () => {
       policyService.authorize.mockResolvedValue(undefined);
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
       await expect(controller.createClippedVersions({ siteUuid: "" })).rejects.toThrow(BadRequestException);
     });
 
     it("should throw BadRequestException when projectUuid is empty string", async () => {
       policyService.authorize.mockResolvedValue(undefined);
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
       await expect(controller.createClippedVersions({ projectUuid: "" })).rejects.toThrow(BadRequestException);
     });
 
     it("should throw BadRequestException when siteUuid is null after isEmpty check", async () => {
       policyService.authorize.mockResolvedValue(undefined);
       jest.spyOn(Site, "findOne").mockResolvedValue(null);
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
       await expect(controller.createClippedVersions({ siteUuid: null as unknown as string })).rejects.toThrow(
         BadRequestException
       );
@@ -222,7 +222,7 @@ describe("PolygonClippingController", () => {
     it("should throw BadRequestException when projectUuid is null after isEmpty check", async () => {
       policyService.authorize.mockResolvedValue(undefined);
       jest.spyOn(Project, "findOne").mockResolvedValue(null);
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
       await expect(controller.createClippedVersions({ projectUuid: null as unknown as string })).rejects.toThrow(
         BadRequestException
       );
@@ -237,7 +237,7 @@ describe("PolygonClippingController", () => {
         polygonIds: polygonUuids
       });
       mockQueue.add.mockResolvedValue({ id: "job-1" } as Job);
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
 
       const result = await controller.createClippedVersions({ projectUuid });
 
@@ -264,7 +264,7 @@ describe("PolygonClippingController", () => {
         getSourceFromRoles: jest.fn().mockReturnValue("terramatch")
       } as unknown as User);
       mockQueue.add.mockResolvedValue({ id: "job-1" } as Job);
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
 
       const result = await controller.createClippedVersions({ siteUuid });
 
@@ -291,7 +291,7 @@ describe("PolygonClippingController", () => {
         getSourceFromRoles: jest.fn().mockReturnValue(null)
       } as unknown as User);
       mockQueue.add.mockResolvedValue({ id: "job-1" } as Job);
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
 
       const result = await controller.createClippedVersions({ siteUuid });
 
@@ -314,7 +314,7 @@ describe("PolygonClippingController", () => {
       });
       jest.spyOn(User, "findByPk").mockResolvedValue(null);
       mockQueue.add.mockResolvedValue({ id: "job-1" } as Job);
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
 
       const result = await controller.createClippedVersions({ siteUuid });
 
@@ -337,7 +337,7 @@ describe("PolygonClippingController", () => {
         polygonIds: polygonUuids
       });
       mockQueue.add.mockResolvedValue({ id: "job-1" } as Job);
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
 
       const result = await controller.createClippedVersions({ siteUuid });
 
@@ -359,7 +359,7 @@ describe("PolygonClippingController", () => {
 
     it("should throw UnauthorizedException when user is not authorized", async () => {
       policyService.authorize.mockRejectedValue(new UnauthorizedException());
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
 
       await expect(controller.createPolygonListClippedVersions(payload)).rejects.toThrow(UnauthorizedException);
       expect(policyService.authorize).toHaveBeenCalledWith("update", SitePolygon);
@@ -377,7 +377,7 @@ describe("PolygonClippingController", () => {
       };
 
       policyService.authorize.mockResolvedValue(undefined);
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
 
       await expect(controller.createPolygonListClippedVersions(emptyPayload)).rejects.toThrow(BadRequestException);
       expect(clippingService.filterFixablePolygonsFromList).not.toHaveBeenCalled();
@@ -386,7 +386,7 @@ describe("PolygonClippingController", () => {
     it("should throw NotFoundException when no fixable polygons are found", async () => {
       policyService.authorize.mockResolvedValue(undefined);
       clippingService.filterFixablePolygonsFromList.mockResolvedValue([]);
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
 
       await expect(controller.createPolygonListClippedVersions(payload)).rejects.toThrow(NotFoundException);
       expect(clippingService.filterFixablePolygonsFromList).toHaveBeenCalledWith(polygonUuids);
@@ -407,7 +407,7 @@ describe("PolygonClippingController", () => {
       policyService.authorize.mockResolvedValue(undefined);
       clippingService.filterFixablePolygonsFromList.mockResolvedValue(fixablePolygonUuids);
       clippingService.clipAndCreateVersions.mockResolvedValue(createdVersions);
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
 
       const result = await controller.createPolygonListClippedVersions(payload);
 
@@ -424,7 +424,7 @@ describe("PolygonClippingController", () => {
       policyService.authorize.mockResolvedValue(undefined);
       clippingService.filterFixablePolygonsFromList.mockResolvedValue(fixablePolygonUuids);
       clippingService.clipAndCreateVersions.mockResolvedValue([]);
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
 
       await expect(controller.createPolygonListClippedVersions(payload)).rejects.toThrow(NotFoundException);
       expect(clippingService.clipAndCreateVersions).toHaveBeenCalled();
@@ -460,7 +460,7 @@ describe("PolygonClippingController", () => {
         } as Site
       ]);
       mockQueue.add.mockResolvedValue({ id: "job-1" } as Job);
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
 
       const result = await controller.createPolygonListClippedVersions(payloadMultiple);
 
@@ -531,7 +531,7 @@ describe("PolygonClippingController", () => {
         createdBy: 1
       } as unknown as DelayedJob);
       mockQueue.add.mockResolvedValue({ id: "job-1" } as Job);
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
 
       await controller.createPolygonListClippedVersions(payloadMultiple);
 
@@ -612,7 +612,7 @@ describe("PolygonClippingController", () => {
         createdBy: 1
       } as unknown as DelayedJob);
       mockQueue.add.mockResolvedValue({ id: "job-1" } as Job);
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
 
       await controller.createPolygonListClippedVersions(payloadMultiple);
 
@@ -684,7 +684,7 @@ describe("PolygonClippingController", () => {
         createdBy: 1
       } as unknown as DelayedJob);
       mockQueue.add.mockResolvedValue({ id: "job-1" } as Job);
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
 
       await controller.createPolygonListClippedVersions(payloadMultiple);
 
@@ -726,7 +726,7 @@ describe("PolygonClippingController", () => {
         createdBy: 1
       } as unknown as DelayedJob);
       mockQueue.add.mockResolvedValue({ id: "job-1" } as Job);
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
 
       await controller.createPolygonListClippedVersions(payloadMultiple);
 
@@ -759,7 +759,7 @@ describe("PolygonClippingController", () => {
         fullName: null,
         getSourceFromRoles: jest.fn().mockReturnValue("terramatch")
       } as unknown as User);
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
 
       const result = await controller.createPolygonListClippedVersions(payload);
 
@@ -783,7 +783,7 @@ describe("PolygonClippingController", () => {
       clippingService.filterFixablePolygonsFromList.mockResolvedValue(fixablePolygonUuids);
       clippingService.clipAndCreateVersions.mockResolvedValue(createdVersions);
       jest.spyOn(User, "findByPk").mockResolvedValue(null);
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
 
       const result = await controller.createPolygonListClippedVersions(payload);
 
@@ -811,7 +811,7 @@ describe("PolygonClippingController", () => {
         fullName: "Test User",
         getSourceFromRoles: jest.fn().mockReturnValue(null)
       } as unknown as User);
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
 
       const result = await controller.createPolygonListClippedVersions(payload);
 

--- a/apps/research-service/src/polygon-clipping/polygon-clipping.controller.ts
+++ b/apps/research-service/src/polygon-clipping/polygon-clipping.controller.ts
@@ -22,7 +22,7 @@ import { populateDto } from "@terramatch-microservices/common/dto/json-api-attri
 import { ClippingQueryDto } from "./dto/clipping-query.dto";
 import { isEmpty, uniq } from "lodash";
 import { isNotNull } from "@terramatch-microservices/database/types/array";
-import { authenticatedUserId } from "@terramatch-microservices/common/guards/auth.guard";
+import { UserContext } from "@terramatch-microservices/common/contexts/user.context";
 
 @ApiTags("Polygon Clipping")
 @Controller("polygonClipping/v3")
@@ -58,7 +58,7 @@ export class PolygonClippingController {
       throw new BadRequestException("Exactly one of siteUuid or projectUuid must be provided");
     }
 
-    const user = await User.findByPk(authenticatedUserId(), {
+    const user = await User.findByPk(UserContext.authenticatedUserId, {
       attributes: ["firstName", "lastName"],
       include: [{ association: "roles", attributes: ["name"] }]
     });
@@ -111,7 +111,7 @@ export class PolygonClippingController {
       totalContent: fixablePolygons.length,
       processedContent: 0,
       progressMessage: "Starting clipping...",
-      createdBy: authenticatedUserId(),
+      createdBy: UserContext.authenticatedUserId,
       metadata: {
         entity_id: entityId,
         entity_type: entityType,
@@ -121,7 +121,7 @@ export class PolygonClippingController {
 
     await this.clippingQueue.add("clipAndVersion", {
       polygonUuids: fixablePolygons,
-      userId: authenticatedUserId(),
+      userId: UserContext.authenticatedUserId,
       userFullName,
       source,
       delayedJobId: delayedJob.id,
@@ -146,7 +146,7 @@ export class PolygonClippingController {
   async createPolygonListClippedVersions(@Body() payload: PolygonListClippingRequestBody) {
     await this.policyService.authorize("update", SitePolygon);
 
-    const user = await User.findByPk(authenticatedUserId(), {
+    const user = await User.findByPk(UserContext.authenticatedUserId, {
       attributes: ["firstName", "lastName"],
       include: [{ association: "roles", attributes: ["name"] }]
     });
@@ -168,7 +168,7 @@ export class PolygonClippingController {
     if (fixablePolygons.length === 1) {
       const createdVersions = await this.clippingService.clipAndCreateVersions(
         fixablePolygons,
-        authenticatedUserId() as number,
+        UserContext.authenticatedUserId as number,
         userFullName,
         source
       );
@@ -255,7 +255,7 @@ export class PolygonClippingController {
       totalContent: fixablePolygons.length,
       processedContent: 0,
       progressMessage: "Starting clipping...",
-      createdBy: authenticatedUserId(),
+      createdBy: UserContext.authenticatedUserId,
       metadata: {
         ...(entityId != null && { entity_id: entityId }),
         ...(entityType != null && { entity_type: entityType }),
@@ -265,7 +265,7 @@ export class PolygonClippingController {
 
     await this.clippingQueue.add("clipAndVersion", {
       polygonUuids: fixablePolygons,
-      userId: authenticatedUserId(),
+      userId: UserContext.authenticatedUserId,
       userFullName,
       source,
       delayedJobId: delayedJob.id,

--- a/apps/research-service/src/validations/validation.controller.spec.ts
+++ b/apps/research-service/src/validations/validation.controller.spec.ts
@@ -3,7 +3,7 @@ import { ValidationController } from "./validation.controller";
 import { ValidationService } from "./validation.service";
 import { ValidationDto } from "./dto/validation.dto";
 import { populateDto } from "@terramatch-microservices/common/dto/json-api-attributes";
-import { mockRequestContext, serialize } from "@terramatch-microservices/common/util/testing";
+import { mockUserContext, serialize } from "@terramatch-microservices/common/util/testing";
 import { SiteValidationQueryDto } from "./dto/site-validation-query.dto";
 import { ValidationRequestBody } from "./dto/validation-request.dto";
 import { SiteValidationRequestBody } from "./dto/site-validation-request.dto";
@@ -614,7 +614,7 @@ describe("ValidationController", () => {
           }
         }
       };
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
       const result = serialize(await controller.createSiteValidation(siteUuid, request));
 
       expect(mockValidationService.getSitePolygonUuids).toHaveBeenCalledWith(siteUuid);
@@ -636,7 +636,7 @@ describe("ValidationController", () => {
           }
         }
       };
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
       await expect(controller.createSiteValidation(siteUuid, request)).rejects.toThrow(NotFoundException);
     });
 
@@ -647,7 +647,7 @@ describe("ValidationController", () => {
           attributes: {}
         }
       };
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
       await controller.createSiteValidation(siteUuid, request);
       expect(mockQueue.add).toHaveBeenCalledWith("siteValidation", expect.objectContaining({ siteUuid }));
     });
@@ -659,7 +659,7 @@ describe("ValidationController", () => {
           attributes: { validationTypes: [] }
         }
       };
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
       await controller.createSiteValidation(siteUuid, request);
       expect(mockQueue.add).toHaveBeenCalledWith(
         "siteValidation",
@@ -675,7 +675,7 @@ describe("ValidationController", () => {
           attributes: { validationTypes: ["SELF_INTERSECTION"] as ValidationType[] }
         }
       };
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
       await expect(controller.createSiteValidation(siteUuid, request)).rejects.toThrow(NotFoundException);
       expect(DelayedJob.create).not.toHaveBeenCalled();
     });

--- a/apps/research-service/src/validations/validation.controller.ts
+++ b/apps/research-service/src/validations/validation.controller.ts
@@ -21,7 +21,7 @@ import { InjectQueue } from "@nestjs/bullmq";
 import { Queue } from "bullmq";
 import { DelayedJob, Site } from "@terramatch-microservices/database/entities";
 import { DelayedJobDto } from "@terramatch-microservices/common/dto/delayed-job.dto";
-import { authenticatedUserId } from "@terramatch-microservices/common/guards/auth.guard";
+import { UserContext } from "@terramatch-microservices/common/contexts/user.context";
 
 @Controller("validations/v3")
 @ApiTags("Validations")
@@ -159,7 +159,7 @@ export class ValidationController {
       totalContent: polygonUuids.length,
       processedContent: 0,
       progressMessage: "Starting validation...",
-      createdBy: authenticatedUserId(),
+      createdBy: UserContext.authenticatedUserId,
       metadata: {
         entity_id: site.id,
         entity_type: Site.LARAVEL_TYPE,
@@ -181,14 +181,14 @@ export class ValidationController {
     operationId: "validateGeometries",
     summary: "Validate raw GeoJSON geometries without persistence",
     description: `Validates raw GeoJSON geometries in-memory without persisting results to the database.
-    
+
     This endpoint is useful for validating geometries before creating site polygons, allowing you to check
     for issues without saving the data.
-    
+
     Input:
     - Provide an array of GeoJSON FeatureCollections containing the geometries to validate
     - Optionally specify which validation types to run (defaults to all non-persistent validation types)
-    
+
     Supported validation types (non-persistent):
     - SELF_INTERSECTION: Checks if polygon edges intersect with themselves
     - POLYGON_SIZE: Validates polygon area is within acceptable range ( 1000 ha )
@@ -197,16 +197,16 @@ export class ValidationController {
     - DATA_COMPLETENESS: Validates required properties are present
     - FEATURE_BOUNDS: Validates geometry coordinates are within valid bounds
     - GEOMETRY_TYPE: Validates geometry type is supported (multipolygon, polygon or point)
-    
+
     Response:
     - Returns a JSON:API document with validation results in the \`data\` array
     - Each validation result contains a \`polygonUuid\` identifier (from feature properties.id if provided, otherwise auto-generated as "feature-{index}")
     - This identifier is NOT a database UUID - it's only used to match validation results back to the input features
     - Each result includes a \`criteriaList\` with validation details for each criteria checked
     - Results are not persisted to the database and are only returned in the response
-    
+
     Note: For duplicate geometry validation, features must include \`siteId\`in their properties.
-    
+
     Property naming: GeoJSON properties support both camelCase and snake_case.
     camelCase takes precedence if both formats are present for the same property.`
   })

--- a/apps/unified-database-service/src/webhook/webhook.controller.spec.ts
+++ b/apps/unified-database-service/src/webhook/webhook.controller.spec.ts
@@ -4,7 +4,7 @@ import { AirtableService } from "../airtable/airtable.service";
 import { createMock, DeepMocked } from "@golevelup/ts-jest";
 import { UnauthorizedException } from "@nestjs/common";
 
-import { mockRequestContext } from "@terramatch-microservices/common/util/testing";
+import { mockUserContext } from "@terramatch-microservices/common/util/testing";
 
 describe("WebhookController", () => {
   let controller: WebhookController;
@@ -25,13 +25,13 @@ describe("WebhookController", () => {
 
   describe("updateRecords", () => {
     it("should throw an error if the user doesn't have the correct permissions", async () => {
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
       await expect(controller.updateRecords({ entityType: "projects" })).rejects.toThrow(UnauthorizedException);
     });
 
     it("should call into the service with query params", async () => {
       const updatedSince = new Date();
-      mockRequestContext({ userId: 1, permissions: ["reports-manage"] });
+      mockUserContext({ userId: 1, permissions: ["reports-manage"] });
       let result = await controller.updateRecords({ entityType: "projects", startPage: 2, updatedSince });
       expect(result).toEqual({ status: "OK" });
       expect(service.updateAirtable).toHaveBeenCalledWith("projects", 2, updatedSince);
@@ -44,7 +44,7 @@ describe("WebhookController", () => {
 
   describe("removeDeletedRecords", () => {
     it("should throw an error if the user doesn't have the correct permissions", async () => {
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
       await expect(
         controller.removeDeletedRecords({ entityType: "projects", deletedSince: new Date() })
       ).rejects.toThrow(UnauthorizedException);
@@ -52,7 +52,7 @@ describe("WebhookController", () => {
 
     it("should call into the service with query params", async () => {
       const deletedSince = new Date();
-      mockRequestContext({ userId: 1, permissions: ["reports-manage"] });
+      mockUserContext({ userId: 1, permissions: ["reports-manage"] });
       const result = await controller.removeDeletedRecords({ entityType: "projects", deletedSince });
       expect(result).toEqual({ status: "OK" });
       expect(service.deleteFromAirtable).toHaveBeenCalledWith("projects", deletedSince);
@@ -61,13 +61,13 @@ describe("WebhookController", () => {
 
   describe("updateAll", () => {
     it("should throw an error if the user doesn't have the correct permissions", async () => {
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
       await expect(controller.updateAll({ updatedSince: new Date() })).rejects.toThrow(UnauthorizedException);
     });
 
     it("should call into the service with query params", async () => {
       const updatedSince = new Date();
-      mockRequestContext({ userId: 1, permissions: ["reports-manage"] });
+      mockUserContext({ userId: 1, permissions: ["reports-manage"] });
       const result = await controller.updateAll({ updatedSince: updatedSince });
       expect(result).toEqual({ status: "OK" });
       expect(service.updateAll).toHaveBeenCalledWith(updatedSince);

--- a/apps/unified-database-service/src/webhook/webhook.controller.ts
+++ b/apps/unified-database-service/src/webhook/webhook.controller.ts
@@ -5,20 +5,20 @@ import { UpdateRecordsQueryDto } from "./dto/update-records-query.dto";
 import { DeleteRecordsQueryDto } from "./dto/delete-records-query.dto";
 import { UpdateAllQueryDto } from "./dto/update-all-query.dto";
 import { ExceptionResponse } from "@terramatch-microservices/common/decorators";
-import { authenticatedUserId, permissions } from "@terramatch-microservices/common/guards/auth.guard";
+import { UserContext } from "@terramatch-microservices/common/contexts/user.context";
 
 @Controller("unified-database/v3/webhook")
 export class WebhookController {
   constructor(private readonly airtableService: AirtableService) {}
 
   private async authorize() {
-    const userId = authenticatedUserId();
+    const userId = UserContext.authenticatedUserId;
     if (userId == null) throw new UnauthorizedException();
 
     // This isn't a perfect match for what this controller does, but it is close, and all admins have
     // this permission, so it's a reasonable way for now to restrict this controller to logged in
     // admins.
-    if (!permissions()?.includes("reports-manage")) {
+    if (!UserContext.permissions?.includes("reports-manage")) {
       throw new UnauthorizedException();
     }
   }

--- a/apps/user-service/src/actions/actions.controller.spec.ts
+++ b/apps/user-service/src/actions/actions.controller.spec.ts
@@ -11,7 +11,7 @@ import {
 } from "@terramatch-microservices/database/factories";
 import { serialize } from "@terramatch-microservices/common/util/testing";
 import { Resource } from "@terramatch-microservices/common/util/json-api-builder";
-import { mockRequestContext } from "@terramatch-microservices/common/util/testing";
+import { mockUserContext } from "@terramatch-microservices/common/util/testing";
 
 describe("ActionsController", () => {
   let controller: ActionsController;
@@ -58,7 +58,7 @@ describe("ActionsController", () => {
 
       actionsService.getActions.mockResolvedValue([mockData]);
 
-      mockRequestContext({ userId: user.id });
+      mockUserContext({ userId: user.id });
 
       const result = serialize(await controller.index());
 
@@ -70,7 +70,7 @@ describe("ActionsController", () => {
 
     it("should handle empty results", async () => {
       const user = await UserFactory.create();
-      mockRequestContext({ userId: user.id });
+      mockUserContext({ userId: user.id });
 
       actionsService.getActions.mockResolvedValue([]);
 
@@ -107,7 +107,7 @@ describe("ActionsController", () => {
 
       actionsService.getActions.mockResolvedValue([mockData]);
 
-      mockRequestContext({ userId: user.id });
+      mockUserContext({ userId: user.id });
 
       const result = serialize(await controller.index());
 
@@ -156,7 +156,7 @@ describe("ActionsController", () => {
 
       actionsService.getActions.mockResolvedValue([mockData]);
 
-      mockRequestContext({ userId: user.id });
+      mockUserContext({ userId: user.id });
 
       const result = serialize(await controller.index());
 

--- a/apps/user-service/src/actions/actions.controller.ts
+++ b/apps/user-service/src/actions/actions.controller.ts
@@ -3,8 +3,8 @@ import { ApiOperation } from "@nestjs/swagger";
 import { ActionDto } from "@terramatch-microservices/common/dto";
 import { ExceptionResponse, JsonApiResponse } from "@terramatch-microservices/common/decorators";
 import { buildJsonApi } from "@terramatch-microservices/common/util";
-import { authenticatedUserId } from "@terramatch-microservices/common/guards/auth.guard";
 import { ActionsService } from "./actions.service";
+import { UserContext } from "@terramatch-microservices/common/contexts/user.context";
 
 @Controller("users/v3/actions")
 export class ActionsController {
@@ -20,7 +20,7 @@ export class ActionsController {
   @ExceptionResponse(UnauthorizedException, { description: "Authentication failed" })
   @ExceptionResponse(BadRequestException, { description: "Invalid query parameters" })
   async index() {
-    const userId = authenticatedUserId() as number;
+    const userId = UserContext.authenticatedUserId as number;
 
     const data = await this.actionsService.getActions(userId);
 

--- a/apps/user-service/src/auth/login.controller.ts
+++ b/apps/user-service/src/auth/login.controller.ts
@@ -3,7 +3,7 @@ import { AuthService } from "./auth.service";
 import { LoginBody } from "./dto/login-request.dto";
 import { LoginDto } from "./dto/login.dto";
 import { ApiOperation } from "@nestjs/swagger";
-import { NoBearerAuth } from "@terramatch-microservices/common/guards";
+import { AuthOptional } from "@terramatch-microservices/common/guards";
 import { ExceptionResponse, JsonApiResponse } from "@terramatch-microservices/common/decorators";
 import { buildJsonApi } from "@terramatch-microservices/common/util";
 import { populateDto } from "@terramatch-microservices/common/dto/json-api-attributes";
@@ -13,7 +13,7 @@ export class LoginController {
   constructor(private readonly authService: AuthService) {}
 
   @Post()
-  @NoBearerAuth
+  @AuthOptional
   @ApiOperation({
     operationId: "authLogin",
     description: "Receive a JWT Token in exchange for login credentials"

--- a/apps/user-service/src/auth/reset-password.controller.ts
+++ b/apps/user-service/src/auth/reset-password.controller.ts
@@ -5,7 +5,7 @@ import { ExceptionResponse, JsonApiResponse } from "@terramatch-microservices/co
 import { buildJsonApi } from "@terramatch-microservices/common/util";
 import { ResetPasswordRequest } from "./dto/reset-password-request.dto";
 import { ResetPasswordDto } from "./dto/reset-password.dto";
-import { NoBearerAuth } from "@terramatch-microservices/common/guards";
+import { AuthOptional } from "@terramatch-microservices/common/guards";
 import { ResetPasswordResponseDto } from "./dto/reset-password-response.dto";
 import { populateDto } from "@terramatch-microservices/common/dto/json-api-attributes";
 
@@ -14,7 +14,7 @@ export class ResetPasswordController {
   constructor(private readonly resetPasswordService: ResetPasswordService) {}
 
   @Post()
-  @NoBearerAuth
+  @AuthOptional
   @ApiOperation({
     operationId: "requestPasswordReset",
     description: "Send password reset email with a token"
@@ -30,7 +30,7 @@ export class ResetPasswordController {
   }
 
   @Put(":token")
-  @NoBearerAuth
+  @AuthOptional
   @ApiOperation({
     operationId: "resetPassword",
     description: "Reset password using the provided token"
@@ -46,7 +46,7 @@ export class ResetPasswordController {
   }
 
   @Get(":token")
-  @NoBearerAuth
+  @AuthOptional
   @ApiOperation({
     operationId: "getResetPassword",
     description: "Get the reset password status for a token"

--- a/apps/user-service/src/auth/verification-user.controller.ts
+++ b/apps/user-service/src/auth/verification-user.controller.ts
@@ -5,7 +5,7 @@ import { buildJsonApi } from "@terramatch-microservices/common/util";
 import { VerificationUserService } from "./verification-user.service";
 import { ResendVerificationBody, VerificationUserBody } from "./dto/verification-user-request.dto";
 import { ResendVerificationResponseDto, VerificationUserResponseDto } from "./dto/verification-user-response.dto";
-import { NoBearerAuth } from "@terramatch-microservices/common/guards";
+import { AuthOptional } from "@terramatch-microservices/common/guards";
 import { populateDto } from "@terramatch-microservices/common/dto/json-api-attributes";
 
 @Controller("auth/v3/verifications")
@@ -13,7 +13,7 @@ export class VerificationUserController {
   constructor(private readonly verificationUserService: VerificationUserService) {}
 
   @Post()
-  @NoBearerAuth
+  @AuthOptional
   @ApiOperation({
     operationId: "verifyUser",
     description: "Receive a token to verify a user and return the verification status"
@@ -30,7 +30,7 @@ export class VerificationUserController {
   }
 
   @Post("resend")
-  @NoBearerAuth
+  @AuthOptional
   @ApiOperation({
     operationId: "resendUserVerification",
     description: "Resend a verification email for a user by email address"

--- a/apps/user-service/src/exports/user-service-exports.processor.ts
+++ b/apps/user-service/src/exports/user-service-exports.processor.ts
@@ -8,7 +8,6 @@ import { Job, Queue } from "bullmq";
 import { CsvExportService } from "@terramatch-microservices/common/export/csv-export.service";
 import { InternalServerErrorException } from "@nestjs/common";
 import { DelayedJob, Media, Organisation } from "@terramatch-microservices/database/entities";
-import { authenticatedUserId } from "@terramatch-microservices/common/guards/auth.guard";
 import { buildJsonApi } from "@terramatch-microservices/common/util";
 import { DelayedJobDto } from "@terramatch-microservices/common/dto";
 import { PaginatedQueryBuilder } from "@terramatch-microservices/common/util/paginated-query.builder";
@@ -16,6 +15,7 @@ import { batchFindAll } from "@terramatch-microservices/common/util/batch-find-a
 import { Dictionary, startCase } from "lodash";
 import { FileDownloadDto } from "@terramatch-microservices/common/dto/file-download.dto";
 import { MediaService } from "@terramatch-microservices/common/media/media.service";
+import { UserContext } from "@terramatch-microservices/common/contexts/user.context";
 
 export type UserServiceExportJobData = {
   delayedJobId: number;
@@ -75,7 +75,7 @@ export class UserServiceExportsProcessor extends DelayedJobWorker<UserServiceExp
   static async queueOrganisationExport(queue: Queue, fileName: string) {
     const delayedJob = await DelayedJob.create({
       name: "Organisation CSV Export",
-      createdBy: authenticatedUserId()
+      createdBy: UserContext.authenticatedUserId
     });
     const data: UserServiceExportJobData = { delayedJobId: delayedJob.id, fileName: fileName };
     await queue.add(ORGANISATIONS_EXPORT, data);

--- a/apps/user-service/src/organisations/organisation-creation.service.ts
+++ b/apps/user-service/src/organisations/organisation-creation.service.ts
@@ -17,7 +17,7 @@ import { DRAFT, PENDING } from "@terramatch-microservices/database/constants/sta
 import { InjectQueue } from "@nestjs/bullmq";
 import { Queue } from "bullmq";
 import { AdminUserCreationEmail } from "@terramatch-microservices/common/email/admin-user-creation.email";
-import { authenticatedUserId } from "@terramatch-microservices/common/guards/auth.guard";
+import { UserContext } from "@terramatch-microservices/common/contexts/user.context";
 
 @Injectable()
 export class OrganisationCreationService {
@@ -46,7 +46,7 @@ export class OrganisationCreationService {
 
     const organisation = await Organisation.create(this.buildOrganisationData(attributes, DRAFT) as Organisation);
 
-    const userId = authenticatedUserId();
+    const userId = UserContext.authenticatedUserId;
     if (userId != null) {
       await User.update({ organisationId: organisation.id }, { where: { id: userId } });
     }

--- a/apps/user-service/src/organisations/organisations.controller.spec.ts
+++ b/apps/user-service/src/organisations/organisations.controller.spec.ts
@@ -28,7 +28,7 @@ import {
   OwnershipStake,
   TreeSpecies
 } from "@terramatch-microservices/database/entities";
-import { mockRequestContext, serialize } from "@terramatch-microservices/common/util/testing";
+import { mockUserContext, serialize } from "@terramatch-microservices/common/util/testing";
 import { Resource } from "@terramatch-microservices/common/util";
 import { MediaService } from "@terramatch-microservices/common/media/media.service";
 import { FinancialIndicatorDto } from "@terramatch-microservices/common/dto/financial-indicator.dto";
@@ -1094,7 +1094,7 @@ describe("OrganisationsController", () => {
       organisationsService.findOne.mockResolvedValue(org);
       organisationsService.update.mockResolvedValue(updatedOrg as Organisation);
       policyService.authorize.mockResolvedValue(undefined);
-      mockRequestContext({ userId: 123 });
+      mockUserContext({ userId: 123 });
 
       const updatePayload = {
         data: {
@@ -1121,7 +1121,7 @@ describe("OrganisationsController", () => {
       organisationsService.findOne.mockResolvedValue(org);
       organisationsService.update.mockResolvedValue(updatedOrg as Organisation);
       policyService.authorize.mockResolvedValue(undefined);
-      mockRequestContext({ userId: 123 });
+      mockUserContext({ userId: 123 });
 
       const updatePayload = {
         data: {
@@ -1171,7 +1171,7 @@ describe("OrganisationsController", () => {
       organisationsService.findOne.mockResolvedValue(org);
       organisationsService.update.mockResolvedValue(updatedOrg as Organisation);
       policyService.authorize.mockResolvedValue(undefined);
-      mockRequestContext({ userId: 123 });
+      mockUserContext({ userId: 123 });
 
       const updatePayload = {
         data: {
@@ -1195,7 +1195,7 @@ describe("OrganisationsController", () => {
       organisationsService.findOne.mockResolvedValue(org);
       organisationsService.update.mockResolvedValue(updatedOrg as Organisation);
       policyService.authorize.mockResolvedValue(undefined);
-      mockRequestContext();
+      mockUserContext();
 
       const updatePayload = {
         data: {
@@ -1219,7 +1219,7 @@ describe("OrganisationsController", () => {
       organisationsService.findOne.mockResolvedValue(org);
       organisationsService.update.mockResolvedValue(updatedOrg as Organisation);
       policyService.authorize.mockResolvedValue(undefined);
-      mockRequestContext({ userId: 123 });
+      mockUserContext({ userId: 123 });
       emailQueue.add.mockRejectedValue(new Error("Queue error"));
 
       const updatePayload = {

--- a/apps/user-service/src/organisations/organisations.controller.ts
+++ b/apps/user-service/src/organisations/organisations.controller.ts
@@ -44,7 +44,6 @@ import { FinancialReportLightDto } from "@terramatch-microservices/common/dto/fi
 import { LeadershipDto } from "@terramatch-microservices/common/dto/leadership.dto";
 import { OwnershipStakeDto } from "@terramatch-microservices/common/dto/ownership-stake.dto";
 import { TreeSpeciesDto } from "@terramatch-microservices/common/dto/tree-species.dto";
-import { authenticatedUserId } from "@terramatch-microservices/common/guards/auth.guard";
 import { TMLogger } from "@terramatch-microservices/common/util/tm-logger";
 import { OrganisationApprovedEmail } from "@terramatch-microservices/common/email/organisation-approved.email";
 import { OrganisationRejectedEmail } from "@terramatch-microservices/common/email/organisation-rejected.email";
@@ -52,6 +51,7 @@ import { FileDownloadDto } from "@terramatch-microservices/common/dto/file-downl
 import { DateTime } from "luxon";
 import { CsvExportService } from "@terramatch-microservices/common/export/csv-export.service";
 import { USER_SERVICE_EXPORT_QUEUE, UserServiceExportsProcessor } from "../exports/user-service-exports.processor";
+import { UserContext } from "@terramatch-microservices/common/contexts/user.context";
 
 @Controller("organisations/v3/organisations")
 export class OrganisationsController {
@@ -182,7 +182,7 @@ export class OrganisationsController {
     await this.organisationsService.update(organisation, updatePayload.data.attributes);
 
     if (isStatusChange && oldStatus !== newStatus) {
-      const userId = authenticatedUserId();
+      const userId = UserContext.authenticatedUserId;
       if (userId != null) {
         try {
           if (newStatus === "approved") {

--- a/apps/user-service/src/organisations/organisations.service.spec.ts
+++ b/apps/user-service/src/organisations/organisations.service.spec.ts
@@ -16,7 +16,7 @@ import {
   FundingTypeFactory
 } from "@terramatch-microservices/database/factories";
 import { Organisation, Media, TreeSpecies } from "@terramatch-microservices/database/entities";
-import { mockRequestContext } from "@terramatch-microservices/common/util/testing";
+import { mockUserContext } from "@terramatch-microservices/common/util/testing";
 import { BadRequestException, NotFoundException } from "@nestjs/common";
 import { PolicyService } from "@terramatch-microservices/common";
 import { MediaService } from "@terramatch-microservices/common/media/media.service";
@@ -50,7 +50,7 @@ describe("OrganisationsService", () => {
   describe("findMany", () => {
     it("should return organisations for admin user", async () => {
       await OrganisationFactory.createMany(2);
-      mockRequestContext({ permissions: ["framework-test"] });
+      mockUserContext({ permissions: ["framework-test"] });
 
       const result = await service.findMany({});
 
@@ -59,7 +59,7 @@ describe("OrganisationsService", () => {
     });
 
     it("should throw error if non-admin user is not authenticated", async () => {
-      mockRequestContext();
+      mockUserContext();
       await expect(service.findMany({})).rejects.toThrow(BadRequestException);
     });
 
@@ -71,7 +71,7 @@ describe("OrganisationsService", () => {
       const project = await ProjectFactory.create({ organisationId: org2.id });
       await user.$add("projects", project);
 
-      mockRequestContext({ userId: user.id });
+      mockUserContext({ userId: user.id });
       const result = await service.findMany({});
 
       expect(result.organisations.length).toBeGreaterThanOrEqual(1);
@@ -79,27 +79,27 @@ describe("OrganisationsService", () => {
 
     it("should filter by funding programme UUID", async () => {
       const programmeUuid = faker.string.uuid();
-      mockRequestContext({ permissions: ["framework-test"] });
+      mockUserContext({ permissions: ["framework-test"] });
       await service.findMany({ fundingProgrammeUuid: programmeUuid });
     });
 
     it("should filter by search query", async () => {
       await OrganisationFactory.create({ name: "Test Organisation" });
-      mockRequestContext({ permissions: ["framework-test"] });
+      mockUserContext({ permissions: ["framework-test"] });
       const result = await service.findMany({ search: "Test" });
       expect(result.organisations.length).toBeGreaterThanOrEqual(1);
     });
 
     it("should filter by status", async () => {
       await OrganisationFactory.create({ status: "pending" });
-      mockRequestContext({ permissions: ["framework-test"] });
+      mockUserContext({ permissions: ["framework-test"] });
       const result = await service.findMany({ status: "pending" });
       expect(result.organisations.length).toBeGreaterThanOrEqual(1);
     });
 
     it("should filter by type", async () => {
       await OrganisationFactory.create({ type: "non-profit-organization" });
-      mockRequestContext({ permissions: ["framework-test"] });
+      mockUserContext({ permissions: ["framework-test"] });
       const result = await service.findMany({ type: "non-profit-organization" });
       expect(result.organisations.length).toBeGreaterThanOrEqual(1);
     });
@@ -107,7 +107,7 @@ describe("OrganisationsService", () => {
     it("should filter by hqCountry", async () => {
       const country = faker.location.countryCode("alpha-3");
       await OrganisationFactory.create({ hqCountry: country });
-      mockRequestContext({ permissions: ["framework-test"] });
+      mockUserContext({ permissions: ["framework-test"] });
       const result = await service.findMany({ hqCountry: country });
       expect(result.organisations.length).toBeGreaterThanOrEqual(1);
     });
@@ -119,34 +119,34 @@ describe("OrganisationsService", () => {
         isTest: false,
         name: "Public Org"
       });
-      mockRequestContext({ userId: 999 });
+      mockUserContext({ userId: 999 });
       const result = await service.findMany({ view: "public" });
       expect(result.organisations.length).toBeGreaterThanOrEqual(1);
       expect(result.organisations.every(o => o.status === "approved" && !o.private && !o.isTest)).toBe(true);
     });
 
     it("should sort by valid field", async () => {
-      mockRequestContext({ permissions: ["framework-test"] });
+      mockUserContext({ permissions: ["framework-test"] });
       await service.findMany({ sort: { field: "name", direction: "ASC" } });
     });
 
     it("should sort by mapped field", async () => {
-      mockRequestContext({ permissions: ["framework-test"] });
+      mockUserContext({ permissions: ["framework-test"] });
       await service.findMany({ sort: { field: "created_at", direction: "ASC" } });
     });
 
     it("should handle descending sort", async () => {
-      mockRequestContext({ permissions: ["framework-test"] });
+      mockUserContext({ permissions: ["framework-test"] });
       await service.findMany({ sort: { field: "-name" } });
     });
 
     it("should throw error for invalid sort field", async () => {
-      mockRequestContext({ permissions: ["framework-test"] });
+      mockUserContext({ permissions: ["framework-test"] });
       await expect(service.findMany({ sort: { field: "invalidField" } })).rejects.toThrow(BadRequestException);
     });
 
     it("should allow sorting by id field", async () => {
-      mockRequestContext({ permissions: ["framework-test"] });
+      mockUserContext({ permissions: ["framework-test"] });
       await service.findMany({ sort: { field: "id" } });
     });
   });

--- a/apps/user-service/src/organisations/organisations.service.ts
+++ b/apps/user-service/src/organisations/organisations.service.ts
@@ -16,7 +16,6 @@ import { OrganisationShowQueryDto } from "./dto/organisation-show-query.dto";
 import { PaginatedQueryBuilder } from "@terramatch-microservices/common/util/paginated-query.builder";
 import { Op } from "sequelize";
 import { OrganisationUpdateAttributes } from "./dto/organisation-update.dto";
-import { authenticatedUserId } from "@terramatch-microservices/common/guards/auth.guard";
 import { PolicyService } from "@terramatch-microservices/common";
 import { APPROVED } from "@terramatch-microservices/database/constants/status";
 import { MediaService } from "@terramatch-microservices/common/media/media.service";
@@ -28,6 +27,7 @@ import { FinancialReportLightDto } from "@terramatch-microservices/common/dto/fi
 import { LeadershipDto } from "@terramatch-microservices/common/dto/leadership.dto";
 import { OwnershipStakeDto } from "@terramatch-microservices/common/dto/ownership-stake.dto";
 import { TreeSpeciesDto } from "@terramatch-microservices/common/dto/tree-species.dto";
+import { UserContext } from "@terramatch-microservices/common/contexts/user.context";
 
 @Injectable()
 export class OrganisationsService {
@@ -62,7 +62,7 @@ export class OrganisationsService {
         builder.order([["name", "ASC"]]);
       }
     } else if (!hasFrameworkPermission) {
-      const userId = authenticatedUserId();
+      const userId = UserContext.authenticatedUserId;
       if (userId == null) {
         throw new BadRequestException("User ID is required");
       }

--- a/apps/user-service/src/users/users.controller.spec.ts
+++ b/apps/user-service/src/users/users.controller.spec.ts
@@ -14,7 +14,7 @@ import { Relationship, Resource } from "@terramatch-microservices/common/util";
 import { UserCreateAttributes } from "./dto/user-create.dto";
 import { UserCreationService } from "./user-creation.service";
 import { ValidLocale } from "@terramatch-microservices/database/constants/locale";
-import { mockRequestContext, serialize } from "@terramatch-microservices/common/util/testing";
+import { mockUserContext, serialize } from "@terramatch-microservices/common/util/testing";
 import { UsersService } from "./users.service";
 import { User } from "@terramatch-microservices/database/entities";
 import { Queue } from "bullmq";
@@ -56,20 +56,20 @@ describe("UsersController", () => {
 
   describe("findOne", () => {
     it("should throw not found if the user is not found", async () => {
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
       await expect(controller.findOne("0")).rejects.toThrow(NotFoundException);
     });
 
     it("should throw an error if the policy does not authorize", async () => {
       policyService.authorize.mockRejectedValue(new UnauthorizedException());
       const { uuid } = await UserFactory.create();
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
       await expect(controller.findOne(uuid!)).rejects.toThrow(UnauthorizedException);
     });
 
     it('should return the currently logged in user if the id is "me"', async () => {
       const { id, uuid } = await UserFactory.create();
-      mockRequestContext({ userId: id });
+      mockUserContext({ userId: id });
       const result = serialize(await controller.findOne("me"));
       expect((result.data as Resource).id).toBe(uuid);
     });
@@ -77,14 +77,14 @@ describe("UsersController", () => {
     it("should return the indicated user if the logged in user is allowed to access", async () => {
       policyService.authorize.mockResolvedValue(undefined);
       const { id, uuid } = await UserFactory.create();
-      mockRequestContext({ userId: id + 1 });
+      mockUserContext({ userId: id + 1 });
       const result = serialize(await controller.findOne(uuid!));
       expect((result.data as Resource).id).toBe(uuid);
     });
 
     it("should return a document without includes if there is no org", async () => {
       const { id } = await UserFactory.create();
-      mockRequestContext({ userId: id });
+      mockUserContext({ userId: id });
       const result = serialize(await controller.findOne("me"));
       expect(result.included).not.toBeDefined();
     });
@@ -93,7 +93,7 @@ describe("UsersController", () => {
       const user = await UserFactory.create();
       const org = await OrganisationFactory.create();
       await user.$add("organisationsConfirmed", org);
-      mockRequestContext({ userId: user.id });
+      mockUserContext({ userId: user.id });
       const result = serialize(await controller.findOne("me"));
       expect(result.included).toHaveLength(1);
       expect(result.included![0]).toMatchObject({ type: "organisations", id: org.uuid });
@@ -111,7 +111,7 @@ describe("UsersController", () => {
       const user = await UserFactory.create();
       const org = await OrganisationFactory.create();
       await user.$set("organisation", org);
-      mockRequestContext({ userId: user.id });
+      mockUserContext({ userId: user.id });
       const result = serialize(await controller.findOne("me"));
       expect(result.included).toHaveLength(1);
       expect(result.included![0]).toMatchObject({ type: "organisations", id: org.uuid });
@@ -135,7 +135,7 @@ describe("UsersController", () => {
         isMonitoring: true,
         isManaging: false
       });
-      mockRequestContext({ userId: user.id + 1 });
+      mockUserContext({ userId: user.id + 1 });
 
       const result = serialize(await controller.findOne(user.uuid!));
       const data = result.data as Resource;
@@ -151,13 +151,13 @@ describe("UsersController", () => {
 
   describe("verifyUser", () => {
     it("should throw not found if the user is not found", async () => {
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
       await expect(controller.verifyUser("missing-uuid")).rejects.toThrow(NotFoundException);
     });
 
     it("should throw unauthorized if policy does not authorize", async () => {
       const { uuid } = await UserFactory.create();
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
       policyService.authorize.mockRejectedValue(new UnauthorizedException());
 
       await expect(controller.verifyUser(uuid!)).rejects.toThrow(UnauthorizedException);
@@ -165,7 +165,7 @@ describe("UsersController", () => {
 
     it("should verify user and return JSON:API document", async () => {
       const user = await UserFactory.create({ emailAddressVerifiedAt: null });
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
       policyService.authorize.mockResolvedValue(undefined);
 
       const result = serialize(await controller.verifyUser(user.uuid!));
@@ -277,7 +277,7 @@ describe("UsersController", () => {
     it("authorizes creation when request is authenticated", async () => {
       const user = await UserFactory.create();
       const attributes = new UserCreateAttributes();
-      mockRequestContext({ userId: 1 });
+      mockUserContext({ userId: 1 });
       userCreationService.createNewUser.mockResolvedValue(user);
 
       await controller.create(createRequest(attributes));
@@ -289,7 +289,7 @@ describe("UsersController", () => {
     it("does not authorize creation when request is unauthenticated", async () => {
       const user = await UserFactory.create();
       const attributes = new UserCreateAttributes();
-      mockRequestContext();
+      mockUserContext();
       userCreationService.createNewUser.mockResolvedValue(user);
 
       await controller.create(createRequest(attributes));

--- a/apps/user-service/src/users/users.controller.ts
+++ b/apps/user-service/src/users/users.controller.ts
@@ -37,10 +37,10 @@ import { UserCreateBaseBody } from "./dto/user-create.dto";
 import { UserCreationService } from "./user-creation.service";
 import { UserQueryDto } from "./dto/user-query.dto";
 import { UsersService } from "./users.service";
-import { authenticatedUserId } from "@terramatch-microservices/common/guards/auth.guard";
 import { SendLoginDetailsResponseDto } from "../auth/dto/verification-user-response.dto";
 import { SendLoginDetailsRequestDto } from "../auth/dto/send-login-details.dto";
 import { populateDto } from "@terramatch-microservices/common/dto/json-api-attributes";
+import { UserContext } from "@terramatch-microservices/common/contexts/user.context";
 
 export const USER_ORG_RELATIONSHIP = {
   name: "org",
@@ -96,7 +96,7 @@ export class UsersController {
   @ExceptionResponse(UnauthorizedException, { description: "Authorization failed" })
   @ExceptionResponse(NotFoundException, { description: "User with that UUID not found" })
   async findOne(@Param("uuid") pathId: string) {
-    const userWhere = pathId === "me" ? { id: authenticatedUserId() } : { uuid: pathId };
+    const userWhere = pathId === "me" ? { id: UserContext.authenticatedUserId } : { uuid: pathId };
     const user = await User.findOne({
       include: ["roles", "organisation", "frameworks"],
       where: userWhere
@@ -158,7 +158,7 @@ export class UsersController {
   @JsonApiResponse(USER_RESPONSE_SHAPE)
   @ExceptionResponse(UnauthorizedException, { description: "user creation failed." })
   async create(@Body() payload: UserCreateBaseBody) {
-    const isAuthenticated = authenticatedUserId() != null;
+    const isAuthenticated = UserContext.authenticatedUserId != null;
     if (isAuthenticated) {
       await this.policyService.authorize("create", User);
     }

--- a/apps/user-service/src/users/users.controller.ts
+++ b/apps/user-service/src/users/users.controller.ts
@@ -32,7 +32,7 @@ import {
   getStableRequestQuery
 } from "@terramatch-microservices/common/util";
 import { UserUpdateBody } from "./dto/user-update.dto";
-import { OptionalBearerAuth } from "@terramatch-microservices/common/guards";
+import { AuthOptional } from "@terramatch-microservices/common/guards";
 import { UserCreateBaseBody } from "./dto/user-create.dto";
 import { UserCreationService } from "./user-creation.service";
 import { UserQueryDto } from "./dto/user-query.dto";
@@ -150,7 +150,7 @@ export class UsersController {
   }
 
   @Post()
-  @OptionalBearerAuth
+  @AuthOptional
   @ApiOperation({
     operationId: "userCreation",
     description: "Create a new user"

--- a/libs/common/src/lib/common.module.ts
+++ b/libs/common/src/lib/common.module.ts
@@ -1,5 +1,4 @@
-import { Module } from "@nestjs/common";
-import { RequestContextModule } from "nestjs-request-context";
+import { MiddlewareConsumer, Module, NestModule } from "@nestjs/common";
 import { APP_GUARD } from "@nestjs/core";
 import { AuthGuard } from "./guards";
 import { JwtModule } from "@nestjs/jwt";
@@ -22,13 +21,13 @@ import { FileService } from "./file/file.service";
 import { CsvExportService } from "./export/csv-export.service";
 import { GreenhouseNotificationProcessor } from "./notifications/greenhouse-notification.processor";
 import { GreenhouseNotificationService } from "./notifications/greenhouse-notification.service";
+import { UserContextMiddleware } from "./middleware/user-context.middleware";
 
 export const QUEUES = ["email", "analytics", "entities", "greenhouse"];
 const IS_REPL = process.env["REPL"] === "true";
 
 @Module({
   imports: [
-    RequestContextModule,
     JwtModule.registerAsync({
       imports: [ConfigModule.forRoot({ isGlobal: true })],
       inject: [ConfigService],
@@ -74,6 +73,7 @@ const IS_REPL = process.env["REPL"] === "true";
     AnalyticsEventService,
     CsvExportService,
     GreenhouseNotificationService,
+    UserContextMiddleware,
 
     ...(IS_REPL ? [] : [GreenhouseNotificationProcessor, EmailProcessor, AnalyticsProcessor])
   ],
@@ -92,4 +92,8 @@ const IS_REPL = process.env["REPL"] === "true";
     GreenhouseNotificationService
   ]
 })
-export class CommonModule {}
+export class CommonModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(UserContextMiddleware).forRoutes("*");
+  }
+}

--- a/libs/common/src/lib/contexts/user.context.ts
+++ b/libs/common/src/lib/contexts/user.context.ts
@@ -1,0 +1,25 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { ValidLocale } from "@terramatch-microservices/database/constants/locale";
+import { PolicyBuilder } from "../policies/policy.service";
+
+export class UserContext {
+  static contextStore = new AsyncLocalStorage<UserContext>();
+
+  static get current() {
+    return this.contextStore.getStore();
+  }
+
+  static use(userId: number, permissions: string[], locale: ValidLocale, next: () => void) {
+    UserContext.contextStore.run(new UserContext(userId, permissions, locale), next);
+  }
+
+  public policyBuilder: PolicyBuilder;
+
+  constructor(
+    readonly authenticatedUserId: number,
+    readonly permissions: string[],
+    readonly userLocale: ValidLocale
+  ) {
+    this.policyBuilder = new PolicyBuilder(authenticatedUserId, permissions);
+  }
+}

--- a/libs/common/src/lib/contexts/user.context.ts
+++ b/libs/common/src/lib/contexts/user.context.ts
@@ -13,6 +13,22 @@ export class UserContext {
     UserContext.contextStore.run(new UserContext(userId, permissions, locale), next);
   }
 
+  static get authenticatedUserId() {
+    return UserContext.current?.authenticatedUserId;
+  }
+
+  static get permissions() {
+    return UserContext.current?.permissions;
+  }
+
+  static get policyBuilder() {
+    return UserContext.current?.policyBuilder;
+  }
+
+  static get userLocale() {
+    return UserContext.current?.userLocale;
+  }
+
   public policyBuilder: PolicyBuilder;
 
   constructor(

--- a/libs/common/src/lib/events/entity-status-update.event-processor.spec.ts
+++ b/libs/common/src/lib/events/entity-status-update.event-processor.spec.ts
@@ -37,7 +37,7 @@ import {
   ReportStatus,
   STARTED
 } from "@terramatch-microservices/database/constants/status";
-import { mockRequestContext } from "../util/testing";
+import { mockUserContext } from "../util/testing";
 import { getLinkedFieldConfig } from "../linkedFields";
 import { FormSubmissionFeedbackEmail } from "../email/form-submission-feedback.email";
 import { ApplicationSubmittedEmail } from "../email/application-submitted.email";
@@ -55,7 +55,7 @@ describe("EntityStatusUpdate EventProcessor", () => {
   });
 
   it("should avoid status email and actions for non-entities", async () => {
-    mockRequestContext();
+    mockUserContext();
     const processor = new EntityStatusUpdate(eventService, await UpdateRequestFactory.project().create());
     const statusUpdateSpy = jest.spyOn(processor as any, "sendStatusUpdateEmail");
     const updateActionsSpy = jest.spyOn(processor as any, "updateActions");
@@ -67,7 +67,7 @@ describe("EntityStatusUpdate EventProcessor", () => {
   });
 
   it("should send a status update email", async () => {
-    mockRequestContext();
+    mockUserContext();
     const project = await ProjectFactory.create();
     await new EntityStatusUpdate(eventService, project).handle();
     expect(eventService.emailQueue.add).toHaveBeenCalledWith(
@@ -77,7 +77,7 @@ describe("EntityStatusUpdate EventProcessor", () => {
   });
 
   it("should update actions", async () => {
-    mockRequestContext();
+    mockUserContext();
     const project = await ProjectFactory.create({ status: APPROVED });
     const action = await ActionFactory.forProject.create({ targetableId: project.id });
     await new EntityStatusUpdate(eventService, project).handle();
@@ -96,7 +96,7 @@ describe("EntityStatusUpdate EventProcessor", () => {
   });
 
   it("should update actions and not delete them if the task is not found", async () => {
-    mockRequestContext();
+    mockUserContext();
     const project = await ProjectFactory.create({ status: APPROVED });
     const task = await TaskFactory.create({ projectId: project.id });
     const projectReport = await ProjectReportFactory.create({ projectId: project.id, taskId: task.id });
@@ -107,7 +107,7 @@ describe("EntityStatusUpdate EventProcessor", () => {
   });
 
   it("should update actions and not delete them if the taskId is null", async () => {
-    mockRequestContext();
+    mockUserContext();
     const project = await ProjectFactory.create({ status: APPROVED });
     const projectReport = await ProjectReportFactory.create({ projectId: project.id, taskId: null });
     await ActionFactory.forProjectReport.create({ targetableId: projectReport.id });
@@ -118,7 +118,7 @@ describe("EntityStatusUpdate EventProcessor", () => {
 
   it("should create an approved audit status", async () => {
     const user = await UserFactory.create();
-    mockRequestContext({ userId: user.id });
+    mockUserContext({ userId: user.id });
 
     const feedback = faker.lorem.sentence();
     const project = await ProjectFactory.create({ status: APPROVED, feedback });
@@ -135,7 +135,7 @@ describe("EntityStatusUpdate EventProcessor", () => {
 
   it("should create a needs more information audit status", async () => {
     const user = await UserFactory.create();
-    mockRequestContext({ userId: user.id });
+    mockUserContext({ userId: user.id });
 
     const feedback = faker.lorem.sentence();
     const question = await FormQuestionFactory.section().create({ label: "Form Question Label" });
@@ -277,7 +277,7 @@ describe("EntityStatusUpdate EventProcessor", () => {
     });
 
     it("should send status update email for FinancialReport to createdBy user", async () => {
-      mockRequestContext();
+      mockUserContext();
       const user = await UserFactory.create();
       const { id } = await FinancialReportFactory.org().create({ status: APPROVED, createdBy: user.id });
       // the org type has to be loaded on the report for this test to work (see Form's entity scope).
@@ -360,7 +360,7 @@ describe("EntityStatusUpdate EventProcessor", () => {
   describe("handleFormSubmission", () => {
     it("should create an audit status", async () => {
       const user = await UserFactory.create();
-      mockRequestContext({ userId: user.id });
+      mockUserContext({ userId: user.id });
 
       const feedback = faker.lorem.sentence();
       const submission = await FormSubmissionFactory.create({ status: REJECTED, feedback });
@@ -377,7 +377,7 @@ describe("EntityStatusUpdate EventProcessor", () => {
 
     it("should handle submit for approval", async () => {
       const user = await UserFactory.create();
-      mockRequestContext({ userId: user.id });
+      mockUserContext({ userId: user.id });
 
       const application = await ApplicationFactory.create();
       const pitch = await ProjectPitchFactory.create();
@@ -403,7 +403,7 @@ describe("EntityStatusUpdate EventProcessor", () => {
 
     it("should handle admin feedback", async () => {
       const user = await UserFactory.create();
-      mockRequestContext({ userId: user.id });
+      mockUserContext({ userId: user.id });
 
       const submission = await FormSubmissionFactory.create({ status: "rejected" });
 
@@ -416,7 +416,7 @@ describe("EntityStatusUpdate EventProcessor", () => {
 
     it("should add a job to the entities queue on approval when stage is null", async () => {
       const user = await UserFactory.create();
-      mockRequestContext({ userId: user.id });
+      mockUserContext({ userId: user.id });
 
       const submission = await FormSubmissionFactory.create({ status: "approved" });
 
@@ -428,7 +428,7 @@ describe("EntityStatusUpdate EventProcessor", () => {
 
     it("should add a job to the entities queue on approval when stage is final in programme", async () => {
       const user = await UserFactory.create();
-      mockRequestContext({ userId: user.id });
+      mockUserContext({ userId: user.id });
 
       const fp = await FundingProgrammeFactory.create();
       const stages = await Promise.all([
@@ -445,7 +445,7 @@ describe("EntityStatusUpdate EventProcessor", () => {
 
     it("should not add a job to the entities queue on approval when stage is not final in programme", async () => {
       const user = await UserFactory.create();
-      mockRequestContext({ userId: user.id });
+      mockUserContext({ userId: user.id });
 
       const fp = await FundingProgrammeFactory.create();
       const stages = await Promise.all([

--- a/libs/common/src/lib/events/entity-status-update.event-processor.ts
+++ b/libs/common/src/lib/events/entity-status-update.event-processor.ts
@@ -48,12 +48,12 @@ import { getLinkedFieldConfig } from "../linkedFields";
 import { isField, LinkedField } from "@terramatch-microservices/database/constants/linked-fields";
 import { isNotNull } from "@terramatch-microservices/database/types/array";
 import { APPROVAL_PROCESSERS } from "./processors";
-import { authenticatedUserId } from "../guards/auth.guard";
 import { LinkedAnswerCollector } from "../linkedFields/linkedAnswerCollector";
 import { ApplicationSubmittedEmail } from "../email/application-submitted.email";
 import { EntityStatusUpdateEmail } from "../email/entity-status-update.email";
 import { ProjectManagerEmail } from "../email/project-manager.email";
 import { FormSubmissionFeedbackEmail } from "../email/form-submission-feedback.email";
+import { UserContext } from "../contexts/user.context";
 
 const TASK_UPDATE_REPORT_STATUSES = [APPROVED, NEEDS_MORE_INFORMATION, AWAITING_APPROVAL];
 
@@ -210,7 +210,10 @@ export class EntityStatusUpdate extends EventProcessor {
 
     if (submission.status === "awaiting-approval") {
       if (submission.applicationId != null) {
-        await Application.update({ updatedBy: authenticatedUserId() }, { where: { id: submission.applicationId } });
+        await Application.update(
+          { updatedBy: UserContext.authenticatedUserId },
+          { where: { id: submission.applicationId } }
+        );
       }
 
       if (submission.projectPitchUuid != null) {
@@ -255,7 +258,7 @@ export class EntityStatusUpdate extends EventProcessor {
   private async sendApplicationSubmittedEmail(submission: FormSubmission) {
     this.logger.log(`Sending application submitted email queue [${JSON.stringify({ id: submission.id })}]`);
 
-    const userId = authenticatedUserId();
+    const userId = UserContext.authenticatedUserId;
     if (userId == null) {
       this.logger.error("Cannot send application submitted email without authenticated user");
       return;
@@ -318,7 +321,7 @@ export class EntityStatusUpdate extends EventProcessor {
       }
     }
     const type = status === NEEDS_MORE_INFORMATION ? "change-request" : "status";
-    await AuditStatus.createAudit(model, authenticatedUserId(), type, comment);
+    await AuditStatus.createAudit(model, UserContext.authenticatedUserId, type, comment);
   }
 
   private async getNeedsMoreInfoComment() {

--- a/libs/common/src/lib/guards/auth.guard.spec.ts
+++ b/libs/common/src/lib/guards/auth.guard.spec.ts
@@ -1,4 +1,4 @@
-import { AuthGuard, NoBearerAuth, OptionalBearerAuth } from "./auth.guard";
+import { AuthGuard, AuthOptional } from "./auth.guard";
 import { Test } from "@nestjs/testing";
 import { APP_GUARD } from "@nestjs/core";
 import { createMock, DeepMocked } from "@golevelup/ts-jest";
@@ -14,13 +14,7 @@ class TestController {
     return "test";
   }
 
-  @NoBearerAuth
-  @Get("/no-auth")
-  noAuth() {
-    return "no-auth";
-  }
-
-  @OptionalBearerAuth
+  @AuthOptional
   @Get("/optional-auth")
   optionalAuth() {
     return "optional-auth";
@@ -58,15 +52,6 @@ describe("AuthGuard", () => {
     jwtService.verifyAsync.mockResolvedValue({ sub: "fakeuserid" });
 
     await request(app.getHttpServer()).get("/test").set("Authorization", `Bearer ${token}`).expect(HttpStatus.OK);
-  });
-
-  it("should ignore bearer token on an endpoint with @NoBearerAuth", async () => {
-    await request(app.getHttpServer()).get("/test/no-auth").expect(HttpStatus.OK);
-
-    await request(app.getHttpServer())
-      .get("/test/no-auth")
-      .set("Authorization", "Bearer fake jwt token")
-      .expect(HttpStatus.OK);
   });
 
   it("should use an api key for login", async () => {

--- a/libs/common/src/lib/guards/auth.guard.spec.ts
+++ b/libs/common/src/lib/guards/auth.guard.spec.ts
@@ -1,11 +1,10 @@
 import { AuthGuard, AuthOptional } from "./auth.guard";
 import { Test } from "@nestjs/testing";
 import { APP_GUARD } from "@nestjs/core";
-import { createMock, DeepMocked } from "@golevelup/ts-jest";
-import { JwtService } from "@nestjs/jwt";
 import { Controller, Get, HttpStatus, INestApplication } from "@nestjs/common";
 import { UserFactory } from "@terramatch-microservices/database/factories";
 import request from "supertest";
+import { mockContextForUser } from "../util/testing";
 
 @Controller("test")
 class TestController {
@@ -22,17 +21,13 @@ class TestController {
 }
 
 describe("AuthGuard", () => {
-  let jwtService: DeepMocked<JwtService>;
   let app: INestApplication;
 
   beforeEach(async () => {
     app = (
       await Test.createTestingModule({
         controllers: [TestController],
-        providers: [
-          { provide: JwtService, useValue: (jwtService = createMock<JwtService>()) },
-          { provide: APP_GUARD, useClass: AuthGuard }
-        ]
+        providers: [{ provide: APP_GUARD, useClass: AuthGuard }]
       }).compile()
     ).createNestApplication();
     await app.init();
@@ -43,54 +38,21 @@ describe("AuthGuard", () => {
     jest.restoreAllMocks();
   });
 
-  it("should return an error when no auth header is present", async () => {
+  it("should return an error when no user is found in context", async () => {
     await request(app.getHttpServer()).get("/test").expect(HttpStatus.UNAUTHORIZED);
   });
 
-  it("should not return an error when a valid auth header is present", async () => {
-    const token = "fake jwt token";
-    jwtService.verifyAsync.mockResolvedValue({ sub: "fakeuserid" });
-
-    await request(app.getHttpServer()).get("/test").set("Authorization", `Bearer ${token}`).expect(HttpStatus.OK);
+  it("should use the user found in context for auth", async () => {
+    mockContextForUser(await UserFactory.create());
+    await request(app.getHttpServer()).get("/test").expect(HttpStatus.OK);
   });
 
-  it("should use an api key for login", async () => {
-    const apiKey = "fake-api-key";
-    await UserFactory.create({ apiKey });
-    jwtService.decode.mockReturnValue(null);
-
-    await request(app.getHttpServer()).get("/test").set("Authorization", `Bearer ${apiKey}`).expect(HttpStatus.OK);
-  });
-
-  it("should throw when the api key is not recognized", async () => {
-    jwtService.decode.mockReturnValue(null);
-
-    await request(app.getHttpServer())
-      .get("/test")
-      .set("Authorization", "Bearer foobar")
-      .expect(HttpStatus.UNAUTHORIZED);
-  });
-
-  it("should allow missing auth on an endpoint with @OptionalBearerAuth", async () => {
+  it("should allow missing auth on an endpoint with @AuthOptional", async () => {
     await request(app.getHttpServer()).get("/test/optional-auth").expect(HttpStatus.OK);
   });
 
-  it("should allow invalid auth on an endpoint with @OptionalBearerAuth", async () => {
-    jwtService.verifyAsync.mockRejectedValue(new Error("Invalid token"));
-
-    await request(app.getHttpServer())
-      .get("/test/optional-auth")
-      .set("Authorization", "Bearer invalid-token")
-      .expect(HttpStatus.OK);
-  });
-
-  it("should allow valid auth on an endpoint with @OptionalBearerAuth", async () => {
-    const token = "valid-token";
-    jwtService.verifyAsync.mockResolvedValue({ sub: "fakeuserid" });
-
-    await request(app.getHttpServer())
-      .get("/test/optional-auth")
-      .set("Authorization", `Bearer ${token}`)
-      .expect(HttpStatus.OK);
+  it("should allow valid auth on an endpoint with @AuthOptional", async () => {
+    mockContextForUser(await UserFactory.create());
+    await request(app.getHttpServer()).get("/test/optional-auth").expect(HttpStatus.OK);
   });
 });

--- a/libs/common/src/lib/guards/auth.guard.ts
+++ b/libs/common/src/lib/guards/auth.guard.ts
@@ -2,23 +2,14 @@ import { CanActivate, ExecutionContext, Injectable, SetMetadata, UnauthorizedExc
 import { Reflector } from "@nestjs/core";
 import { UserContext } from "../contexts/user.context";
 
-const NO_BEARER_AUTH = "noBearerAuth";
-export const NoBearerAuth = SetMetadata(NO_BEARER_AUTH, true);
-
 const OPTIONAL_BEARER_AUTH = "optionalBearerAuth";
-export const OptionalBearerAuth = SetMetadata(OPTIONAL_BEARER_AUTH, true);
+export const AuthOptional = SetMetadata(OPTIONAL_BEARER_AUTH, true);
 
 @Injectable()
 export class AuthGuard implements CanActivate {
   constructor(private reflector: Reflector) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const skipAuth = this.reflector.getAllAndOverride<boolean>(NO_BEARER_AUTH, [
-      context.getHandler(),
-      context.getClass()
-    ]);
-    if (skipAuth) return true;
-
     const optionalAuth = this.reflector.getAllAndOverride<boolean>(OPTIONAL_BEARER_AUTH, [
       context.getHandler(),
       context.getClass()

--- a/libs/common/src/lib/guards/auth.guard.ts
+++ b/libs/common/src/lib/guards/auth.guard.ts
@@ -1,10 +1,6 @@
 import { CanActivate, ExecutionContext, Injectable, SetMetadata, UnauthorizedException } from "@nestjs/common";
-import { JwtService } from "@nestjs/jwt";
 import { Reflector } from "@nestjs/core";
-import { Permission, User } from "@terramatch-microservices/database/entities";
-import { RequestContext } from "nestjs-request-context";
-import { PolicyBuilder } from "../policies/policy.service";
-import { ValidLocale } from "@terramatch-microservices/database/constants/locale";
+import { UserContext } from "../contexts/user.context";
 
 const NO_BEARER_AUTH = "noBearerAuth";
 export const NoBearerAuth = SetMetadata(NO_BEARER_AUTH, true);
@@ -12,17 +8,14 @@ export const NoBearerAuth = SetMetadata(NO_BEARER_AUTH, true);
 const OPTIONAL_BEARER_AUTH = "optionalBearerAuth";
 export const OptionalBearerAuth = SetMetadata(OPTIONAL_BEARER_AUTH, true);
 
-export const authenticatedUserId = () => RequestContext.currentContext?.req?.authenticatedUserId as number | undefined;
-export const permissions = () => RequestContext.currentContext?.req?.permissions as string[] | undefined;
-export const policyBuilder = () => RequestContext.currentContext?.req?.policyBuilder as PolicyBuilder | undefined;
-export const userLocale = () => RequestContext.currentContext?.req?.userLocale as ValidLocale | undefined;
+export const authenticatedUserId = () => UserContext.current?.authenticatedUserId;
+export const permissions = () => UserContext.current?.permissions;
+export const policyBuilder = () => UserContext.current?.policyBuilder;
+export const userLocale = () => UserContext.current?.userLocale;
 
 @Injectable()
 export class AuthGuard implements CanActivate {
-  constructor(
-    private jwtService: JwtService,
-    private reflector: Reflector
-  ) {}
+  constructor(private reflector: Reflector) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const skipAuth = this.reflector.getAllAndOverride<boolean>(NO_BEARER_AUTH, [
@@ -35,44 +28,9 @@ export class AuthGuard implements CanActivate {
       context.getHandler(),
       context.getClass()
     ]);
+    if (optionalAuth) return true;
 
-    const request = context.switchToHttp().getRequest();
-    const [type, token] = request.headers.authorization?.split(" ") ?? [];
-    if (type !== "Bearer" || token == null) {
-      if (optionalAuth) return true;
-      throw new UnauthorizedException();
-    }
-
-    const userId = this.isJwtToken(token) ? await this.getJwtUserId(token) : await this.getApiKeyUserId(token);
-    if (userId == null) {
-      if (optionalAuth) return true;
-      throw new UnauthorizedException();
-    }
-
-    // Most requests won't need the actual user object; Instead, we cache the user id and a couple
-    // of other frequently needed values on the request object.
-    request.authenticatedUserId = userId;
-    request.permissions = await Permission.getUserPermissionNames(userId);
-    request.policyBuilder = new PolicyBuilder(userId, request.permissions);
-    request.userLocale = await User.findLocale(userId);
+    if (authenticatedUserId() == null) throw new UnauthorizedException();
     return true;
-  }
-
-  private isJwtToken(token: string) {
-    return this.jwtService.decode(token) != null;
-  }
-
-  private async getJwtUserId(token: string) {
-    try {
-      const { sub } = await this.jwtService.verifyAsync(token);
-      return sub;
-    } catch {
-      return null;
-    }
-  }
-
-  private async getApiKeyUserId(token: string) {
-    const { id } = (await User.findOne({ where: { apiKey: token }, attributes: ["id"] })) ?? {};
-    return id;
   }
 }

--- a/libs/common/src/lib/guards/auth.guard.ts
+++ b/libs/common/src/lib/guards/auth.guard.ts
@@ -8,11 +8,6 @@ export const NoBearerAuth = SetMetadata(NO_BEARER_AUTH, true);
 const OPTIONAL_BEARER_AUTH = "optionalBearerAuth";
 export const OptionalBearerAuth = SetMetadata(OPTIONAL_BEARER_AUTH, true);
 
-export const authenticatedUserId = () => UserContext.current?.authenticatedUserId;
-export const permissions = () => UserContext.current?.permissions;
-export const policyBuilder = () => UserContext.current?.policyBuilder;
-export const userLocale = () => UserContext.current?.userLocale;
-
 @Injectable()
 export class AuthGuard implements CanActivate {
   constructor(private reflector: Reflector) {}
@@ -30,7 +25,7 @@ export class AuthGuard implements CanActivate {
     ]);
     if (optionalAuth) return true;
 
-    if (authenticatedUserId() == null) throw new UnauthorizedException();
+    if (UserContext.authenticatedUserId == null) throw new UnauthorizedException();
     return true;
   }
 }

--- a/libs/common/src/lib/guards/index.ts
+++ b/libs/common/src/lib/guards/index.ts
@@ -1,1 +1,1 @@
-export { AuthGuard, NoBearerAuth, OptionalBearerAuth } from "./auth.guard";
+export { AuthGuard, AuthOptional } from "./auth.guard";

--- a/libs/common/src/lib/health/health.controller.ts
+++ b/libs/common/src/lib/health/health.controller.ts
@@ -3,7 +3,7 @@ import { HealthCheck, HealthCheckService, SequelizeHealthIndicator } from "@nest
 import { ApiExcludeController } from "@nestjs/swagger";
 import { User } from "@terramatch-microservices/database/entities";
 import { QueueHealthIndicator } from "./queue-health.indicator";
-import { NoBearerAuth } from "../guards";
+import { AuthOptional } from "../guards";
 
 @Controller("health")
 @ApiExcludeController()
@@ -16,7 +16,7 @@ export class HealthController {
 
   @Get()
   @HealthCheck()
-  @NoBearerAuth
+  @AuthOptional
   async check() {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const sequelize = User.sequelize!;

--- a/libs/common/src/lib/middleware/user-context.middleware.ts
+++ b/libs/common/src/lib/middleware/user-context.middleware.ts
@@ -1,0 +1,50 @@
+import { Injectable, NestMiddleware } from "@nestjs/common";
+import { Request, NextFunction } from "express";
+import { JwtService } from "@nestjs/jwt";
+import { UserContext } from "../contexts/user.context";
+import { Permission, User } from "@terramatch-microservices/database/entities";
+
+@Injectable()
+export class UserContextMiddleware implements NestMiddleware {
+  constructor(private jwtService: JwtService) {}
+
+  async use(req: Request, _: unknown, next: NextFunction) {
+    const [type, token] = req.headers.authorization?.split(" ") ?? [];
+    if (type !== "Bearer" || token == null) {
+      next();
+      return;
+    }
+
+    const userId = this.isJwtToken(token) ? await this.getJwtUserId(token) : await this.getApiKeyUserId(token);
+    if (userId == null) {
+      next();
+      return;
+    }
+
+    const permissions = await Permission.getUserPermissionNames(userId);
+    const locale = await User.findLocale(userId);
+    UserContext.use(userId, permissions, locale ?? "en-US", next);
+  }
+
+  private isJwtToken(token: string) {
+    return this.jwtService.decode(token) != null;
+  }
+
+  private async getJwtUserId(token: string): Promise<number | null> {
+    try {
+      const { sub } = await this.jwtService.verifyAsync(token);
+      return sub;
+    } catch {
+      return null;
+    }
+  }
+
+  private async getApiKeyUserId(token: string): Promise<number | null> {
+    try {
+      const { sub } = await this.jwtService.verifyAsync(token);
+      return sub;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/libs/common/src/lib/policies/anr-plot-geometry.policy.spec.ts
+++ b/libs/common/src/lib/policies/anr-plot-geometry.policy.spec.ts
@@ -9,7 +9,7 @@ import {
   SitePolygonFactory,
   UserFactory
 } from "@terramatch-microservices/database/factories";
-import { mockRequestContext, mockRequestForUser } from "../util/testing";
+import { mockUserContext, mockContextForUser } from "../util/testing";
 
 describe("AnrPlotGeometryPolicy", () => {
   let service: PolicyService;
@@ -29,7 +29,7 @@ describe("AnrPlotGeometryPolicy", () => {
   describe("polygons-manage permission", () => {
     it("allows service accounts with polygons-manage to read and create any anr plot geometry", async () => {
       const user = await UserFactory.create();
-      mockRequestForUser(user, "polygons-manage");
+      mockContextForUser(user, "polygons-manage");
 
       const anrPlotGeometry = new AnrPlotGeometry();
       anrPlotGeometry.createdBy = user.id + 1;
@@ -40,7 +40,7 @@ describe("AnrPlotGeometryPolicy", () => {
 
     it("allows service accounts with polygons-manage to update and delete any anr plot geometries", async () => {
       const user = await UserFactory.create();
-      mockRequestForUser(user, "polygons-manage");
+      mockContextForUser(user, "polygons-manage");
 
       const ownPlotGeometry = new AnrPlotGeometry();
       ownPlotGeometry.createdBy = user.id;
@@ -60,7 +60,7 @@ describe("AnrPlotGeometryPolicy", () => {
       const site = await SiteFactory.create({ frameworkKey: "ppc" });
       const sitePolygon = await SitePolygonFactory.create({ siteUuid: site.uuid });
 
-      mockRequestContext({ userId: 123, permissions: ["framework-ppc"] });
+      mockUserContext({ userId: 123, permissions: ["framework-ppc"] });
       const anrPlotGeometry = new AnrPlotGeometry();
       anrPlotGeometry.sitePolygonId = sitePolygon.id;
 
@@ -74,7 +74,7 @@ describe("AnrPlotGeometryPolicy", () => {
       const site = await SiteFactory.create({ projectId: project.id });
       const sitePolygon = await SitePolygonFactory.create({ siteUuid: site.uuid });
 
-      mockRequestForUser(user, "manage-own");
+      mockContextForUser(user, "manage-own");
       const anrPlotGeometry = new AnrPlotGeometry();
       anrPlotGeometry.sitePolygonId = sitePolygon.id;
 
@@ -88,7 +88,7 @@ describe("AnrPlotGeometryPolicy", () => {
       const site = await SiteFactory.create({ projectId: project.id });
       const sitePolygon = await SitePolygonFactory.create({ siteUuid: site.uuid });
 
-      mockRequestForUser(user, "projects-manage");
+      mockContextForUser(user, "projects-manage");
       const anrPlotGeometry = new AnrPlotGeometry();
       anrPlotGeometry.sitePolygonId = sitePolygon.id;
 
@@ -102,7 +102,7 @@ describe("AnrPlotGeometryPolicy", () => {
       const site = await SiteFactory.create({ projectId: project.id });
       const sitePolygon = await SitePolygonFactory.create({ siteUuid: site.uuid });
 
-      mockRequestForUser(user, "projects-manage");
+      mockContextForUser(user, "projects-manage");
       const anrPlotGeometry = new AnrPlotGeometry();
       anrPlotGeometry.sitePolygonId = sitePolygon.id;
 
@@ -113,7 +113,7 @@ describe("AnrPlotGeometryPolicy", () => {
   describe("read-only permissions", () => {
     it("allows reading with view-dashboard permission", async () => {
       const user = await UserFactory.create();
-      mockRequestForUser(user, "view-dashboard");
+      mockContextForUser(user, "view-dashboard");
 
       const anrPlotGeometry = new AnrPlotGeometry();
 
@@ -125,7 +125,7 @@ describe("AnrPlotGeometryPolicy", () => {
 
     it("allows reading with projects-read permission", async () => {
       const user = await UserFactory.create();
-      mockRequestForUser(user, "projects-read");
+      mockContextForUser(user, "projects-read");
 
       const anrPlotGeometry = new AnrPlotGeometry();
 
@@ -139,7 +139,7 @@ describe("AnrPlotGeometryPolicy", () => {
   describe("no permissions", () => {
     it("denies all operations when user has no permissions", async () => {
       const user = await UserFactory.create();
-      mockRequestForUser(user);
+      mockContextForUser(user);
 
       const anrPlotGeometry = new AnrPlotGeometry();
 

--- a/libs/common/src/lib/policies/application.policy.spec.ts
+++ b/libs/common/src/lib/policies/application.policy.spec.ts
@@ -1,6 +1,6 @@
 import { PolicyService } from "./policy.service";
 import { Test } from "@nestjs/testing";
-import { mockRequestContext, mockRequestForUser } from "../util/testing";
+import { mockUserContext, mockContextForUser } from "../util/testing";
 import { expectCan, expectCannot } from "./policy.service.spec";
 import { Application } from "@terramatch-microservices/database/entities";
 import {
@@ -26,14 +26,14 @@ describe("ApplicationPolicy", () => {
   });
 
   it("allows reading applications for all admins", async () => {
-    mockRequestContext({ userId: 123, permissions: ["framework-terrafund"] });
+    mockUserContext({ userId: 123, permissions: ["framework-terrafund"] });
     await expectCan(service, "read", new Application());
   });
 
   it("allows reading own org applications", async () => {
     const org = await OrganisationFactory.create();
     const user = await UserFactory.create({ organisationId: org.id });
-    mockRequestForUser(user, "manage-own");
+    mockContextForUser(user, "manage-own");
     let application = await ApplicationFactory.create({ organisationUuid: org.uuid });
     await expectCan(service, "read", application);
     application = await ApplicationFactory.create();
@@ -44,7 +44,7 @@ describe("ApplicationPolicy", () => {
     const associatedOrg = await OrganisationFactory.create();
     const pendingOrg = await OrganisationFactory.create();
     const user = await UserFactory.create();
-    mockRequestForUser(user, "manage-own");
+    mockContextForUser(user, "manage-own");
     await OrganisationUserFactory.create({ organisationId: associatedOrg.id, userId: user.id, status: "approved" });
     await OrganisationUserFactory.create({ organisationId: pendingOrg.id, userId: user.id, status: "requested" });
     const associatedSubmission = await ApplicationFactory.create({ organisationUuid: associatedOrg.uuid });

--- a/libs/common/src/lib/policies/audit-status.policy.spec.ts
+++ b/libs/common/src/lib/policies/audit-status.policy.spec.ts
@@ -2,7 +2,7 @@ import { Test } from "@nestjs/testing";
 import { PolicyService } from "./policy.service";
 import { AuditStatusFactory, UserFactory } from "@terramatch-microservices/database/factories";
 import { expectCan } from "./policy.service.spec";
-import { mockRequestContext } from "../util/testing";
+import { mockUserContext } from "../util/testing";
 
 describe("AuditStatusPolicy", () => {
   let service: PolicyService;
@@ -21,7 +21,7 @@ describe("AuditStatusPolicy", () => {
 
   it("should allow upload files if user is managing projects", async () => {
     const user = await UserFactory.create();
-    mockRequestContext({ userId: user.id });
+    mockUserContext({ userId: user.id });
     const auditStatus = await AuditStatusFactory.project().create({ createdBy: user.emailAddress });
     await expectCan(service, "uploadFiles", auditStatus);
   });

--- a/libs/common/src/lib/policies/disturbance-report.policy.spec.ts
+++ b/libs/common/src/lib/policies/disturbance-report.policy.spec.ts
@@ -9,7 +9,7 @@ import {
   ProjectUserFactory,
   UserFactory
 } from "@terramatch-microservices/database/factories";
-import { mockRequestContext, mockRequestForUser } from "../util/testing";
+import { mockUserContext, mockContextForUser } from "../util/testing";
 
 describe("DisturbanceReportPolicy", () => {
   let service: PolicyService;
@@ -27,13 +27,13 @@ describe("DisturbanceReportPolicy", () => {
   });
 
   it("allows reading all disturbance reports with view-dashboard permissions", async () => {
-    mockRequestContext({ userId: 123, permissions: ["view-dashboard"] });
+    mockUserContext({ userId: 123, permissions: ["view-dashboard"] });
     await expectCan(service, "read", new DisturbanceReport());
     await expectCannot(service, "delete", new DisturbanceReport());
   });
 
   it("allows managing disturbance reports in your framework", async () => {
-    mockRequestContext({ userId: 123, permissions: ["framework-ppc"] });
+    mockUserContext({ userId: 123, permissions: ["framework-ppc"] });
     const ppc = await DisturbanceReportFactory.create({ frameworkKey: "ppc" });
     const tf = await DisturbanceReportFactory.create({ frameworkKey: "terrafund" });
     await expectAuthority(service, {
@@ -45,7 +45,7 @@ describe("DisturbanceReportPolicy", () => {
   it("allows managing disturbance reports for own projects", async () => {
     const org = await OrganisationFactory.create();
     const user = await UserFactory.create({ organisationId: org.id });
-    mockRequestForUser(user, "manage-own");
+    mockContextForUser(user, "manage-own");
 
     const p1 = await ProjectFactory.create({ organisationId: org.id });
     const p2 = await ProjectFactory.create();
@@ -76,7 +76,7 @@ describe("DisturbanceReportPolicy", () => {
 
   it("allows managing disturbance reports for managed projects", async () => {
     const user = await UserFactory.create();
-    mockRequestForUser(user, "projects-manage");
+    mockContextForUser(user, "projects-manage");
 
     const p1 = await ProjectFactory.create();
     const p2 = await ProjectFactory.create();

--- a/libs/common/src/lib/policies/disturbance.policy.spec.ts
+++ b/libs/common/src/lib/policies/disturbance.policy.spec.ts
@@ -2,7 +2,7 @@ import { PolicyService } from "./policy.service";
 import { Test } from "@nestjs/testing";
 import { expectCan, expectCannot } from "./policy.service.spec";
 import { Disturbance } from "@terramatch-microservices/database/entities";
-import { mockRequestContext } from "../util/testing";
+import { mockUserContext } from "../util/testing";
 
 describe("DisturbancePolicy", () => {
   let service: PolicyService;
@@ -20,13 +20,13 @@ describe("DisturbancePolicy", () => {
   });
 
   it("allows reading all disturbances with framework permissions", async () => {
-    mockRequestContext({ userId: 123, permissions: ["framework-ppc"] });
+    mockUserContext({ userId: 123, permissions: ["framework-ppc"] });
     await expectCan(service, "read", new Disturbance());
     await expectCannot(service, "delete", new Disturbance());
   });
 
   it("dany reading all disturbances with projects-read permissions", async () => {
-    mockRequestContext({ userId: 123, permissions: ["projects-read"] });
+    mockUserContext({ userId: 123, permissions: ["projects-read"] });
     await expectCannot(service, "read", new Disturbance());
   });
 });

--- a/libs/common/src/lib/policies/financial-indicator.policy.spec.ts
+++ b/libs/common/src/lib/policies/financial-indicator.policy.spec.ts
@@ -3,7 +3,7 @@ import { PolicyService } from "./policy.service";
 import { OrganisationFactory, UserFactory } from "@terramatch-microservices/database/factories";
 import { expectAuthority, expectCan, expectCannot } from "./policy.service.spec";
 import { FinancialIndicatorFactory } from "@terramatch-microservices/database/factories/financial-indicator.factory";
-import { mockRequestContext, mockRequestForUser } from "../util/testing";
+import { mockUserContext, mockContextForUser } from "../util/testing";
 
 describe("FinancialIndicatorPolicy", () => {
   let service: PolicyService;
@@ -23,13 +23,13 @@ describe("FinancialIndicatorPolicy", () => {
   it("should allow upload and delete files if user has organisationId", async () => {
     const org = await OrganisationFactory.create();
     const user = await UserFactory.create({ organisationId: org.id });
-    mockRequestForUser(user);
+    mockContextForUser(user);
     const financialIndicator = await FinancialIndicatorFactory.org(org).create();
     await expectCan(service, ["uploadFiles", "deleteFiles"], financialIndicator);
   });
 
   it("should allow managing all financial indicators with framework permissions", async () => {
-    mockRequestContext({ userId: 123, permissions: ["framework-pcc"] });
+    mockUserContext({ userId: 123, permissions: ["framework-pcc"] });
     const fi1 = await FinancialIndicatorFactory.org().create();
     const fi2 = await FinancialIndicatorFactory.org().create();
     await expectAuthority(service, {
@@ -43,7 +43,7 @@ describe("FinancialIndicatorPolicy", () => {
   it("should not allow managing financial indicators without framework permissions", async () => {
     const org = await OrganisationFactory.create();
     const user = await UserFactory.create({ organisationId: org.id });
-    mockRequestForUser(user, "other-permission");
+    mockContextForUser(user, "other-permission");
     const financialIndicator = await FinancialIndicatorFactory.org(org).create();
     await expectCannot(service, ["read", "delete", "update", "approve", "create"], financialIndicator);
     await expectCan(service, ["uploadFiles", "deleteFiles"], financialIndicator);

--- a/libs/common/src/lib/policies/financial-report.policy.spec.ts
+++ b/libs/common/src/lib/policies/financial-report.policy.spec.ts
@@ -9,7 +9,7 @@ import {
   RoleFactory,
   UserFactory
 } from "@terramatch-microservices/database/factories";
-import { mockRequestContext, mockRequestForUser } from "../util/testing";
+import { mockUserContext, mockContextForUser } from "../util/testing";
 import { AWAITING_APPROVAL, DUE, STARTED } from "@terramatch-microservices/database/constants/status";
 import { ModelHasRole, User } from "@terramatch-microservices/database/entities";
 
@@ -29,7 +29,7 @@ describe("FinancialReportPolicy", () => {
   });
 
   it("allows managing financial reports in your framework", async () => {
-    mockRequestContext({ userId: 123, permissions: ["framework-ppc"] });
+    mockUserContext({ userId: 123, permissions: ["framework-ppc"] });
     const ppc = await FinancialReportFactory.org().create({ frameworkKey: "ppc" });
     const tf = await FinancialReportFactory.org().create({ frameworkKey: "terrafund" });
     await expectAuthority(service, {
@@ -41,7 +41,7 @@ describe("FinancialReportPolicy", () => {
   it("allows managing own financial reports", async () => {
     const org = await OrganisationFactory.create();
     const user = await UserFactory.create({ organisationId: org.id });
-    mockRequestForUser(user, "manage-own");
+    mockContextForUser(user, "manage-own");
 
     const fr1 = await FinancialReportFactory.org(org).create();
     const fr2 = await FinancialReportFactory.org().create();
@@ -52,7 +52,7 @@ describe("FinancialReportPolicy", () => {
   });
 
   it("allows managing all financial reports with reports-manage permission", async () => {
-    mockRequestContext({ userId: 123, permissions: ["reports-manage"] });
+    mockUserContext({ userId: 123, permissions: ["reports-manage"] });
     const fr1 = await FinancialReportFactory.org().create();
     const fr2 = await FinancialReportFactory.org().create();
     await expectAuthority(service, {
@@ -65,7 +65,7 @@ describe("FinancialReportPolicy", () => {
 
   it("does not allow access for users without organisation", async () => {
     const user = await UserFactory.create({ organisationId: null });
-    mockRequestForUser(user, "manage-own");
+    mockContextForUser(user, "manage-own");
 
     const financialReport = await FinancialReportFactory.org().create();
     await expectCannot(service, "read", financialReport);
@@ -75,7 +75,7 @@ describe("FinancialReportPolicy", () => {
   it("allows updateAnswers for own organisation when status is started or due", async () => {
     const org = await OrganisationFactory.create();
     const user = await UserFactory.create({ organisationId: org.id });
-    mockRequestForUser(user, "manage-own");
+    mockContextForUser(user, "manage-own");
 
     const started = await FinancialReportFactory.org(org).create({ status: STARTED });
     const due = await FinancialReportFactory.org(org).create({ status: DUE });
@@ -90,7 +90,7 @@ describe("FinancialReportPolicy", () => {
   it("allows updateAnswers when awaiting approval and nothingToReport is true", async () => {
     const org = await OrganisationFactory.create();
     const user = await UserFactory.create({ organisationId: org.id });
-    mockRequestForUser(user, "manage-own");
+    mockContextForUser(user, "manage-own");
 
     const report = await FinancialReportFactory.org(org).create({
       status: AWAITING_APPROVAL,
@@ -102,7 +102,7 @@ describe("FinancialReportPolicy", () => {
   it("denies updateAnswers when awaiting approval without nothingToReport", async () => {
     const org = await OrganisationFactory.create();
     const user = await UserFactory.create({ organisationId: org.id });
-    mockRequestForUser(user, "manage-own");
+    mockContextForUser(user, "manage-own");
 
     const report = await FinancialReportFactory.org(org).create({
       status: AWAITING_APPROVAL,
@@ -112,7 +112,7 @@ describe("FinancialReportPolicy", () => {
   });
 
   it("allows export and reminder actions for framework users", async () => {
-    mockRequestContext({ userId: 123, permissions: ["framework-ppc"] });
+    mockUserContext({ userId: 123, permissions: ["framework-ppc"] });
     const ppc = await FinancialReportFactory.org().create({ frameworkKey: "ppc" });
     await expectAuthority(service, {
       can: [
@@ -133,7 +133,7 @@ describe("FinancialReportPolicy", () => {
       isMonitoring: false,
       isManaging: true
     });
-    mockRequestForUser(user, "projects-manage");
+    mockContextForUser(user, "projects-manage");
 
     const visible = await FinancialReportFactory.org(orgFromProject).create();
     const hidden = await FinancialReportFactory.org().create({
@@ -151,7 +151,7 @@ describe("FinancialReportPolicy", () => {
     const pmRole = await RoleFactory.create({ name: "project-manager" });
     await ModelHasRole.create({ modelId: user.id, roleId: pmRole.id, modelType: User.LARAVEL_TYPE });
 
-    mockRequestForUser(user);
+    mockContextForUser(user);
 
     const ownOrgReport = await FinancialReportFactory.org(org).create();
     const otherReport = await FinancialReportFactory.org().create();

--- a/libs/common/src/lib/policies/form-question-option.policy.spec.ts
+++ b/libs/common/src/lib/policies/form-question-option.policy.spec.ts
@@ -2,7 +2,7 @@ import { PolicyService } from "./policy.service";
 import { Test } from "@nestjs/testing";
 import { expectCan, expectCannot } from "./policy.service.spec";
 import { FormQuestionOptionFactory, UserFactory } from "@terramatch-microservices/database/factories";
-import { mockRequestForUser } from "../util/testing";
+import { mockContextForUser } from "../util/testing";
 
 describe("FormQuestionOptionPolicy", () => {
   let service: PolicyService;
@@ -21,14 +21,14 @@ describe("FormQuestionOptionPolicy", () => {
 
   it("should allow uploading files for question options if you can forms manage", async () => {
     const user = await UserFactory.create();
-    mockRequestForUser(user, "custom-forms-manage");
+    mockContextForUser(user, "custom-forms-manage");
     const option = await FormQuestionOptionFactory.forQuestion().create();
     await expectCan(service, ["uploadFiles"], option);
   });
 
   it("should disallow uploading files for question options if you cannot forms manage", async () => {
     const user = await UserFactory.create();
-    mockRequestForUser(user, "framework-terrafund");
+    mockContextForUser(user, "framework-terrafund");
     const option = await FormQuestionOptionFactory.forQuestion().create();
     await expectCannot(service, ["uploadFiles"], option);
   });

--- a/libs/common/src/lib/policies/form-submission.policy.spec.ts
+++ b/libs/common/src/lib/policies/form-submission.policy.spec.ts
@@ -1,6 +1,6 @@
 import { PolicyService } from "./policy.service";
 import { Test } from "@nestjs/testing";
-import { mockRequestContext, mockRequestForUser } from "../util/testing";
+import { mockUserContext, mockContextForUser } from "../util/testing";
 import { expectCan, expectCannot } from "./policy.service.spec";
 import { FormSubmission } from "@terramatch-microservices/database/entities";
 import {
@@ -26,14 +26,14 @@ describe("FormSubmissionPolicy", () => {
   });
 
   it("allows reading form submission for all admins", async () => {
-    mockRequestContext({ userId: 123, permissions: ["framework-terrafund"] });
+    mockUserContext({ userId: 123, permissions: ["framework-terrafund"] });
     await expectCan(service, "read", new FormSubmission());
   });
 
   it("allows reading own org submissions", async () => {
     const org = await OrganisationFactory.create();
     const user = await UserFactory.create({ organisationId: org.id });
-    mockRequestForUser(user, "manage-own");
+    mockContextForUser(user, "manage-own");
     let submission = await FormSubmissionFactory.create({ organisationUuid: org.uuid });
     await expectCan(service, "read", submission);
     submission = await FormSubmissionFactory.create({ organisationUuid: "other-org" });
@@ -44,7 +44,7 @@ describe("FormSubmissionPolicy", () => {
     const associatedOrg = await OrganisationFactory.create();
     const pendingOrg = await OrganisationFactory.create();
     const user = await UserFactory.create();
-    mockRequestForUser(user, "manage-own");
+    mockContextForUser(user, "manage-own");
     await OrganisationUserFactory.create({ organisationId: associatedOrg.id, userId: user.id, status: "approved" });
     await OrganisationUserFactory.create({ organisationId: pendingOrg.id, userId: user.id, status: "requested" });
     const associatedSubmission = await FormSubmissionFactory.create({ organisationUuid: associatedOrg.uuid });

--- a/libs/common/src/lib/policies/form.policy.spec.ts
+++ b/libs/common/src/lib/policies/form.policy.spec.ts
@@ -2,7 +2,7 @@ import { PolicyService } from "./policy.service";
 import { Test } from "@nestjs/testing";
 import { expectCan, expectCannot } from "./policy.service.spec";
 import { FormFactory, UserFactory } from "@terramatch-microservices/database/factories";
-import { mockRequestForUser } from "../util/testing";
+import { mockContextForUser } from "../util/testing";
 
 describe("FormPolicy", () => {
   let service: PolicyService;
@@ -21,14 +21,14 @@ describe("FormPolicy", () => {
 
   it("should allow uploading files to forms if you can forms manage", async () => {
     const user = await UserFactory.create();
-    mockRequestForUser(user, "custom-forms-manage");
+    mockContextForUser(user, "custom-forms-manage");
     const form = await FormFactory.create();
     await expectCan(service, ["uploadFiles"], form);
   });
 
   it("should disallow uploading files for forms if you cannot forms manage", async () => {
     const user = await UserFactory.create();
-    mockRequestForUser(user, "framework-terrafund");
+    mockContextForUser(user, "framework-terrafund");
     const form = await FormFactory.create();
     await expectCannot(service, ["uploadFiles"], form);
   });

--- a/libs/common/src/lib/policies/funding-programme.policy.spec.ts
+++ b/libs/common/src/lib/policies/funding-programme.policy.spec.ts
@@ -1,7 +1,7 @@
 import { PolicyService } from "./policy.service";
 import { Test } from "@nestjs/testing";
 import { expectCan, expectCannot } from "./policy.service.spec";
-import { mockRequestContext } from "../util/testing";
+import { mockUserContext } from "../util/testing";
 import { FundingProgrammeFactory } from "@terramatch-microservices/database/factories";
 
 describe("FundingProgrammePolicy", () => {
@@ -20,7 +20,7 @@ describe("FundingProgrammePolicy", () => {
   });
 
   it("allows uploading files with framework permissions", async () => {
-    mockRequestContext({ userId: 123, permissions: ["framework-ppc"] });
+    mockUserContext({ userId: 123, permissions: ["framework-ppc"] });
     let fp = await FundingProgrammeFactory.create({ frameworkKey: "ppc" });
     await expectCan(service, "uploadFiles", fp);
     fp = await FundingProgrammeFactory.create({ frameworkKey: "terrafund" });

--- a/libs/common/src/lib/policies/impact-story.policy.spec.ts
+++ b/libs/common/src/lib/policies/impact-story.policy.spec.ts
@@ -2,7 +2,7 @@ import { Test } from "@nestjs/testing";
 import { PolicyService } from "./policy.service";
 import { ImpactStoryFactory, UserFactory } from "@terramatch-microservices/database/factories";
 import { expectCan } from "./policy.service.spec";
-import { mockRequestForUser } from "../util/testing";
+import { mockContextForUser } from "../util/testing";
 
 describe("ImpactStoryPolicy", () => {
   let service: PolicyService;
@@ -21,7 +21,7 @@ describe("ImpactStoryPolicy", () => {
 
   it("should allow uploading files for impact stories for admins", async () => {
     const user = await UserFactory.create();
-    mockRequestForUser(user, "framework-ppc");
+    mockContextForUser(user, "framework-ppc");
     const impactStory = await ImpactStoryFactory.create();
     await expectCan(service, ["uploadFiles"], impactStory);
   });

--- a/libs/common/src/lib/policies/media.policy.spec.ts
+++ b/libs/common/src/lib/policies/media.policy.spec.ts
@@ -3,7 +3,7 @@ import { Test } from "@nestjs/testing";
 import { expectCan } from "./policy.service.spec";
 import { MediaFactory } from "@terramatch-microservices/database/factories";
 import { UnauthorizedException } from "@nestjs/common";
-import { mockRequestContext } from "../util/testing";
+import { mockUserContext } from "../util/testing";
 
 describe("MediaPolicy", () => {
   let service: PolicyService;
@@ -22,19 +22,19 @@ describe("MediaPolicy", () => {
 
   describe("bulkDelete", () => {
     it("should allow bulk delete if the user has the media-manage permission and the media is created by the user", async () => {
-      mockRequestContext({ userId: 123, permissions: ["media-manage"] });
+      mockUserContext({ userId: 123, permissions: ["media-manage"] });
       await expectCan(service, "bulkDelete", await MediaFactory.project().create({ createdBy: 123 }));
     });
 
     it("should not allow bulk delete if the user does not have the media-manage permission even if the media is created by the user", async () => {
-      mockRequestContext({ userId: 123 });
+      mockUserContext({ userId: 123 });
       await expect(
         service.authorize("bulkDelete", await MediaFactory.project().create({ createdBy: 123 }))
       ).rejects.toThrow(UnauthorizedException);
     });
 
     it("should not allow bulk delete if the user have the media-manage permission but the media is not created by the user", async () => {
-      mockRequestContext({ userId: 123, permissions: ["media-manage"] });
+      mockUserContext({ userId: 123, permissions: ["media-manage"] });
       await expect(
         service.authorize("bulkDelete", await MediaFactory.project().create({ createdBy: 124 }))
       ).rejects.toThrow(UnauthorizedException);

--- a/libs/common/src/lib/policies/nursery-report.policy.spec.ts
+++ b/libs/common/src/lib/policies/nursery-report.policy.spec.ts
@@ -10,7 +10,7 @@ import {
   ProjectUserFactory,
   UserFactory
 } from "@terramatch-microservices/database/factories";
-import { mockRequestContext, mockRequestForUser } from "../util/testing";
+import { mockUserContext, mockContextForUser } from "../util/testing";
 
 describe("NurseryReportPolicy", () => {
   let service: PolicyService;
@@ -28,13 +28,13 @@ describe("NurseryReportPolicy", () => {
   });
 
   it("allows reading all nursery reports with view-dashboard permissions", async () => {
-    mockRequestContext({ userId: 123, permissions: ["view-dashboard"] });
+    mockUserContext({ userId: 123, permissions: ["view-dashboard"] });
     await expectCan(service, "read", new NurseryReport());
     await expectCannot(service, "delete", new NurseryReport());
   });
 
   it("allows managing nursery reports in your framework", async () => {
-    mockRequestContext({ userId: 123, permissions: ["framework-ppc"] });
+    mockUserContext({ userId: 123, permissions: ["framework-ppc"] });
     const ppc = await NurseryReportFactory.create({ frameworkKey: "ppc" });
     const tf = await NurseryReportFactory.create({ frameworkKey: "terrafund" });
     await expectAuthority(service, {
@@ -46,7 +46,7 @@ describe("NurseryReportPolicy", () => {
   it("allows managing nursery reports for own projects", async () => {
     const org = await OrganisationFactory.create();
     const user = await UserFactory.create({ organisationId: org.id });
-    mockRequestForUser(user, "manage-own");
+    mockContextForUser(user, "manage-own");
 
     const p1 = await ProjectFactory.create({ organisationId: org.id });
     const p2 = await ProjectFactory.create();
@@ -82,7 +82,7 @@ describe("NurseryReportPolicy", () => {
 
   it("allows managing nursery reports for managed projects", async () => {
     const user = await UserFactory.create();
-    mockRequestForUser(user, "projects-manage");
+    mockContextForUser(user, "projects-manage");
 
     const p1 = await ProjectFactory.create();
     const p2 = await ProjectFactory.create();

--- a/libs/common/src/lib/policies/nursery.policy.spec.ts
+++ b/libs/common/src/lib/policies/nursery.policy.spec.ts
@@ -9,7 +9,7 @@ import {
   ProjectUserFactory,
   UserFactory
 } from "@terramatch-microservices/database/factories";
-import { mockRequestContext, mockRequestForUser } from "../util/testing";
+import { mockUserContext, mockContextForUser } from "../util/testing";
 
 describe("NurseryPolicy", () => {
   let service: PolicyService;
@@ -27,18 +27,18 @@ describe("NurseryPolicy", () => {
   });
 
   it("allows reading all nurseries with view-dashboard permissions", async () => {
-    mockRequestContext({ userId: 123, permissions: ["view-dashboard"] });
+    mockUserContext({ userId: 123, permissions: ["view-dashboard"] });
     await expectCan(service, "read", new Nursery());
     await expectCannot(service, "delete", new Nursery());
   });
 
   it("allows reading all nurseries with projects-read permissions", async () => {
-    mockRequestContext({ userId: 123, permissions: ["projects-read"] });
+    mockUserContext({ userId: 123, permissions: ["projects-read"] });
     await expectCan(service, "read", new Nursery());
   });
 
   it("allows managing nurseries in your framework", async () => {
-    mockRequestContext({ userId: 123, permissions: ["framework-ppc"] });
+    mockUserContext({ userId: 123, permissions: ["framework-ppc"] });
     const ppc = await NurseryFactory.create({ frameworkKey: "ppc" });
     const tf = await NurseryFactory.create({ frameworkKey: "terrafund" });
     await expectAuthority(service, {
@@ -50,7 +50,7 @@ describe("NurseryPolicy", () => {
   it("allows managing own nurseries", async () => {
     const org = await OrganisationFactory.create();
     const user = await UserFactory.create({ organisationId: org.id });
-    mockRequestForUser(user, "manage-own");
+    mockContextForUser(user, "manage-own");
 
     const p1 = await ProjectFactory.create({ organisationId: org.id });
     const p2 = await ProjectFactory.create();
@@ -83,7 +83,7 @@ describe("NurseryPolicy", () => {
     const user = await UserFactory.create();
     const project = await ProjectFactory.create();
     await ProjectUserFactory.create({ userId: user.id, projectId: project.id, isMonitoring: false, isManaging: true });
-    mockRequestForUser(user, "projects-manage");
+    mockContextForUser(user, "projects-manage");
     const s1 = await NurseryFactory.create({ projectId: project.id });
     const s2 = await NurseryFactory.create();
     await expectAuthority(service, {

--- a/libs/common/src/lib/policies/organisation.policy.spec.ts
+++ b/libs/common/src/lib/policies/organisation.policy.spec.ts
@@ -10,7 +10,7 @@ import {
   RoleFactory,
   UserFactory
 } from "@terramatch-microservices/database/factories";
-import { mockRequestContext, mockRequestForUser } from "../util/testing";
+import { mockUserContext, mockContextForUser } from "../util/testing";
 
 describe("OrganisationPolicy", () => {
   let service: PolicyService;
@@ -34,7 +34,7 @@ describe("OrganisationPolicy", () => {
         private: false,
         isTest: false
       });
-      mockRequestContext({ userId: 123 });
+      mockUserContext({ userId: 123 });
       await expectCan(service, "listing", org);
     });
 
@@ -44,7 +44,7 @@ describe("OrganisationPolicy", () => {
         private: true,
         isTest: false
       });
-      mockRequestContext({ userId: 123 });
+      mockUserContext({ userId: 123 });
       await expectCannot(service, "listing", org);
     });
 
@@ -54,7 +54,7 @@ describe("OrganisationPolicy", () => {
         private: false,
         isTest: true
       });
-      mockRequestContext({ userId: 123 });
+      mockUserContext({ userId: 123 });
       await expectCannot(service, "listing", org);
     });
 
@@ -64,20 +64,20 @@ describe("OrganisationPolicy", () => {
         private: false,
         isTest: false
       });
-      mockRequestContext({ userId: 123 });
+      mockUserContext({ userId: 123 });
       await expectCannot(service, "listing", org);
     });
   });
 
   describe("framework permissions", () => {
     it("allows reading, updating, and deleting organisations with framework permissions", async () => {
-      mockRequestContext({ userId: 123, permissions: ["framework-pcc"] });
+      mockUserContext({ userId: 123, permissions: ["framework-pcc"] });
       const org = await OrganisationFactory.create();
       await expectCan(service, ["read", "update", "delete"], org);
     });
 
     it("disallows reading organisations without framework permissions", async () => {
-      mockRequestContext({ userId: 123 });
+      mockUserContext({ userId: 123 });
       const org = await OrganisationFactory.create();
       await expectCannot(service, "read", org);
     });
@@ -85,18 +85,18 @@ describe("OrganisationPolicy", () => {
 
   describe("users-manage permissions", () => {
     it("allows creating organisations for all authenticated users", async () => {
-      mockRequestContext({ userId: 123 });
+      mockUserContext({ userId: 123 });
       await expectCan(service, "create", Organisation);
     });
 
     it("allows uploading, deleting, and updating files with users-manage permissions", async () => {
-      mockRequestContext({ userId: 123, permissions: ["users-manage"] });
+      mockUserContext({ userId: 123, permissions: ["users-manage"] });
       const org = await OrganisationFactory.create();
       await expectCan(service, ["uploadFiles", "deleteFiles", "updateFiles"], org);
     });
 
     it("allows deleting organisations with users-manage permissions", async () => {
-      mockRequestContext({ userId: 123, permissions: ["users-manage"] });
+      mockUserContext({ userId: 123, permissions: ["users-manage"] });
       const org = await OrganisationFactory.create();
       await expectCan(service, "delete", org);
     });
@@ -106,14 +106,14 @@ describe("OrganisationPolicy", () => {
     it("allows reading organisations via orgUuids", async () => {
       const org = await OrganisationFactory.create();
       const user = await UserFactory.create({ organisationId: org.id });
-      mockRequestForUser(user, "manage-own");
+      mockContextForUser(user, "manage-own");
       await expectCan(service, "read", org);
     });
 
     it("allows reading organisations via organisationsConfirmed", async () => {
       const org = await OrganisationFactory.create();
       const user = await UserFactory.create();
-      mockRequestForUser(user, "manage-own");
+      mockContextForUser(user, "manage-own");
       await OrganisationUserFactory.create({ organisationId: org.id, userId: user.id, status: "approved" });
       await expectCan(service, "read", org);
     });
@@ -121,7 +121,7 @@ describe("OrganisationPolicy", () => {
     it("disallows reading organisations not in orgUuids", async () => {
       const orgs = await OrganisationFactory.createMany(2);
       const user = await UserFactory.create({ organisationId: orgs[0].id });
-      mockRequestForUser(user, "manage-own");
+      mockContextForUser(user, "manage-own");
       await expectCannot(service, "read", orgs[1]);
     });
   });
@@ -130,7 +130,7 @@ describe("OrganisationPolicy", () => {
     it("allows reading organisations via project organisationIds", async () => {
       const org = await OrganisationFactory.create();
       const user = await UserFactory.create();
-      mockRequestForUser(user, "manage-own");
+      mockContextForUser(user, "manage-own");
       const project = await ProjectFactory.create({ organisationId: org.id });
       await ProjectUserFactory.create({ userId: user.id, projectId: project.id });
       await expectCan(service, "read", org);
@@ -139,7 +139,7 @@ describe("OrganisationPolicy", () => {
     it("disallows reading organisations not associated with user's projects", async () => {
       const orgs = await OrganisationFactory.createMany(2);
       const user = await UserFactory.create();
-      mockRequestForUser(user, "manage-own");
+      mockContextForUser(user, "manage-own");
       const project = await ProjectFactory.create({ organisationId: orgs[0].id });
       await ProjectUserFactory.create({ userId: user.id, projectId: project.id });
       await expectCannot(service, "read", orgs[1]);
@@ -150,28 +150,28 @@ describe("OrganisationPolicy", () => {
     it("allows uploading and deleting files to the user's org", async () => {
       const org = await OrganisationFactory.create();
       const user = await UserFactory.create({ organisationId: org.id });
-      mockRequestForUser(user, "manage-own");
+      mockContextForUser(user, "manage-own");
       await expectCan(service, ["uploadFiles", "deleteFiles"], org);
     });
 
     it("allows updating and updating files to the user's primary org", async () => {
       const org = await OrganisationFactory.create();
       const user = await UserFactory.create({ organisationId: org.id });
-      mockRequestForUser(user, "manage-own");
+      mockContextForUser(user, "manage-own");
       await expectCan(service, ["update", "updateFiles"], org);
     });
 
     it("disallows uploading and deleting files to other orgs", async () => {
       const orgs = await OrganisationFactory.createMany(2);
       const user = await UserFactory.create({ organisationId: orgs[0].id });
-      mockRequestForUser(user, "manage-own");
+      mockContextForUser(user, "manage-own");
       await expectCannot(service, ["uploadFiles", "deleteFiles"], orgs[1]);
     });
 
     it("allows updating organisations via organisationsConfirmed", async () => {
       const org = await OrganisationFactory.create();
       const user = await UserFactory.create();
-      mockRequestForUser(user, "manage-own");
+      mockContextForUser(user, "manage-own");
       await OrganisationUserFactory.create({ organisationId: org.id, userId: user.id, status: "approved" });
       await expectCan(service, "update", org);
     });
@@ -179,7 +179,7 @@ describe("OrganisationPolicy", () => {
     it("disallows updating organisations not in organisationsConfirmed", async () => {
       const orgs = await OrganisationFactory.createMany(2);
       const user = await UserFactory.create();
-      mockRequestForUser(user, "manage-own");
+      mockContextForUser(user, "manage-own");
       await OrganisationUserFactory.create({ organisationId: orgs[0].id, userId: user.id, status: "approved" });
       await expectCannot(service, "update", orgs[1]);
     });
@@ -188,7 +188,7 @@ describe("OrganisationPolicy", () => {
       const primaryOrg = await OrganisationFactory.create();
       const requestedOrg = await OrganisationFactory.create();
       const user = await UserFactory.create({ organisationId: primaryOrg.id });
-      mockRequestForUser(user, "manage-own");
+      mockContextForUser(user, "manage-own");
       await OrganisationUserFactory.create({ organisationId: requestedOrg.id, userId: user.id, status: "requested" });
       await expectCan(service, "update", primaryOrg);
       await expectCannot(service, "update", requestedOrg);
@@ -197,14 +197,14 @@ describe("OrganisationPolicy", () => {
     it("allows deleting draft organisations for user's primary org", async () => {
       const draftOrg = await OrganisationFactory.create({ status: "draft" });
       const user = await UserFactory.create({ organisationId: draftOrg.id });
-      mockRequestForUser(user, "manage-own");
+      mockContextForUser(user, "manage-own");
       await expectCan(service, "delete", draftOrg);
     });
 
     it("disallows deleting non-draft organisations for user's primary org", async () => {
       const pendingOrg = await OrganisationFactory.create({ status: "pending" });
       const user = await UserFactory.create({ organisationId: pendingOrg.id });
-      mockRequestForUser(user, "manage-own");
+      mockContextForUser(user, "manage-own");
       await expectCannot(service, "delete", pendingOrg);
     });
   });
@@ -213,13 +213,13 @@ describe("OrganisationPolicy", () => {
     it("allows approveReject for verified admin users (admin role + email verified)", async () => {
       const org = await OrganisationFactory.create();
       const user = await UserFactory.create({});
-      mockRequestForUser(user, "framework-terrafund");
+      mockContextForUser(user, "framework-terrafund");
       await expectCan(service, "approveReject", org);
     });
 
     it("allows approveReject for framework admins", async () => {
       const org = await OrganisationFactory.create();
-      mockRequestContext({ userId: 123, permissions: ["framework-ppc"] });
+      mockUserContext({ userId: 123, permissions: ["framework-ppc"] });
       await expectCan(service, "approveReject", org);
     });
 
@@ -228,49 +228,49 @@ describe("OrganisationPolicy", () => {
       const adminRole = await RoleFactory.create({ name: "admin-terrafund" });
       const user = await UserFactory.create({ emailAddressVerifiedAt: null });
       await ModelHasRole.create({ modelId: user.id, roleId: adminRole.id, modelType: User.LARAVEL_TYPE });
-      mockRequestForUser(user, "users-manage");
+      mockContextForUser(user, "users-manage");
       await expectCannot(service, "approveReject", org);
     });
 
     it("disallows approveReject for users without admin role", async () => {
       const org = await OrganisationFactory.create();
       const user = await UserFactory.create({ emailAddressVerifiedAt: new Date() });
-      mockRequestForUser(user, "manage-own");
+      mockContextForUser(user, "manage-own");
       await expectCannot(service, "approveReject", org);
     });
 
     it("disallows approveReject for regular users", async () => {
       const org = await OrganisationFactory.create();
       const user = await UserFactory.create();
-      mockRequestForUser(user);
+      mockContextForUser(user);
       await expectCannot(service, "approveReject", org);
     });
 
     it("allows approveReject for admin-ppc role with email verified", async () => {
       const org = await OrganisationFactory.create();
       const user = await UserFactory.create();
-      mockRequestForUser(user, "framework-ppc");
+      mockContextForUser(user, "framework-ppc");
       await expectCan(service, "approveReject", org);
     });
 
     it("allows approveReject for admin-terrafund role with email verified", async () => {
       const org = await OrganisationFactory.create();
       const user = await UserFactory.create();
-      mockRequestForUser(user, "framework-terrafund");
+      mockContextForUser(user, "framework-terrafund");
       await expectCan(service, "approveReject", org);
     });
 
     it("allows approveReject for organisation owners (primary org)", async () => {
       const org = await OrganisationFactory.create();
       const user = await UserFactory.create({ organisationId: org.id });
-      mockRequestForUser(user);
+      mockContextForUser(user);
       await expectCan(service, "approveReject", org);
     });
 
     it("disallows approveReject for organisation owners of different org", async () => {
       const orgs = await OrganisationFactory.createMany(2);
       const user = await UserFactory.create({ organisationId: orgs[0].id });
-      mockRequestForUser(user);
+      mockContextForUser(user);
       await expectCan(service, "approveReject", orgs[0]);
       await expectCannot(service, "approveReject", orgs[1]);
     });
@@ -279,7 +279,7 @@ describe("OrganisationPolicy", () => {
       const org = await OrganisationFactory.create();
       const user = await UserFactory.create();
       await OrganisationUserFactory.create({ organisationId: org.id, userId: user.id, status: "approved" });
-      mockRequestForUser(user);
+      mockContextForUser(user);
       await expectCan(service, "approveReject", org);
     });
 
@@ -287,7 +287,7 @@ describe("OrganisationPolicy", () => {
       const org = await OrganisationFactory.create();
       const user = await UserFactory.create();
       await OrganisationUserFactory.create({ organisationId: org.id, userId: user.id, status: "requested" });
-      mockRequestForUser(user);
+      mockContextForUser(user);
       await expectCannot(service, "approveReject", org);
     });
 
@@ -295,7 +295,7 @@ describe("OrganisationPolicy", () => {
       const org = await OrganisationFactory.create();
       const user = await UserFactory.create();
       await OrganisationUserFactory.create({ organisationId: org.id, userId: user.id, status: "rejected" });
-      mockRequestForUser(user);
+      mockContextForUser(user);
       await expectCannot(service, "approveReject", org);
     });
 
@@ -304,7 +304,7 @@ describe("OrganisationPolicy", () => {
       const user = await UserFactory.create();
       await OrganisationUserFactory.create({ organisationId: orgs[0].id, userId: user.id, status: "approved" });
       await OrganisationUserFactory.create({ organisationId: orgs[1].id, userId: user.id, status: "approved" });
-      mockRequestForUser(user);
+      mockContextForUser(user);
       await expectCan(service, "approveReject", orgs[0]);
       await expectCan(service, "approveReject", orgs[1]);
     });
@@ -314,7 +314,7 @@ describe("OrganisationPolicy", () => {
     it("allows joinRequest for regular users", async () => {
       const org = await OrganisationFactory.create();
       const user = await UserFactory.create();
-      mockRequestForUser(user);
+      mockContextForUser(user);
       await expectCan(service, "joinRequest", org);
     });
 
@@ -323,7 +323,7 @@ describe("OrganisationPolicy", () => {
       const serviceRole = await RoleFactory.create({ name: "greenhouse-service-account" });
       const user = await UserFactory.create();
       await ModelHasRole.create({ modelId: user.id, roleId: serviceRole.id, modelType: User.LARAVEL_TYPE });
-      mockRequestForUser(user);
+      mockContextForUser(user);
       await expectCannot(service, "joinRequest", org);
     });
   });

--- a/libs/common/src/lib/policies/policy.service.spec.ts
+++ b/libs/common/src/lib/policies/policy.service.spec.ts
@@ -3,7 +3,7 @@ import { PolicyService } from "./policy.service";
 import { UnauthorizedException } from "@nestjs/common";
 import { ModelHasRole, User } from "@terramatch-microservices/database/entities";
 import { isArray } from "lodash";
-import { mockRequestContext } from "../util/testing";
+import { mockUserContext } from "../util/testing";
 
 type Subject = Parameters<PolicyService["authorize"]>[1];
 export async function expectCan(service: PolicyService, action: string | string[], subject: Subject) {
@@ -46,13 +46,13 @@ describe("PolicyService", () => {
   });
 
   it("should throw an error if no authed user is found", async () => {
-    mockRequestContext({ permissions: null });
+    mockUserContext({ permissions: null });
     await expect(service.authorize("foo", new User())).rejects.toThrow(UnauthorizedException);
     expect(() => service.permissions).toThrow(UnauthorizedException);
   });
 
   it("should throw an error if there is no policy defined", async () => {
-    mockRequestContext({ userId: 123 });
+    mockUserContext({ userId: 123 });
     await expect(service.authorize("foo", new ModelHasRole())).rejects.toThrow(UnauthorizedException);
   });
 });

--- a/libs/common/src/lib/policies/policy.service.ts
+++ b/libs/common/src/lib/policies/policy.service.ts
@@ -59,10 +59,10 @@ import { DisturbancePolicy } from "./disturbance.policy";
 import { OrganisationPolicy } from "./organisation.policy";
 import { DisturbanceReportPolicy } from "./disturbance-report.policy";
 import { SrpReportPolicy } from "./srp-report.policy";
-import { authenticatedUserId, permissions, policyBuilder } from "../guards/auth.guard";
 import { FormSubmissionPolicy } from "./form-submission.policy";
 import { ApplicationPolicy } from "./application.policy";
 import { MediaPolicy } from "./media.policy";
+import { UserContext } from "../contexts/user.context";
 
 type EntityClass = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -138,11 +138,11 @@ export class PolicyService {
   private readonly log = new TMLogger(PolicyService.name);
 
   get userId() {
-    return authenticatedUserId();
+    return UserContext.authenticatedUserId;
   }
 
   get permissions() {
-    const value = permissions();
+    const value = UserContext.permissions;
     if (value == null) throw new UnauthorizedException();
 
     return value;
@@ -169,7 +169,7 @@ export class PolicyService {
   }
 
   private async getAbilityWith(policyClass: PolicyClass) {
-    const builder = policyBuilder();
+    const builder = UserContext.policyBuilder;
     if (builder == null) throw new UnauthorizedException();
 
     return await builder.getAbilityWith(policyClass);

--- a/libs/common/src/lib/policies/project-pitch.policy.spec.ts
+++ b/libs/common/src/lib/policies/project-pitch.policy.spec.ts
@@ -2,7 +2,7 @@ import { PolicyService } from "./policy.service";
 import { Test } from "@nestjs/testing";
 import { expectCan, expectCannot } from "./policy.service.spec";
 import { ProjectPitch } from "@terramatch-microservices/database/entities";
-import { mockRequestContext } from "../util/testing";
+import { mockUserContext } from "../util/testing";
 import { OrganisationFactory, ProjectPitchFactory, UserFactory } from "@terramatch-microservices/database/factories";
 
 describe("ProjectPitchPolicy", () => {
@@ -21,20 +21,20 @@ describe("ProjectPitchPolicy", () => {
   });
 
   it("allows reading all project pitch with framework permissions", async () => {
-    mockRequestContext({ userId: 123, permissions: ["framework-pcc"] });
+    mockUserContext({ userId: 123, permissions: ["framework-pcc"] });
     await expectCan(service, "read", new ProjectPitch());
     await expectCannot(service, "delete", new ProjectPitch());
   });
 
   it("deny reading all project pitch with projects-read permissions", async () => {
-    mockRequestContext({ userId: 123, permissions: ["projects-read"] });
+    mockUserContext({ userId: 123, permissions: ["projects-read"] });
     await expectCannot(service, "read", new ProjectPitch());
   });
 
   it("allows managing own org pitches", async () => {
     const org = await OrganisationFactory.create();
     const user = await UserFactory.create({ organisationId: org.id });
-    mockRequestContext({ userId: user.id, permissions: ["manage-own"] });
+    mockUserContext({ userId: user.id, permissions: ["manage-own"] });
     let pitch = await ProjectPitchFactory.create({ organisationId: org.uuid });
     await expectCan(service, "read", pitch);
     await expectCan(service, "update", pitch);

--- a/libs/common/src/lib/policies/project-polygon.policy.spec.ts
+++ b/libs/common/src/lib/policies/project-polygon.policy.spec.ts
@@ -8,7 +8,7 @@ import {
   ProjectPolygonFactory,
   UserFactory
 } from "@terramatch-microservices/database/factories";
-import { mockRequestForUser } from "../util/testing";
+import { mockContextForUser } from "../util/testing";
 
 describe("ProjectPolygonPolicy", () => {
   let service: PolicyService;
@@ -28,7 +28,7 @@ describe("ProjectPolygonPolicy", () => {
   describe("polygons-manage permission (Admin)", () => {
     it("should allow admins to read, create, update and delete all project polygons", async () => {
       const user = await UserFactory.create();
-      mockRequestForUser(user, "polygons-manage");
+      mockContextForUser(user, "polygons-manage");
 
       const projectPolygon = await ProjectPolygonFactory.forPitch().build();
 
@@ -46,7 +46,7 @@ describe("ProjectPolygonPolicy", () => {
       const pitch = await ProjectPitchFactory.create({ fundingProgrammeId: fundingProgramme.uuid });
       const projectPolygon = await ProjectPolygonFactory.forPitch(pitch).build();
 
-      mockRequestForUser(user, "framework-ppc");
+      mockContextForUser(user, "framework-ppc");
 
       await expectCan(service, "read", projectPolygon);
       await expectCan(service, "create", projectPolygon);
@@ -58,7 +58,7 @@ describe("ProjectPolygonPolicy", () => {
       const pitch = await ProjectPitchFactory.create({ fundingProgrammeId: fundingProgramme.uuid });
       const projectPolygon = await ProjectPolygonFactory.forPitch(pitch).build();
 
-      mockRequestForUser(user, "framework-ppc");
+      mockContextForUser(user, "framework-ppc");
 
       await expectCannot(service, "update", projectPolygon);
       await expectCannot(service, "delete", projectPolygon);
@@ -70,7 +70,7 @@ describe("ProjectPolygonPolicy", () => {
       const pitch = await ProjectPitchFactory.create({ fundingProgrammeId: fundingProgramme.uuid });
       const projectPolygon = await ProjectPolygonFactory.forPitch(pitch).build();
 
-      mockRequestForUser(user, "framework-ppc");
+      mockContextForUser(user, "framework-ppc");
 
       await expectCannot(service, "read", projectPolygon);
       await expectCannot(service, "create", projectPolygon);
@@ -86,7 +86,7 @@ describe("ProjectPolygonPolicy", () => {
       const projectPolygon1 = await ProjectPolygonFactory.forPitch(pitch1).build();
       const projectPolygon2 = await ProjectPolygonFactory.forPitch(pitch2).build();
 
-      mockRequestForUser(user, "framework-ppc", "framework-terrafund");
+      mockContextForUser(user, "framework-ppc", "framework-terrafund");
 
       await expectCan(service, "read", projectPolygon1);
       await expectCan(service, "read", projectPolygon2);
@@ -100,7 +100,7 @@ describe("ProjectPolygonPolicy", () => {
       const pitch = await ProjectPitchFactory.create({ organisationId: organisation.uuid });
       const projectPolygon = await ProjectPolygonFactory.forPitch(pitch).build();
 
-      mockRequestForUser(user, "manage-own");
+      mockContextForUser(user, "manage-own");
 
       await expectCan(service, "read", projectPolygon);
       await expectCan(service, "create", projectPolygon);
@@ -115,7 +115,7 @@ describe("ProjectPolygonPolicy", () => {
       const pitch = await ProjectPitchFactory.create({ organisationId: organisation2.uuid });
       const projectPolygon = await ProjectPolygonFactory.forPitch(pitch).build({});
 
-      mockRequestForUser(user, "manage-own");
+      mockContextForUser(user, "manage-own");
 
       await expectCannot(service, "read", projectPolygon);
       await expectCannot(service, "create", projectPolygon);
@@ -125,7 +125,7 @@ describe("ProjectPolygonPolicy", () => {
       const user = await UserFactory.create({ organisationId: null });
       const projectPolygon = await ProjectPolygonFactory.forPitch().build();
 
-      mockRequestForUser(user, "manage-own");
+      mockContextForUser(user, "manage-own");
 
       await expectCannot(service, "read", projectPolygon);
     });
@@ -143,7 +143,7 @@ describe("ProjectPolygonPolicy", () => {
       const ownOrgPolygon = await ProjectPolygonFactory.forPitch(ownerPitch).build();
       const frameworkPolygon = await ProjectPolygonFactory.forPitch(frameworkPitch).build();
 
-      mockRequestForUser(user, "manage-own", "framework-ppc");
+      mockContextForUser(user, "manage-own", "framework-ppc");
 
       // Can fully manage own org polygons
       await expectCan(service, "read", ownOrgPolygon);
@@ -161,7 +161,7 @@ describe("ProjectPolygonPolicy", () => {
       const user = await UserFactory.create();
       const projectPolygon = await ProjectPolygonFactory.forPitch().build();
 
-      mockRequestForUser(user);
+      mockContextForUser(user);
 
       await expectCannot(service, "read", projectPolygon);
       await expectCannot(service, "create", projectPolygon);

--- a/libs/common/src/lib/policies/project-report.policy.spec.ts
+++ b/libs/common/src/lib/policies/project-report.policy.spec.ts
@@ -9,7 +9,7 @@ import {
   ProjectUserFactory,
   UserFactory
 } from "@terramatch-microservices/database/factories";
-import { mockRequestContext, mockRequestForUser } from "../util/testing";
+import { mockUserContext, mockContextForUser } from "../util/testing";
 
 describe("ProjectReportPolicy", () => {
   let service: PolicyService;
@@ -27,13 +27,13 @@ describe("ProjectReportPolicy", () => {
   });
 
   it("allows reading all project reports with view-dashboard permissions", async () => {
-    mockRequestContext({ userId: 123, permissions: ["view-dashboard"] });
+    mockUserContext({ userId: 123, permissions: ["view-dashboard"] });
     await expectCan(service, "read", new ProjectReport());
     await expectCannot(service, "delete", new ProjectReport());
   });
 
   it("allows managing project reports in your framework", async () => {
-    mockRequestContext({ userId: 123, permissions: ["framework-ppc"] });
+    mockUserContext({ userId: 123, permissions: ["framework-ppc"] });
     const ppc = await ProjectReportFactory.create({ frameworkKey: "ppc" });
     const tf = await ProjectReportFactory.create({ frameworkKey: "terrafund" });
     await expectAuthority(service, {
@@ -45,7 +45,7 @@ describe("ProjectReportPolicy", () => {
   it("allows managing project reports for own projects", async () => {
     const org = await OrganisationFactory.create();
     const user = await UserFactory.create({ organisationId: org.id });
-    mockRequestForUser(user, "manage-own");
+    mockContextForUser(user, "manage-own");
 
     const p1 = await ProjectFactory.create({ organisationId: org.id });
     const p2 = await ProjectFactory.create();
@@ -76,7 +76,7 @@ describe("ProjectReportPolicy", () => {
 
   it("allows managing project reports for managed projects", async () => {
     const user = await UserFactory.create();
-    mockRequestForUser(user, "projects-manage");
+    mockContextForUser(user, "projects-manage");
 
     const p1 = await ProjectFactory.create();
     const p2 = await ProjectFactory.create();

--- a/libs/common/src/lib/policies/project.policy.spec.ts
+++ b/libs/common/src/lib/policies/project.policy.spec.ts
@@ -8,7 +8,7 @@ import {
   ProjectUserFactory,
   UserFactory
 } from "@terramatch-microservices/database/factories";
-import { mockRequestContext, mockRequestForUser } from "../util/testing";
+import { mockUserContext, mockContextForUser } from "../util/testing";
 
 describe("ProjectPolicy", () => {
   let service: PolicyService;
@@ -26,19 +26,19 @@ describe("ProjectPolicy", () => {
   });
 
   it("allows reading all projects with projects-read permissions", async () => {
-    mockRequestContext({ userId: 123, permissions: ["projects-read"] });
+    mockUserContext({ userId: 123, permissions: ["projects-read"] });
     await expectCan(service, "read", new Project());
     await expectCannot(service, "delete", new Project());
   });
 
   it("allows reading all projects with view-dashboard permissions", async () => {
-    mockRequestContext({ userId: 123, permissions: ["view-dashboard"] });
+    mockUserContext({ userId: 123, permissions: ["view-dashboard"] });
     await expectCan(service, "read", new Project());
     await expectCannot(service, "delete", new Project());
   });
 
   it("allows managing projects in your framework", async () => {
-    mockRequestContext({ userId: 123, permissions: ["framework-ppc"] });
+    mockUserContext({ userId: 123, permissions: ["framework-ppc"] });
     const ppc = await ProjectFactory.create({ frameworkKey: "ppc" });
     const tf = await ProjectFactory.create({ frameworkKey: "terrafund" });
     await expectAuthority(service, {
@@ -50,7 +50,7 @@ describe("ProjectPolicy", () => {
   it("allows managing own projects", async () => {
     const org = await OrganisationFactory.create();
     const user = await UserFactory.create({ organisationId: org.id });
-    mockRequestForUser(user, "manage-own");
+    mockContextForUser(user, "manage-own");
 
     const p1 = await ProjectFactory.create({ status: "started", organisationId: org.id });
     const p2 = await ProjectFactory.create({ status: "started" });
@@ -76,7 +76,7 @@ describe("ProjectPolicy", () => {
 
   it("allows reading and deleting managed projects", async () => {
     const user = await UserFactory.create();
-    mockRequestForUser(user, "projects-manage");
+    mockContextForUser(user, "projects-manage");
     const p1 = await ProjectFactory.create();
     const p2 = await ProjectFactory.create();
     await ProjectUserFactory.create({ userId: user.id, projectId: p1.id, isMonitoring: false, isManaging: true });

--- a/libs/common/src/lib/policies/site-polygon.policy.spec.ts
+++ b/libs/common/src/lib/policies/site-polygon.policy.spec.ts
@@ -8,7 +8,7 @@ import {
   SiteFactory,
   UserFactory
 } from "@terramatch-microservices/database/factories";
-import { mockRequestContext, mockRequestForUser } from "../util/testing";
+import { mockUserContext, mockContextForUser } from "../util/testing";
 
 describe("SitePolygonPolicy", () => {
   let service: PolicyService;
@@ -27,7 +27,7 @@ describe("SitePolygonPolicy", () => {
 
   it("allows service accounts with polygons-manage-own to read and create any polygon", async () => {
     const user = await UserFactory.create();
-    mockRequestForUser(user, "polygons-manage-own");
+    mockContextForUser(user, "polygons-manage-own");
 
     const sitePolygon = new SitePolygon();
     sitePolygon.createdBy = 999; // Different user
@@ -38,7 +38,7 @@ describe("SitePolygonPolicy", () => {
 
   it("allows service accounts with polygons-manage-own to update and delete only their own polygons", async () => {
     const user = await UserFactory.create();
-    mockRequestForUser(user, "polygons-manage-own");
+    mockContextForUser(user, "polygons-manage-own");
 
     const ownPolygon = new SitePolygon();
     ownPolygon.createdBy = user.id;
@@ -54,7 +54,7 @@ describe("SitePolygonPolicy", () => {
 
   it("allows service accounts with polygons-manage to take any action on any polygon", async () => {
     const user = await UserFactory.create();
-    mockRequestForUser(user, "polygons-manage");
+    mockContextForUser(user, "polygons-manage");
 
     const sitePolygon = new SitePolygon();
     await expectCan(service, "read", sitePolygon);
@@ -66,7 +66,7 @@ describe("SitePolygonPolicy", () => {
   it("allows managing polygons within frameworks", async () => {
     const site = await SiteFactory.create({ frameworkKey: "ppc" });
 
-    mockRequestContext({ userId: 123, permissions: ["framework-ppc"] });
+    mockUserContext({ userId: 123, permissions: ["framework-ppc"] });
     const sitePolygon = new SitePolygon();
     sitePolygon.siteUuid = site.uuid;
 
@@ -79,7 +79,7 @@ describe("SitePolygonPolicy", () => {
     await ProjectUserFactory.create({ userId: user.id, projectId: project.id });
     const site = await SiteFactory.create({ projectId: project.id });
 
-    mockRequestForUser(user, "manage-own");
+    mockContextForUser(user, "manage-own");
     const sitePolygon = new SitePolygon();
     sitePolygon.siteUuid = site.uuid;
 
@@ -92,7 +92,7 @@ describe("SitePolygonPolicy", () => {
     await ProjectUserFactory.create({ userId: user.id, projectId: project.id, isManaging: true });
     const site = await SiteFactory.create({ projectId: project.id });
 
-    mockRequestForUser(user, "projects-manage");
+    mockContextForUser(user, "projects-manage");
     const sitePolygon = new SitePolygon();
     sitePolygon.siteUuid = site.uuid;
 
@@ -105,7 +105,7 @@ describe("SitePolygonPolicy", () => {
     await ProjectUserFactory.create({ userId: user.id, projectId: project.id, isManaging: false });
     const site = await SiteFactory.create({ projectId: project.id });
 
-    mockRequestForUser(user, "projects-manage");
+    mockContextForUser(user, "projects-manage");
     const sitePolygon = new SitePolygon();
     sitePolygon.siteUuid = site.uuid;
 
@@ -113,14 +113,14 @@ describe("SitePolygonPolicy", () => {
   });
 
   it("disallows reading polygons without polygons-manage", async () => {
-    mockRequestContext({ userId: 123 });
+    mockUserContext({ userId: 123 });
     await expectCannot(service, "read", SitePolygon);
   });
 
   it("allows deleting polygons within frameworks", async () => {
     const site = await SiteFactory.create({ frameworkKey: "ppc" });
 
-    mockRequestContext({ userId: 123, permissions: ["framework-ppc"] });
+    mockUserContext({ userId: 123, permissions: ["framework-ppc"] });
     const sitePolygon = new SitePolygon();
     sitePolygon.siteUuid = site.uuid;
 
@@ -133,7 +133,7 @@ describe("SitePolygonPolicy", () => {
     await ProjectUserFactory.create({ userId: user.id, projectId: project.id });
     const site = await SiteFactory.create({ projectId: project.id });
 
-    mockRequestForUser(user, "manage-own");
+    mockContextForUser(user, "manage-own");
     const sitePolygon = new SitePolygon();
     sitePolygon.siteUuid = site.uuid;
 
@@ -146,7 +146,7 @@ describe("SitePolygonPolicy", () => {
     await ProjectUserFactory.create({ userId: user.id, projectId: project.id, isManaging: true });
     const site = await SiteFactory.create({ projectId: project.id });
 
-    mockRequestForUser(user, "projects-manage");
+    mockContextForUser(user, "projects-manage");
     const sitePolygon = new SitePolygon();
     sitePolygon.siteUuid = site.uuid;
 
@@ -158,7 +158,7 @@ describe("SitePolygonPolicy", () => {
     const sitePolygon = new SitePolygon();
     sitePolygon.siteUuid = site.uuid;
 
-    mockRequestContext({ userId: 123 });
+    mockUserContext({ userId: 123 });
 
     await expectCannot(service, "delete", sitePolygon);
   });
@@ -168,7 +168,7 @@ describe("SitePolygonPolicy", () => {
       const user = await UserFactory.create();
       const site = await SiteFactory.create();
 
-      mockRequestForUser(user, "polygons-manage-own");
+      mockContextForUser(user, "polygons-manage-own");
 
       const sitePolygon = new SitePolygon();
       sitePolygon.siteUuid = site.uuid;
@@ -181,7 +181,7 @@ describe("SitePolygonPolicy", () => {
       const user = await UserFactory.create();
       const site = await SiteFactory.create();
 
-      mockRequestForUser(user, "polygons-manage-own");
+      mockContextForUser(user, "polygons-manage-own");
 
       const sitePolygon = new SitePolygon();
       sitePolygon.siteUuid = site.uuid;
@@ -194,7 +194,7 @@ describe("SitePolygonPolicy", () => {
       const user = await UserFactory.create();
       const site = await SiteFactory.create();
 
-      mockRequestForUser(user, "polygons-manage-own");
+      mockContextForUser(user, "polygons-manage-own");
 
       const sitePolygon = new SitePolygon();
       sitePolygon.siteUuid = site.uuid;

--- a/libs/common/src/lib/policies/site-report.policy.spec.ts
+++ b/libs/common/src/lib/policies/site-report.policy.spec.ts
@@ -10,7 +10,7 @@ import {
   SiteReportFactory,
   UserFactory
 } from "@terramatch-microservices/database/factories";
-import { mockRequestContext, mockRequestForUser } from "../util/testing";
+import { mockUserContext, mockContextForUser } from "../util/testing";
 
 describe("SiteReportPolicy", () => {
   let service: PolicyService;
@@ -28,19 +28,19 @@ describe("SiteReportPolicy", () => {
   });
 
   it("allows reading all site reports with view-dashboard permissions", async () => {
-    mockRequestContext({ userId: 123, permissions: ["view-dashboard"] });
+    mockUserContext({ userId: 123, permissions: ["view-dashboard"] });
     await expectCan(service, "read", new SiteReport());
     await expectCannot(service, "delete", new SiteReport());
   });
 
   it("allows reading all site reports with projects-read permissions", async () => {
-    mockRequestContext({ userId: 123, permissions: ["projects-read"] });
+    mockUserContext({ userId: 123, permissions: ["projects-read"] });
     await expectCan(service, "read", new SiteReport());
     await expectCannot(service, "delete", new SiteReport());
   });
 
   it("allows managing site reports in your framework", async () => {
-    mockRequestContext({ userId: 123, permissions: ["framework-ppc"] });
+    mockUserContext({ userId: 123, permissions: ["framework-ppc"] });
     const ppc = await SiteReportFactory.create({ frameworkKey: "ppc" });
     const tf = await SiteReportFactory.create({ frameworkKey: "terrafund" });
     await expectAuthority(service, {
@@ -52,7 +52,7 @@ describe("SiteReportPolicy", () => {
   it("allows managing site reports for own site reports", async () => {
     const org = await OrganisationFactory.create();
     const user = await UserFactory.create({ organisationId: org.id });
-    mockRequestForUser(user, "manage-own");
+    mockContextForUser(user, "manage-own");
 
     const p1 = await ProjectFactory.create({ organisationId: org.id });
     const p2 = await ProjectFactory.create();
@@ -88,7 +88,7 @@ describe("SiteReportPolicy", () => {
 
   it("allows managing site reports for managed projects", async () => {
     const user = await UserFactory.create();
-    mockRequestForUser(user, "projects-manage");
+    mockContextForUser(user, "projects-manage");
 
     const p1 = await ProjectFactory.create();
     const p2 = await ProjectFactory.create();

--- a/libs/common/src/lib/policies/site.policy.spec.ts
+++ b/libs/common/src/lib/policies/site.policy.spec.ts
@@ -9,7 +9,7 @@ import {
   SiteFactory,
   UserFactory
 } from "@terramatch-microservices/database/factories";
-import { mockRequestContext, mockRequestForUser } from "../util/testing";
+import { mockUserContext, mockContextForUser } from "../util/testing";
 
 describe("SitePolicy", () => {
   let service: PolicyService;
@@ -27,18 +27,18 @@ describe("SitePolicy", () => {
   });
 
   it("allows reading all sites with view-dashboard permissions", async () => {
-    mockRequestContext({ userId: 123, permissions: ["view-dashboard"] });
+    mockUserContext({ userId: 123, permissions: ["view-dashboard"] });
     await expectCan(service, "read", new Site());
     await expectCannot(service, "delete", new Site());
   });
 
   it("allows reading all sites with projects-read permissions", async () => {
-    mockRequestContext({ userId: 123, permissions: ["projects-read"] });
+    mockUserContext({ userId: 123, permissions: ["projects-read"] });
     await expectCan(service, "read", new Site());
   });
 
   it("allows managing sites in your framework", async () => {
-    mockRequestContext({ userId: 123, permissions: ["framework-ppc"] });
+    mockUserContext({ userId: 123, permissions: ["framework-ppc"] });
     const ppc = await SiteFactory.create({ frameworkKey: "ppc" });
     const tf = await SiteFactory.create({ frameworkKey: "terrafund" });
     await expectAuthority(service, {
@@ -50,7 +50,7 @@ describe("SitePolicy", () => {
   it("allows managing own sites", async () => {
     const org = await OrganisationFactory.create();
     const user = await UserFactory.create({ organisationId: org.id });
-    mockRequestForUser(user, "manage-own");
+    mockContextForUser(user, "manage-own");
 
     const p1 = await ProjectFactory.create({ organisationId: org.id });
     const p2 = await ProjectFactory.create();
@@ -82,7 +82,7 @@ describe("SitePolicy", () => {
     const user = await UserFactory.create();
     const project = await ProjectFactory.create();
     await ProjectUserFactory.create({ userId: user.id, projectId: project.id, isMonitoring: false, isManaging: true });
-    mockRequestForUser(user, "projects-manage");
+    mockContextForUser(user, "projects-manage");
     const s1 = await SiteFactory.create({ projectId: project.id });
     const s2 = await SiteFactory.create();
     await expectAuthority(service, {
@@ -96,7 +96,7 @@ describe("SitePolicy", () => {
     const project = await ProjectFactory.create();
     await ProjectUserFactory.create({ userId: user.id, projectId: project.id, isMonitoring: false, isManaging: true });
     const site = await SiteFactory.create({ projectId: project.id });
-    mockRequestForUser(user, "media-manage");
+    mockContextForUser(user, "media-manage");
     await expectCan(service, "uploadFiles", site);
   });
 });

--- a/libs/common/src/lib/policies/srp-report.policy.spec.ts
+++ b/libs/common/src/lib/policies/srp-report.policy.spec.ts
@@ -9,7 +9,7 @@ import {
   SrpReportFactory,
   UserFactory
 } from "@terramatch-microservices/database/factories";
-import { mockRequestContext, mockRequestForUser } from "../util/testing";
+import { mockUserContext, mockContextForUser } from "../util/testing";
 
 describe("SrpReportPolicy", () => {
   let service: PolicyService;
@@ -27,13 +27,13 @@ describe("SrpReportPolicy", () => {
   });
 
   it("allows reading all disturbance reports with view-dashboard permissions", async () => {
-    mockRequestContext({ userId: 123, permissions: ["view-dashboard"] });
+    mockUserContext({ userId: 123, permissions: ["view-dashboard"] });
     await expectCan(service, "read", new SrpReport());
     await expectCannot(service, "delete", new SrpReport());
   });
 
   it("allows managing disturbance reports in your framework", async () => {
-    mockRequestContext({ userId: 123, permissions: ["framework-ppc"] });
+    mockUserContext({ userId: 123, permissions: ["framework-ppc"] });
     const ppc = await SrpReportFactory.create({ frameworkKey: "ppc" });
     const tf = await SrpReportFactory.create({ frameworkKey: "terrafund" });
     await expectAuthority(service, {
@@ -45,7 +45,7 @@ describe("SrpReportPolicy", () => {
   it("allows managing disturbance reports for own projects", async () => {
     const org = await OrganisationFactory.create();
     const user = await UserFactory.create({ organisationId: org.id });
-    mockRequestForUser(user, "manage-own");
+    mockContextForUser(user, "manage-own");
 
     const p1 = await ProjectFactory.create({ organisationId: org.id });
     const p2 = await ProjectFactory.create();
@@ -76,7 +76,7 @@ describe("SrpReportPolicy", () => {
 
   it("allows managing disturbance reports for managed projects", async () => {
     const user = await UserFactory.create();
-    mockRequestForUser(user, "projects-manage");
+    mockContextForUser(user, "projects-manage");
 
     const p1 = await ProjectFactory.create();
     const p2 = await ProjectFactory.create();

--- a/libs/common/src/lib/policies/task.policy.spec.ts
+++ b/libs/common/src/lib/policies/task.policy.spec.ts
@@ -8,7 +8,7 @@ import {
   TaskFactory,
   UserFactory
 } from "@terramatch-microservices/database/factories";
-import { mockRequestContext, mockRequestForUser } from "../util/testing";
+import { mockUserContext, mockContextForUser } from "../util/testing";
 
 describe("TaskPolicy", () => {
   let service: PolicyService;
@@ -26,7 +26,7 @@ describe("TaskPolicy", () => {
   });
 
   it("allows reading and updating tasks in your framework", async () => {
-    mockRequestContext({ userId: 123, permissions: ["framework-ppc"] });
+    mockUserContext({ userId: 123, permissions: ["framework-ppc"] });
     const ppc = await ProjectFactory.create({ frameworkKey: "ppc" });
     const ppcTask = await TaskFactory.create({ projectId: ppc.id });
     ppcTask.project = ppc;
@@ -43,7 +43,7 @@ describe("TaskPolicy", () => {
   it("allows reading and updating tasks for own projects", async () => {
     const org = await OrganisationFactory.create();
     const user = await UserFactory.create({ organisationId: org.id });
-    mockRequestForUser(user, "manage-own");
+    mockContextForUser(user, "manage-own");
 
     const p1 = await ProjectFactory.create({ organisationId: org.id });
     const p2 = await ProjectFactory.create();
@@ -73,7 +73,7 @@ describe("TaskPolicy", () => {
 
   it("allows reading and updating tasks for managed projects", async () => {
     const user = await UserFactory.create();
-    mockRequestForUser(user, "projects-manage");
+    mockContextForUser(user, "projects-manage");
 
     const p1 = await ProjectFactory.create();
     const p2 = await ProjectFactory.create();

--- a/libs/common/src/lib/policies/tracking.policy.spec.ts
+++ b/libs/common/src/lib/policies/tracking.policy.spec.ts
@@ -2,7 +2,7 @@ import { PolicyService } from "./policy.service";
 import { Test } from "@nestjs/testing";
 import { expectCan, expectCannot } from "./policy.service.spec";
 import { Tracking } from "@terramatch-microservices/database/entities";
-import { mockRequestContext } from "../util/testing";
+import { mockUserContext } from "../util/testing";
 
 describe("TrackingPolicy", () => {
   let service: PolicyService;
@@ -20,13 +20,13 @@ describe("TrackingPolicy", () => {
   });
 
   it("allows reading all trackings with framework permissions", async () => {
-    mockRequestContext({ userId: 123, permissions: ["framework-ppc"] });
+    mockUserContext({ userId: 123, permissions: ["framework-ppc"] });
     await expectCan(service, "read", new Tracking());
     await expectCannot(service, "delete", new Tracking());
   });
 
   it("dany reading all trackings with projects-read permissions", async () => {
-    mockRequestContext({ userId: 123, permissions: ["projects-read"] });
+    mockUserContext({ userId: 123, permissions: ["projects-read"] });
     await expectCannot(service, "read", new Tracking());
   });
 });

--- a/libs/common/src/lib/policies/user.policy.spec.ts
+++ b/libs/common/src/lib/policies/user.policy.spec.ts
@@ -3,7 +3,7 @@ import { PolicyService } from "./policy.service";
 import { expectCan, expectCannot } from "./policy.service.spec";
 import { User } from "@terramatch-microservices/database/entities";
 import { UserFactory } from "@terramatch-microservices/database/factories";
-import { mockRequestContext } from "../util/testing";
+import { mockUserContext } from "../util/testing";
 
 describe("UserPolicy", () => {
   let service: PolicyService;
@@ -15,7 +15,7 @@ describe("UserPolicy", () => {
 
     service = await module.resolve(PolicyService);
 
-    mockRequestContext({ userId: 123 });
+    mockUserContext({ userId: 123 });
   });
 
   afterEach(async () => {
@@ -23,17 +23,17 @@ describe("UserPolicy", () => {
   });
 
   it("allows reading any user as admin", async () => {
-    mockRequestContext({ userId: 123, permissions: ["users-manage"] });
+    mockUserContext({ userId: 123, permissions: ["users-manage"] });
     await expectCan(service, "read", new User());
   });
 
   it("allows reading all users as admin", async () => {
-    mockRequestContext({ userId: 123, permissions: ["users-manage"] });
+    mockUserContext({ userId: 123, permissions: ["users-manage"] });
     await expectCan(service, "readAll", User);
   });
 
   it("allows creating users as admin", async () => {
-    mockRequestContext({ userId: 123, permissions: ["users-manage"] });
+    mockUserContext({ userId: 123, permissions: ["users-manage"] });
     await expectCan(service, "create", User);
   });
 
@@ -50,7 +50,7 @@ describe("UserPolicy", () => {
   });
 
   it("allows updating any user as admin", async () => {
-    mockRequestContext({ userId: 123, permissions: ["users-manage"] });
+    mockUserContext({ userId: 123, permissions: ["users-manage"] });
     await expectCan(service, "update", new User());
   });
 
@@ -63,7 +63,7 @@ describe("UserPolicy", () => {
   });
 
   it("allows verify any user with users-manage", async () => {
-    mockRequestContext({ userId: 123, permissions: ["users-manage"] });
+    mockUserContext({ userId: 123, permissions: ["users-manage"] });
     await expectCan(service, "verify", new User());
   });
 
@@ -132,7 +132,7 @@ describe("UserPolicy", () => {
   });
 
   it("allows deleting any user as users-manage", async () => {
-    mockRequestContext({ userId: 123, permissions: ["users-manage"] });
+    mockUserContext({ userId: 123, permissions: ["users-manage"] });
     await expectCan(service, "delete", new User());
   });
 

--- a/libs/common/src/lib/util/testing.ts
+++ b/libs/common/src/lib/util/testing.ts
@@ -30,7 +30,7 @@ export const serialize = (data: JsonApiDocument | DocumentBuilder | ResourceBuil
  * Note: Your service should likely be providing the real PolicyService instead of a deep mock in
  *   order to take advantage of this utility.
  */
-export function mockRequestContext({
+export function mockUserContext({
   userId,
   permissions = [],
   locale
@@ -49,14 +49,14 @@ export function mockRequestContext({
  * A utility to leave the rest of the request context mock alone and just set the permission.
  */
 export function setMockedPermissions(...permissions: string[]) {
-  mockRequestContext({ userId: UserContext.authenticatedUserId, permissions, locale: UserContext.userLocale });
+  mockUserContext({ userId: UserContext.authenticatedUserId, permissions, locale: UserContext.userLocale });
 }
 
 /**
  * A utility to represent the given user (id and locale) with a set of permissions.
  */
-export function mockRequestForUser(user: User, ...permissions: string[]) {
-  mockRequestContext({ userId: user.id, permissions, locale: user.locale });
+export function mockContextForUser(user: User, ...permissions: string[]) {
+  mockUserContext({ userId: user.id, permissions, locale: user.locale });
 }
 
 export const getRelation = (key: string) => getLinkedFieldConfig(key)?.field as LinkedRelation;

--- a/libs/common/src/lib/util/testing.ts
+++ b/libs/common/src/lib/util/testing.ts
@@ -1,6 +1,5 @@
 /* istanbul ignore file */
 import { DocumentBuilder, JsonApiDocument, ResourceBuilder } from "./json-api-builder";
-import { RequestContext } from "nestjs-request-context";
 import { getLinkedFieldConfig } from "../linkedFields";
 import { LinkedField, LinkedRelation } from "@terramatch-microservices/database/constants/linked-fields";
 import { createMock, DeepMocked } from "@golevelup/ts-jest";
@@ -12,8 +11,8 @@ import { Model } from "sequelize-typescript";
 import { Attributes } from "sequelize";
 import { ValidLocale } from "@terramatch-microservices/database/constants/locale";
 import { PolicyBuilder } from "../policies/policy.service";
-import { authenticatedUserId, userLocale } from "../guards/auth.guard";
 import { User } from "@terramatch-microservices/database/entities";
+import { UserContext } from "../contexts/user.context";
 
 /**
  * A utility for unit tests that can take any likely response from a standard v3 controller and
@@ -36,23 +35,21 @@ export function mockRequestContext({
   permissions = [],
   locale
 }: { userId?: number; permissions?: string[] | null; locale?: ValidLocale | null } = {}) {
-  jest.spyOn(RequestContext, "currentContext", "get").mockReturnValue({
-    req: {
-      authenticatedUserId: userId,
-      permissions: permissions,
-      // this is unusual, but it allows the caller to explicitly set a missing locale for testing
-      userLocale: locale === null ? locale : (locale ?? "en-US"),
-      policyBuilder: userId == null || permissions == null ? undefined : new PolicyBuilder(userId, permissions)
-    },
-    res: {}
-  });
+  jest.spyOn(UserContext, "authenticatedUserId", "get").mockReturnValue(userId);
+  jest.spyOn(UserContext, "permissions", "get").mockReturnValue(permissions as string[]);
+  jest
+    .spyOn(UserContext, "policyBuilder", "get")
+    .mockReturnValue(userId == null || permissions == null ? undefined : new PolicyBuilder(userId, permissions));
+  jest
+    .spyOn(UserContext, "userLocale", "get")
+    .mockReturnValue((locale === null ? locale : (locale ?? "en-US")) as ValidLocale);
 }
 
 /**
  * A utility to leave the rest of the request context mock alone and just set the permission.
  */
 export function setMockedPermissions(...permissions: string[]) {
-  mockRequestContext({ userId: authenticatedUserId(), permissions, locale: userLocale() });
+  mockRequestContext({ userId: UserContext.authenticatedUserId, permissions, locale: UserContext.userLocale });
 }
 
 /**

--- a/libs/common/src/lib/workers/delayed-job-worker.processor.ts
+++ b/libs/common/src/lib/workers/delayed-job-worker.processor.ts
@@ -1,11 +1,12 @@
 import { OnWorkerEvent, WorkerHost } from "@nestjs/bullmq";
 import { Job } from "bullmq";
-import { DelayedJob } from "@terramatch-microservices/database/entities";
+import { DelayedJob, Permission, User } from "@terramatch-microservices/database/entities";
 import { FAILED, SUCCEEDED } from "@terramatch-microservices/database/constants/status";
 import { TMLogger } from "../util/tm-logger";
 import { isString } from "lodash";
 import { DocumentBuilder, JsonApiDocument, ResourceBuilder } from "../util";
 import * as Sentry from "@sentry/nestjs";
+import { UserContext } from "../contexts/user.context";
 
 export type DelayedJobData = {
   delayedJobId: number;
@@ -57,7 +58,7 @@ export abstract class DelayedJobWorker<T extends DelayedJobData> extends WorkerH
 
     try {
       await delayedJob.update({
-        ...serializePayload(await this.processDelayedJob(job)),
+        ...serializePayload(await this.processDelayedJobInUserContext(delayedJob, job)),
         status: SUCCEEDED,
         statusCode: 200
       });
@@ -72,6 +73,18 @@ export abstract class DelayedJobWorker<T extends DelayedJobData> extends WorkerH
   }
 
   abstract processDelayedJob(job: Job<T>): Promise<DelayedJobResult>;
+
+  protected async processDelayedJobInUserContext({ createdBy }: DelayedJob, job: Job<T>) {
+    if (createdBy == null) return await this.processDelayedJob(job);
+
+    const permissions = await Permission.getUserPermissionNames(createdBy);
+    const locale = (await User.findLocale(createdBy)) ?? "en-US";
+    return await new Promise<DelayedJobResult>((resolve, reject) => {
+      UserContext.use(createdBy, permissions, locale, () => {
+        this.processDelayedJob(job).then(resolve, reject);
+      });
+    });
+  }
 
   protected async updateJobProgress(job: Job<T>, update: ProgressUpdate) {
     await DelayedJob.update(update, { where: { id: job.data.delayedJobId } });

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,6 @@
         "mariadb": "^3.0.2",
         "multer": "^2.1.1",
         "mysql2": "^3.22.3",
-        "nestjs-request-context": "^4.0.0",
         "nodemailer": "^8.0.7",
         "progress": "^2.0.3",
         "proj4": "^2.20.8",
@@ -21349,15 +21348,6 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "license": "MIT"
-    },
-    "node_modules/nestjs-request-context": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/nestjs-request-context/-/nestjs-request-context-4.0.0.tgz",
-      "integrity": "sha512-gGGa7xQuZtk9y88jcLDoL8w/zIeweS5ODUV2yMjbJao1vYzxsp5Htm+tYPwJ38+YXH9LoYv4YneJ8q8YYN+5Ww==",
-      "license": "ISC",
-      "peerDependencies": {
-        "@nestjs/common": "*"
-      }
     },
     "node_modules/node-abi": {
       "version": "3.80.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "mariadb": "^3.0.2",
     "multer": "^2.1.1",
     "mysql2": "^3.22.3",
-    "nestjs-request-context": "^4.0.0",
     "nodemailer": "^8.0.7",
     "progress": "^2.0.3",
     "proj4": "^2.20.8",


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-3488

The bug reported on this ticket was caused by the entities service assuming it was operating in the context of the user that generated the request, but in delayed jobs that information was not surfaced. 

The solution was to stop using the RequestContext library, and instead create our own UserContext that can be populated in more contexts than just the request with an auth header. Then following on from that, the last commit on the branch executes delayed jobs in the context of the job's `createdBy` user, which then gives the entities service access to the information it needs to generate the correct exports for PDs in the delayed job process.