### PR TITLE
[TM-3577] Rework how dependent association updatedSince checking works.

### DIFF
--- a/apps/unified-database-service/src/airtable/entities/airtable-entity.spec.ts
+++ b/apps/unified-database-service/src/airtable/entities/airtable-entity.spec.ts
@@ -68,6 +68,7 @@ import {
   STATES
 } from "@terramatch-microservices/database/util/gadm-mock-data";
 import { AirtableBase } from "airtable/lib/airtable_base";
+import { Subquery } from "@terramatch-microservices/database/util/subquery.builder";
 
 const airtableUpdate = jest.fn<Promise<unknown>, [{ fields: object }[], object]>(() => Promise.resolve());
 const airtableSelectFirstPage = jest.fn<Promise<unknown>, never>(() => Promise.resolve([]));
@@ -169,12 +170,10 @@ describe("AirtableEntity", () => {
 
       it("includes the updatedSince timestamp in the query", async () => {
         const entity = new StubEntity(dataApi);
-        const spy = jest.spyOn(entity as never, "getUpdatePageFindOptions") as jest.SpyInstance<FindOptions<Site>>;
+        const spy = jest.spyOn(entity as never, "getUpdateIdSubquery") as jest.SpyInstance<FindOptions<Site>>;
         const updatedSince = new Date();
         await entity.updateBase(Base, { updatedSince });
-        expect(spy.mock.results[0].value.where).toMatchObject({
-          updatedAt: { [Op.gte]: updatedSince }
-        });
+        expect(spy.mock.results[0].value.literal.val).toContain(`updated_at\` >= ${Subquery.escape(updatedSince)}`);
         spy.mockReset();
       });
 

--- a/apps/unified-database-service/src/airtable/entities/airtable-entity.spec.ts
+++ b/apps/unified-database-service/src/airtable/entities/airtable-entity.spec.ts
@@ -2,8 +2,6 @@ import { airtableColumnName, AirtableEntity, ColumnMapping } from "./airtable-en
 import { faker } from "@faker-js/faker";
 import {
   Application,
-  Tracking,
-  TrackingEntry,
   FinancialIndicator,
   Framework,
   FundingProgramme,
@@ -15,12 +13,12 @@ import {
   ProjectReport,
   Site,
   SiteReport,
+  Tracking,
+  TrackingEntry,
   TreeSpecies
 } from "@terramatch-microservices/database/entities";
 import {
   ApplicationFactory,
-  TrackingEntryFactory,
-  TrackingFactory,
   FinancialIndicatorFactory,
   FormSubmissionFactory,
   FundingProgrammeFactory,
@@ -34,13 +32,13 @@ import {
   SitePolygonFactory,
   SiteReportFactory,
   TaskFactory,
+  TrackingEntryFactory,
+  TrackingFactory,
   TreeSpeciesFactory
 } from "@terramatch-microservices/database/factories";
 import Airtable from "airtable";
 import {
   ApplicationEntity,
-  TrackingEntity,
-  TrackingEntryEntity,
   FinancialIndicatorEntity,
   FundingProgrammeEntity,
   NurseryEntity,
@@ -51,6 +49,8 @@ import {
   ProjectReportEntity,
   SiteEntity,
   SiteReportEntity,
+  TrackingEntity,
+  TrackingEntryEntity,
   TreeSpeciesEntity
 } from "./";
 import { orderBy, sortBy, uniq } from "lodash";
@@ -173,7 +173,9 @@ describe("AirtableEntity", () => {
         const spy = jest.spyOn(entity as never, "getUpdateIdSubquery") as jest.SpyInstance<FindOptions<Site>>;
         const updatedSince = new Date();
         await entity.updateBase(Base, { updatedSince });
-        expect(spy.mock.results[0].value.literal.val).toContain(`updated_at\` >= ${Subquery.escape(updatedSince)}`);
+        expect(spy.mock.results[0].value.literal.val).toContain(
+          `updated_at\` >= ${Subquery.clauseBuilder(Site).escape(updatedSince)}`
+        );
         spy.mockReset();
       });
 

--- a/apps/unified-database-service/src/airtable/entities/airtable-entity.ts
+++ b/apps/unified-database-service/src/airtable/entities/airtable-entity.ts
@@ -1,11 +1,12 @@
 import { Model, ModelCtor, ModelType } from "sequelize-typescript";
 import { cloneDeep, flatten, groupBy, isEmpty, isObject, isString, keyBy, mapValues, merge, uniq } from "lodash";
-import { Attributes, FindOptions, Op, WhereOptions } from "sequelize";
+import { Attributes, FindOptions, ModelStatic, Op, WhereOptions } from "sequelize";
 import Airtable from "airtable";
 import { UuidModel } from "@terramatch-microservices/database/types/util";
 import { TMLogger } from "@terramatch-microservices/common/util/tm-logger";
 import { DataApiService } from "@terramatch-microservices/data-api";
 import { Dictionary } from "factory-girl-ts";
+import { Subquery } from "@terramatch-microservices/database/util/subquery.builder";
 
 // The Airtable API only supports bulk updates of up to 10 rows.
 const AIRTABLE_PAGE_SIZE = 10;
@@ -27,6 +28,12 @@ const getFilterFlags = (flags: (string | FilterFlag)[]): FilterFlag[] =>
     hideCondition: isString(flag) ? true : flag.hideCondition
   }));
 
+export type UpdateAssociation<M extends Model, JoinModel extends Model> = {
+  model: ModelStatic<JoinModel>;
+  on: [keyof Attributes<M>, keyof Attributes<JoinModel>];
+  scope?: { [key in keyof Attributes<M>]: string };
+};
+
 export abstract class AirtableEntity<ModelType extends Model, AssociationType = Record<string, never>> {
   abstract readonly TABLE_NAME: string;
   abstract readonly COLUMNS: ColumnMapping<ModelType, AssociationType>[];
@@ -34,6 +41,10 @@ export abstract class AirtableEntity<ModelType extends Model, AssociationType = 
   readonly IDENTITY_COLUMN: string = "uuid";
   readonly SUPPORTS_UPDATED_SINCE: boolean = true;
   readonly FILTER_FLAGS: (string | FilterFlag)[] = [];
+  // Used to include an association in the selection of IDs to update when updatedSince is used. Ignored
+  // if SUPPORTS_UPDATED_SINCE is false.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly UPDATE_ASSOCIATIONS: UpdateAssociation<ModelType, any>[] = [];
 
   protected readonly logger = new TMLogger(AirtableEntity.name);
 
@@ -51,10 +62,8 @@ export abstract class AirtableEntity<ModelType extends Model, AssociationType = 
   }
 
   async updateBase(base: Airtable.Base, { startPage, updatedSince }: UpdateBaseOptions = {}) {
-    // Get any find options that might have been provided by a subclass to issue this query
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { offset, limit, attributes, ...countOptions } = this.getUpdatePageFindOptions(0, updatedSince);
-    const count = await this.MODEL.count(countOptions);
+    const where = { id: { [Op.in]: this.getUpdateIdSubquery(updatedSince).literal } } as WhereOptions<ModelType>;
+    const count = await this.MODEL.count({ where });
     if (count === 0) {
       this.logger.log(`No updates to process, skipping: ${JSON.stringify({ table: this.TABLE_NAME, updatedSince })}`);
       return;
@@ -62,7 +71,9 @@ export abstract class AirtableEntity<ModelType extends Model, AssociationType = 
 
     const expectedPages = Math.floor(count / AIRTABLE_PAGE_SIZE);
     for (let page = startPage ?? 0; await this.processUpdatePage(base, page, updatedSince); page++) {
-      this.logger.log(`Processed update page: ${JSON.stringify({ table: this.TABLE_NAME, page, expectedPages })}`);
+      this.logger.log(
+        `Processed update page: ${JSON.stringify({ table: this.TABLE_NAME, page: page + 1, expectedPages: expectedPages + 1 })}`
+      );
     }
   }
 
@@ -82,17 +93,59 @@ export abstract class AirtableEntity<ModelType extends Model, AssociationType = 
     }
   }
 
-  protected getUpdatePageFindOptions(page: number, updatedSince?: Date) {
-    const where: Dictionary = {};
+  /**
+   * Creates a subquery that calculates all the IDs that should be included in an update process with
+   * the optional updatedSince time stamp.
+   *
+   * If this processor supports it, this will take into account any associations that are specified in
+   * UPDATE_ASSOCIATIONS to find records whose dependent associations have been updated.
+   */
+  protected getUpdateIdSubquery(updatedSince?: Date) {
+    const subquery = Subquery.select(this.MODEL, "id", { distinct: true });
 
-    if (this.SUPPORTS_UPDATED_SINCE && updatedSince != null) {
-      where["updatedAt"] = { [Op.gte]: updatedSince };
-    }
     if (!isEmpty(this.FILTER_FLAGS)) {
       for (const { attribute, hideCondition } of getFilterFlags(this.FILTER_FLAGS)) {
-        where[attribute] = !hideCondition;
+        subquery.eq(attribute, !hideCondition);
       }
     }
+
+    if (this.SUPPORTS_UPDATED_SINCE && updatedSince != null) {
+      if (isEmpty(this.UPDATE_ASSOCIATIONS)) {
+        subquery.gte("updatedAt", updatedSince);
+      } else {
+        let whereClause = subquery.clauses.gte("updatedAt", updatedSince);
+
+        // Builds up join queries that will include any item from UPDATE_ASSOCIATIONS that has been updated
+        // or deleted since the updatedSince timestamp.
+        for (const [index, association] of this.UPDATE_ASSOCIATIONS.entries()) {
+          const as = `association_${index}`;
+          const modelColumn = subquery.clauses.field(association.on[0]);
+          const joinClauses = Subquery.clauseBuilder(association.model, as);
+          const joinModelColumn = joinClauses.field(association.on[1]);
+          let on = `${modelColumn} = ${joinModelColumn} AND (${joinClauses.isNull("deletedAt")} OR ${joinClauses.gte("deletedAt", updatedSince)})`;
+
+          if (association.scope != null) {
+            for (const [attribute, value] of Object.entries(association.scope)) {
+              on += ` AND ${joinClauses.eq(attribute, value)}`;
+            }
+          }
+
+          // Include any row from the base table that has an update association where that association was
+          // updated or deleted since the updatedSince timestamp.
+          whereClause += ` OR ${joinClauses.gte("updatedAt", updatedSince)} OR ${joinClauses.gte("deletedAt", updatedSince)}`;
+
+          subquery.leftJoin(association.model, as, on);
+        }
+
+        subquery.andLiteral(`(${whereClause})`);
+      }
+    }
+
+    return subquery;
+  }
+
+  protected getUpdatePageFindOptions(page: number, updatedSince?: Date) {
+    const where = { id: { [Op.in]: this.getUpdateIdSubquery(updatedSince).literal } } as WhereOptions<ModelType>;
 
     return {
       attributes: selectAttributes(this.COLUMNS),
@@ -307,9 +360,6 @@ export type Include = {
   model?: ModelType<any, any>;
   association?: string;
   attributes?: string[];
-  where?: WhereOptions;
-  paranoid?: boolean;
-  required?: boolean;
 };
 
 type AirtableValue = null | undefined | string | number | boolean | Date | string[];

--- a/apps/unified-database-service/src/airtable/entities/disturbance-report.airtable-entity.ts
+++ b/apps/unified-database-service/src/airtable/entities/disturbance-report.airtable-entity.ts
@@ -1,8 +1,14 @@
 /* istanbul ignore file */
-import { AirtableEntity, associatedValueColumn, ColumnMapping, commonEntityColumns, Include } from "./airtable-entity";
-import { DisturbanceReport, Project } from "@terramatch-microservices/database/entities";
-import { uniq } from "lodash";
-import { Op, WhereOptions } from "sequelize";
+import {
+  AirtableEntity,
+  associatedValueColumn,
+  ColumnMapping,
+  commonEntityColumns,
+  UpdateAssociation
+} from "./airtable-entity";
+import { DisturbanceReport, DisturbanceReportEntry, Project } from "@terramatch-microservices/database/entities";
+import { groupBy, uniq } from "lodash";
+import { Op } from "sequelize";
 import { getEntryData } from "@terramatch-microservices/common/events/processors/disturbance-report-entry.approval-processor";
 
 type DisturbanceReportAssociations = {
@@ -35,56 +41,31 @@ const COLUMNS: ColumnMapping<DisturbanceReport, DisturbanceReportAssociations>[]
   associatedValueColumn("disturbanceDate")
 ];
 
+const ENTRY_ASSOCIATION: UpdateAssociation<DisturbanceReport, DisturbanceReportEntry> = {
+  model: DisturbanceReportEntry,
+  on: ["id", "disturbanceReportId"]
+};
+
 export class DisturbanceReportEntity extends AirtableEntity<DisturbanceReport, DisturbanceReportAssociations> {
   readonly TABLE_NAME = "Disturbance Reports";
   readonly COLUMNS = COLUMNS;
   readonly MODEL = DisturbanceReport;
-
-  // Override the default behavior to both include all entries in the page and to include the
-  // entry updatedAt field as part of the where clause if updatedSince is not null.
-  protected getUpdatePageFindOptions(page: number, updatedSince?: Date) {
-    const options = super.getUpdatePageFindOptions(page, updatedSince);
-
-    const entryInclude: Include = {
-      association: "entries",
-      attributes: ["name", "value", "deletedAt"],
-      required: false
-    };
-    (options.include as Include[]).push(entryInclude);
-
-    // If allowed to do the default behavior of wrapping in a subquery, the where clause
-    // construction may be incorrect
-    options.subQuery = false;
-
-    if (updatedSince != null) {
-      options.where = {
-        [Op.or]: [
-          options.where as WhereOptions<DisturbanceReport>,
-          {
-            "$entries.updated_at$": { [Op.gte]: updatedSince }
-          },
-          {
-            "$entries.deleted_at$": { [Op.gte]: updatedSince }
-          }
-        ]
-      };
-      // we have to make sure to join against entries that were deleted since the timestamp so that
-      // those reports count as updated as well.
-      entryInclude.paranoid = false;
-      entryInclude.where = { [Op.or]: [{ deletedAt: null }, { deletedAt: { [Op.gte]: updatedSince } }] };
-    }
-
-    return options;
-  }
+  readonly UPDATE_ASSOCIATIONS = [ENTRY_ASSOCIATION];
 
   protected async loadAssociations(reports: DisturbanceReport[]) {
     const projectIds = uniq(reports.map(({ projectId }) => projectId));
     const projects = await Project.findAll({ where: { id: projectIds }, attributes: ["id", "uuid"] });
+    const entriesByReport = groupBy(
+      await DisturbanceReportEntry.findAll({
+        where: { disturbanceReportId: { [Op.in]: reports.map(({ id }) => id) } }
+      }),
+      "disturbanceReportId"
+    );
 
     return reports.reduce(
-      (associations, { id, projectId, entries }) => {
+      (associations, { id, projectId }) => {
         const { disturbanceData, affectedPolygonUuids } = getEntryData(
-          (entries ?? []).filter(({ deletedAt }) => deletedAt == null)
+          (entriesByReport[id] ?? []).filter(({ deletedAt }) => deletedAt == null)
         );
         return {
           ...associations,

--- a/apps/unified-database-service/src/repl.ts
+++ b/apps/unified-database-service/src/repl.ts
@@ -1,4 +1,5 @@
 import { AppModule } from "./app.module";
 import { bootstrapRepl } from "@terramatch-microservices/common/util/bootstrap-repl";
+import { AIRTABLE_ENTITIES } from "./airtable/airtable.processor";
 
-bootstrapRepl("Unified Database Service", AppModule);
+bootstrapRepl("Unified Database Service", AppModule, { AIRTABLE_ENTITIES });

--- a/libs/database/src/lib/util/subquery.builder.ts
+++ b/libs/database/src/lib/util/subquery.builder.ts
@@ -3,7 +3,6 @@ import { Attributes, literal, ModelStatic } from "sequelize";
 import { isBoolean, isObject } from "lodash";
 import { Literal } from "sequelize/types/utils";
 import { isNotNull } from "../types/array";
-import { User } from "../entities";
 
 export const isLiteral = <T extends Model>(
   values: string | number | Date | boolean | string[] | number[] | Literal | ModelStatic<T>
@@ -50,10 +49,6 @@ export class Subquery<T extends Model> {
     tableAlias = modelStatic.name
   ) {
     return literal(new Subquery(modelStatic, tableAlias).field(attribute));
-  }
-
-  public static escape(value: string | number | Date) {
-    return User.sql.escape(value);
   }
 
   private select(attribute: keyof Attributes<T>, options: SelectOptions<T> = {}) {

--- a/libs/database/src/lib/util/subquery.builder.ts
+++ b/libs/database/src/lib/util/subquery.builder.ts
@@ -94,30 +94,33 @@ class ClauseBuilder<T extends Model> {
     return this.subquery.field(attribute);
   }
 
+  escape(value: string | number | Date | boolean | Literal) {
+    return isLiteral(value) ? value.val : isBoolean(value) ? value : this.subquery.sql.escape(value);
+  }
+
   isNull(attribute: keyof Attributes<T>) {
-    return `${this.subquery.field(attribute)} IS NULL`;
+    return `${this.field(attribute)} IS NULL`;
   }
 
   isNotNull(attribute: keyof Attributes<T>) {
-    return `${this.subquery.field(attribute)} IS NOT NULL`;
+    return `${this.field(attribute)} IS NOT NULL`;
   }
 
   eq(attribute: keyof Attributes<T>, value: string | number | Date | boolean | Literal) {
-    const escaped = isLiteral(value) ? value.val : isBoolean(value) ? value : this.subquery.sql.escape(value);
-    return `${this.subquery.field(attribute)} = ${escaped}`;
+    return `${this.field(attribute)} = ${this.escape(value)}`;
   }
 
   gte(attribute: keyof Attributes<T>, value: string | number | Date) {
-    return `${this.subquery.field(attribute)} >= ${this.subquery.sql.escape(value)}`;
+    return `${this.field(attribute)} >= ${this.escape(value)}`;
   }
 
   lt(attribute: keyof Attributes<T>, value: string | number | Date) {
-    return `${this.subquery.field(attribute)} < ${this.subquery.sql.escape(value)}`;
+    return `${this.field(attribute)} < ${this.escape(value)}`;
   }
 
   in(attribute: keyof Attributes<T>, values: string[] | number[] | Literal) {
-    const escaped = isLiteral(values) ? values.val : values.map(v => this.subquery.sql.escape(v)).join(",");
-    return `${this.subquery.field(attribute)} IN (${escaped})`;
+    const escaped = isLiteral(values) ? values.val : values.map(v => this.escape(v)).join(",");
+    return `${this.field(attribute)} IN (${escaped})`;
   }
 }
 

--- a/libs/database/src/lib/util/subquery.builder.ts
+++ b/libs/database/src/lib/util/subquery.builder.ts
@@ -3,9 +3,10 @@ import { Attributes, literal, ModelStatic } from "sequelize";
 import { isBoolean, isObject } from "lodash";
 import { Literal } from "sequelize/types/utils";
 import { isNotNull } from "../types/array";
+import { User } from "../entities";
 
-export const isLiteral = (
-  values: string | number | Date | boolean | string[] | number[] | Literal
+export const isLiteral = <T extends Model>(
+  values: string | number | Date | boolean | string[] | number[] | Literal | ModelStatic<T>
 ): values is Literal => isObject(values) && (values as { val: unknown }).val != null;
 
 type AggregateSelection = "MAX";
@@ -17,10 +18,14 @@ type SelectOptions<T extends Model> = {
 };
 
 export class Subquery<T extends Model> {
+  public readonly clauses: ClauseBuilder<T>;
+
   private constructor(
     public readonly modelStatic: ModelStatic<T>,
     public readonly tableAlias: string
-  ) {}
+  ) {
+    this.clauses = new ClauseBuilder(this);
+  }
 
   public static select<T extends Model>(
     modelStatic: ModelStatic<T>,
@@ -28,6 +33,10 @@ export class Subquery<T extends Model> {
     options: SelectOptions<T> = {}
   ) {
     return new Subquery(modelStatic, options.tableAlias ?? modelStatic.tableName).select(attribute, options);
+  }
+
+  public static clauseBuilder<T extends Model>(modelStatic: ModelStatic<T>, tableAlias?: string) {
+    return new Subquery(modelStatic, tableAlias ?? modelStatic.tableName).clauses;
   }
 
   /**
@@ -41,6 +50,10 @@ export class Subquery<T extends Model> {
     tableAlias = modelStatic.name
   ) {
     return literal(new Subquery(modelStatic, tableAlias).field(attribute));
+  }
+
+  public static escape(value: string | number | Date) {
+    return User.sql.escape(value);
   }
 
   private select(attribute: keyof Attributes<T>, options: SelectOptions<T> = {}) {
@@ -74,6 +87,40 @@ export class Subquery<T extends Model> {
   }
 }
 
+class ClauseBuilder<T extends Model> {
+  constructor(private readonly subquery: Subquery<T>) {}
+
+  field(attribute: keyof Attributes<T>) {
+    return this.subquery.field(attribute);
+  }
+
+  isNull(attribute: keyof Attributes<T>) {
+    return `${this.subquery.field(attribute)} IS NULL`;
+  }
+
+  isNotNull(attribute: keyof Attributes<T>) {
+    return `${this.subquery.field(attribute)} IS NOT NULL`;
+  }
+
+  eq(attribute: keyof Attributes<T>, value: string | number | Date | boolean | Literal) {
+    const escaped = isLiteral(value) ? value.val : isBoolean(value) ? value : this.subquery.sql.escape(value);
+    return `${this.subquery.field(attribute)} = ${escaped}`;
+  }
+
+  gte(attribute: keyof Attributes<T>, value: string | number | Date) {
+    return `${this.subquery.field(attribute)} >= ${this.subquery.sql.escape(value)}`;
+  }
+
+  lt(attribute: keyof Attributes<T>, value: string | number | Date) {
+    return `${this.subquery.field(attribute)} < ${this.subquery.sql.escape(value)}`;
+  }
+
+  in(attribute: keyof Attributes<T>, values: string[] | number[] | Literal) {
+    const escaped = isLiteral(values) ? values.val : values.map(v => this.subquery.sql.escape(v)).join(",");
+    return `${this.subquery.field(attribute)} IN (${escaped})`;
+  }
+}
+
 class SubqueryBuilder<T extends Model> {
   private where: string[] = [];
   private joins: string[] = [];
@@ -104,45 +151,54 @@ class SubqueryBuilder<T extends Model> {
     return literal(`EXISTS (${this.sqlString})`);
   }
 
+  get clauses() {
+    return this.subquery.clauses;
+  }
+
   isNull(attribute: keyof Attributes<T>) {
-    this.where.push(`${this.subquery.field(attribute)} IS NULL`);
+    this.where.push(this.clauses.isNull(attribute));
     return this;
   }
 
   isNotNull(attribute: keyof Attributes<T>) {
-    this.where.push(`${this.subquery.field(attribute)} IS NOT NULL`);
+    this.where.push(this.clauses.isNotNull(attribute));
     return this;
   }
 
   eq(attribute: keyof Attributes<T>, value: string | number | Date | boolean | Literal) {
-    const escaped = isLiteral(value) ? value.val : isBoolean(value) ? value : this.subquery.sql.escape(value);
-    this.where.push(`${this.subquery.field(attribute)} = ${escaped}`);
+    this.where.push(this.clauses.eq(attribute, value));
     return this;
   }
 
   gte(attribute: keyof Attributes<T>, value: string | number | Date) {
-    this.where.push(`${this.subquery.field(attribute)} >= ${this.subquery.sql.escape(value)}`);
+    this.where.push(this.clauses.gte(attribute, value));
     return this;
   }
 
   lt(attribute: keyof Attributes<T>, value: string | number | Date) {
-    this.where.push(`${this.subquery.field(attribute)} < ${this.subquery.sql.escape(value)}`);
+    this.where.push(this.clauses.lt(attribute, value));
     return this;
   }
 
   in(attribute: keyof Attributes<T>, values: string[] | number[] | Literal) {
-    const escaped = isLiteral(values) ? values.val : values.map(v => this.subquery.sql.escape(v)).join(",");
-    this.where.push(`${this.subquery.field(attribute)} IN (${escaped})`);
+    this.where.push(this.clauses.in(attribute, values));
     return this;
   }
 
-  innerJoin(select: Literal, as: string, on: string) {
-    this.joins.push(`INNER JOIN (${select.val}) AS \`${as}\` ON ${on}`);
+  innerJoin<ST extends Model>(select: Literal | ModelStatic<ST>, as: string, on: string) {
+    const joinClause = isLiteral(select) ? `(${select.val})` : select.tableName;
+    this.joins.push(`INNER JOIN ${joinClause} AS \`${as}\` ON ${on}`);
     return this;
   }
 
-  andLiteral(clause: Literal) {
-    this.where.push(`${clause.val}`);
+  leftJoin<ST extends Model>(select: Literal | ModelStatic<ST>, as: string, on: string) {
+    const joinClause = isLiteral(select) ? `(${select.val})` : select.tableName;
+    this.joins.push(`LEFT OUTER JOIN ${joinClause} AS \`${as}\` ON ${on}`);
+    return this;
+  }
+
+  andLiteral(clause: Literal | string) {
+    this.where.push(`${isLiteral(clause) ? clause.val : clause}`);
     return this;
   }
 }


### PR DESCRIPTION
The problem here was that including multi row associations in the count / pagination queries didn't work because limit / offset goes against total rows in the query, not total rows of the base table.

The solution is to build a subquery that returns all of the distinct IDs of the base table that are ready for update (taking into account dependent associations), and then fetches those rows without the associations, then pull the associations in the loadAssociations method of the airtable entity.

https://gfw.atlassian.net/browse/TM-3577